### PR TITLE
fix: remove broken rustdoc link to conditional arrow module

### DIFF
--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -21,7 +21,7 @@
 //! ## Cargo Features
 //!
 //! - **`arrow`** - Enables Apache Arrow support for columnar data conversion.
-//!   This adds the [`arrow`] module with functions to convert between Arrow
+//!   This adds the `arrow` module with functions to convert between Arrow
 //!   RecordBatches and JSON Values. Used by the CLI for Parquet I/O.
 //!
 //! ## Quick Start


### PR DESCRIPTION
## Summary

Fix rustdoc warning: unresolved link to `arrow` module.

The `arrow` module is only available when the `arrow` feature is enabled,
so the intra-doc link `[`arrow`]` fails when building docs without that feature.

Changed to plain code formatting instead of a link.