### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.1.0" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.2.0" }
+jpx-core = { path = "crates/jpx-core", version = "0.1.1" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.3.0" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.0...jpx-core-v0.1.1) - 2026-02-08
+
+### Fixed
+
+- resolve 13 ignored tests in jpx-core ([#74](https://github.com/joshrotenberg/jpx/pull/74))
+
+### Other
+
+- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
+- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
+- comprehensive jpx-core test coverage (63 -> 985 tests) ([#55](https://github.com/joshrotenberg/jpx/pull/55))

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.2.0...jpx-engine-v0.3.0) - 2026-02-08
+
+### Added
+
+- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
+- add engine configuration (jpx.toml) and doc improvements ([#51](https://github.com/joshrotenberg/jpx/pull/51))
+- add jpx-core and migrate all crates off jmespath/jmespath_extensions ([#45](https://github.com/joshrotenberg/jpx/pull/45))
+- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))
+
+### Fixed
+
+- strict mode reporting in engine_info and validate (#92, #93) ([#94](https://github.com/joshrotenberg/jpx/pull/94))
+- replace comma-counting arity detection with bracket-aware parser ([#77](https://github.com/joshrotenberg/jpx/pull/77))
+
+### Other
+
+- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
+- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
+- comprehensive jpx-engine test coverage (101 -> 264) ([#56](https://github.com/joshrotenberg/jpx/pull/56))
+- remove CLI direct dependency on jpx-core ([#52](https://github.com/joshrotenberg/jpx/pull/52))
+- split jpx-engine lib.rs into focused modules ([#40](https://github.com/joshrotenberg/jpx/pull/40))
+- add documentation to discovery struct fields ([#24](https://github.com/joshrotenberg/jpx/pull/24))
+
 ## [0.2.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.1.3...jpx-engine-v0.2.0) - 2026-02-03
 
 ### Fixed

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.4...jpx-mcp-v0.4.0) - 2026-02-08
+
+### Added
+
+- add suggest_function MCP tool ([#91](https://github.com/joshrotenberg/jpx/pull/91))
+- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
+- wire EngineConfig into jpx-mcp server ([#54](https://github.com/joshrotenberg/jpx/pull/54))
+- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))
+
+### Fixed
+
+- strict mode reporting in engine_info and validate (#92, #93) ([#94](https://github.com/joshrotenberg/jpx/pull/94))
+
+### Other
+
+- consolidate MCP discovery/registration tools (32 -> 29) ([#79](https://github.com/joshrotenberg/jpx/pull/79))
+- unify jpx and jpx-mcp versioning at 0.4.0 ([#76](https://github.com/joshrotenberg/jpx/pull/76))
+- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
+- upgrade tower-mcp 0.3 to 0.5, remove mock-mcp-server, expand test coverage ([#59](https://github.com/joshrotenberg/jpx/pull/59))
+- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
+
 ## [0.1.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.3...jpx-mcp-v0.1.4) - 2026-02-03
 
 ### Added

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.3.0...jpx-v0.4.0) - 2026-02-08
+
+### Added
+
+- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
+- suggest similar function names on evaluation failure ([#78](https://github.com/joshrotenberg/jpx/pull/78))
+- add jpx-core and migrate all crates off jmespath/jmespath_extensions ([#45](https://github.com/joshrotenberg/jpx/pull/45))
+- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))
+
+### Fixed
+
+- update stale jmespath-extensions references in READMEs ([#71](https://github.com/joshrotenberg/jpx/pull/71))
+- support trailing positional arg as input file (jq convention) ([#64](https://github.com/joshrotenberg/jpx/pull/64))
+
+### Other
+
+- unify jpx and jpx-mcp versioning at 0.4.0 ([#76](https://github.com/joshrotenberg/jpx/pull/76))
+- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
+- document trailing file argument as input source ([#65](https://github.com/joshrotenberg/jpx/pull/65))
+- add assert_cmd integration test suite for jpx CLI (109 tests) ([#58](https://github.com/joshrotenberg/jpx/pull/58))
+- remove CLI direct dependency on jpx-core ([#52](https://github.com/joshrotenberg/jpx/pull/52))
+- split jpx CLI main.rs into focused modules ([#41](https://github.com/joshrotenberg/jpx/pull/41))
+
 ## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.2.2...jpx-v0.3.0) - 2026-02-03
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `jpx-engine`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `jpx`: 0.3.0 -> 0.4.0
* `jpx-mcp`: 0.1.4 -> 0.4.0

### ⚠ `jpx-engine` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant EngineError::EvaluationFailed in /tmp/.tmponPbZq/jpx/crates/jpx-engine/src/error.rs:164

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant EngineError:ConfigError in /tmp/.tmponPbZq/jpx/crates/jpx-engine/src/error.rs:195
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.1.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.0...jpx-core-v0.1.1) - 2026-02-08

### Fixed

- resolve 13 ignored tests in jpx-core ([#74](https://github.com/joshrotenberg/jpx/pull/74))

### Other

- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
- comprehensive jpx-core test coverage (63 -> 985 tests) ([#55](https://github.com/joshrotenberg/jpx/pull/55))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.2.0...jpx-engine-v0.3.0) - 2026-02-08

### Added

- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
- add engine configuration (jpx.toml) and doc improvements ([#51](https://github.com/joshrotenberg/jpx/pull/51))
- add jpx-core and migrate all crates off jmespath/jmespath_extensions ([#45](https://github.com/joshrotenberg/jpx/pull/45))
- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))

### Fixed

- strict mode reporting in engine_info and validate (#92, #93) ([#94](https://github.com/joshrotenberg/jpx/pull/94))
- replace comma-counting arity detection with bracket-aware parser ([#77](https://github.com/joshrotenberg/jpx/pull/77))

### Other

- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
- comprehensive jpx-engine test coverage (101 -> 264) ([#56](https://github.com/joshrotenberg/jpx/pull/56))
- remove CLI direct dependency on jpx-core ([#52](https://github.com/joshrotenberg/jpx/pull/52))
- split jpx-engine lib.rs into focused modules ([#40](https://github.com/joshrotenberg/jpx/pull/40))
- add documentation to discovery struct fields ([#24](https://github.com/joshrotenberg/jpx/pull/24))
</blockquote>

## `jpx`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.3.0...jpx-v0.4.0) - 2026-02-08

### Added

- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
- suggest similar function names on evaluation failure ([#78](https://github.com/joshrotenberg/jpx/pull/78))
- add jpx-core and migrate all crates off jmespath/jmespath_extensions ([#45](https://github.com/joshrotenberg/jpx/pull/45))
- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))

### Fixed

- update stale jmespath-extensions references in READMEs ([#71](https://github.com/joshrotenberg/jpx/pull/71))
- support trailing positional arg as input file (jq convention) ([#64](https://github.com/joshrotenberg/jpx/pull/64))

### Other

- unify jpx and jpx-mcp versioning at 0.4.0 ([#76](https://github.com/joshrotenberg/jpx/pull/76))
- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
- document trailing file argument as input source ([#65](https://github.com/joshrotenberg/jpx/pull/65))
- add assert_cmd integration test suite for jpx CLI (109 tests) ([#58](https://github.com/joshrotenberg/jpx/pull/58))
- remove CLI direct dependency on jpx-core ([#52](https://github.com/joshrotenberg/jpx/pull/52))
- split jpx CLI main.rs into focused modules ([#41](https://github.com/joshrotenberg/jpx/pull/41))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.4...jpx-mcp-v0.4.0) - 2026-02-08

### Added

- add suggest_function MCP tool ([#91](https://github.com/joshrotenberg/jpx/pull/91))
- strict mode rejects let expressions + MCP engine_info ([#89](https://github.com/joshrotenberg/jpx/pull/89))
- wire EngineConfig into jpx-mcp server ([#54](https://github.com/joshrotenberg/jpx/pull/54))
- structured errors, explain tool, and improved error messages ([#42](https://github.com/joshrotenberg/jpx/pull/42))

### Fixed

- strict mode reporting in engine_info and validate (#92, #93) ([#94](https://github.com/joshrotenberg/jpx/pull/94))

### Other

- consolidate MCP discovery/registration tools (32 -> 29) ([#79](https://github.com/joshrotenberg/jpx/pull/79))
- unify jpx and jpx-mcp versioning at 0.4.0 ([#76](https://github.com/joshrotenberg/jpx/pull/76))
- add missing metadata to workspace Cargo.toml files ([#75](https://github.com/joshrotenberg/jpx/pull/75))
- upgrade tower-mcp 0.3 to 0.5, remove mock-mcp-server, expand test coverage ([#59](https://github.com/joshrotenberg/jpx/pull/59))
- bump MSRV to 1.90 ([#68](https://github.com/joshrotenberg/jpx/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).