### PR TITLE
fix: use COMMITTER_TOKEN for GHCR auth in Docker workflows

### DIFF
--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -119,7 +119,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Create and push manifests
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -130,7 +130,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -161,7 +161,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.COMMITTER_TOKEN }}
 
       - name: Create and push manifests
         run: |


### PR DESCRIPTION
## Summary

- Use COMMITTER_TOKEN instead of GITHUB_TOKEN for GHCR authentication in Docker workflows
- Fixes permission denied errors when pushing container images

## Context

The workflow_run triggered Docker workflows were failing with `permission_denied: write_package` because GITHUB_TOKEN has limited permissions for workflow_run triggers.

## Requirement

The COMMITTER_TOKEN PAT needs to have the `write:packages` scope. If it doesn't have this scope, please add it at:
https://github.com/settings/tokens

Select the token and add the `write:packages` permission.