### PR TITLE
fix: add explicit permissions to Docker release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,9 @@ jobs:
     name: Docker linux/amd64
     needs: [plan, host]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/jpx
@@ -368,6 +371,9 @@ jobs:
     name: Docker linux/arm64
     needs: [plan, host]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/jpx
@@ -408,6 +414,9 @@ jobs:
     name: Docker Multi-arch Manifest
     needs: [plan, docker-amd64, docker-arm64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/jpx


### PR DESCRIPTION
## Summary
Fix Docker push failures in Release workflow with `permission_denied: write_package` error.

## Problem
The Release workflow's Docker jobs were failing:
```
ERROR: failed to push ghcr.io/joshrotenberg/jpx:jpx-v0.3.0-arm64: denied: permission_denied: write_package
```

## Fix
Add explicit `permissions` block to each Docker job:
```yaml
permissions:
  contents: read
  packages: write
```

While the workflow has top-level permissions, job-level permissions may be needed when jobs run in a chain or when triggered by programmatic tag creation.

## Test plan
- [ ] Merge and re-run the Release workflow manually
- [ ] Verify Docker images are pushed to GHCR

```bash
gh workflow run Release -f tag=jpx-v0.3.0
```