### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "jmespath",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 jmespath_extensions = { version = "0.9", package = "jmespath_extensions" }
 
 # Internal crates
-jpx-engine = { path = "crates/jpx-engine", version = "0.1.3" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.2.0" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.3...jpx-engine-v0.2.0) - 2026-02-03
+
+### Fixed
+
+- remove broken rustdoc link to conditional arrow module ([#16](https://github.com/joshrotenberg/jpx/pull/16))
+
+### Other
+
+- [**breaking**] rename jpx-server to jpx-mcp ([#17](https://github.com/joshrotenberg/jpx/pull/17))
+
 ## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.2...jpx-engine-v0.1.3) - 2026-02-03
 
 ### Added

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.3...jpx-mcp-v0.1.4) - 2026-02-03
+
+### Added
+
+- improve jpx-mcp server with CLI, HTTP transport, and tests ([#19](https://github.com/joshrotenberg/jpx/pull/19))
+
 ## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-server-v0.1.2...jpx-server-v0.1.3) - 2026-02-03
 
 ### Added

--- a/crates/jpx-mcp/Cargo.toml
+++ b/crates/jpx-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.2...jpx-v0.3.0) - 2026-02-03
+
+### Other
+
+- [**breaking**] rename jpx-server to jpx-mcp ([#17](https://github.com/joshrotenberg/jpx/pull/17))
+
 ## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.1...jpx-v0.2.2) - 2026-02-03
 
 ### Added

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jpx-engine`: 0.1.3 -> 0.2.0 (✓ API compatible changes)
* `jpx`: 0.2.2 -> 0.3.0 (✓ API compatible changes)
* `jpx-mcp`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-engine`

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.3...jpx-engine-v0.2.0) - 2026-02-03

### Fixed

- remove broken rustdoc link to conditional arrow module ([#16](https://github.com/joshrotenberg/jpx/pull/16))

### Other

- [**breaking**] rename jpx-server to jpx-mcp ([#17](https://github.com/joshrotenberg/jpx/pull/17))
</blockquote>

## `jpx`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.2...jpx-v0.3.0) - 2026-02-03

### Other

- [**breaking**] rename jpx-server to jpx-mcp ([#17](https://github.com/joshrotenberg/jpx/pull/17))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.1.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.3...jpx-mcp-v0.1.4) - 2026-02-03

### Added

- improve jpx-mcp server with CLI, HTTP transport, and tests ([#19](https://github.com/joshrotenberg/jpx/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).