### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "jmespath",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "jpx-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 jmespath_extensions = { version = "0.9", package = "jmespath_extensions" }
 
 # Internal crates
-jpx-engine = { path = "crates/jpx-engine", version = "0.1.2" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.1.3" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.2...jpx-engine-v0.1.3) - 2026-02-03
+
+### Added
+
+- initial jpx repository

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx-server/CHANGELOG.md
+++ b/crates/jpx-server/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-server-v0.1.2...jpx-server-v0.1.3) - 2026-02-03
+
+### Added
+
+- initial jpx repository

--- a/crates/jpx-server/Cargo.toml
+++ b/crates/jpx-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-server"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.1...jpx-v0.2.2) - 2026-02-03
+
+### Added
+
+- initial jpx repository

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jpx-engine`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `jpx`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `jpx-server`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-engine`

<blockquote>

## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.2...jpx-engine-v0.1.3) - 2026-02-03

### Added

- initial jpx repository
</blockquote>

## `jpx`

<blockquote>

## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.1...jpx-v0.2.2) - 2026-02-03

### Added

- initial jpx repository
</blockquote>

## `jpx-server`

<blockquote>

## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-server-v0.1.2...jpx-server-v0.1.3) - 2026-02-03

### Added

- initial jpx repository
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).