### PR TITLE
feat: expose JEP-18 let expression support across the stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jmespath"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f40cd1816d6f52b8c97bfd9bfca82af01653ecbf53a5d341968cc4cfeb65c0c"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1303,8 +1301,6 @@ dependencies = [
 [[package]]
 name = "jmespath_extensions"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21ba439f5c8c533cbb1c14c8a32515016a74a140e2eea8eede0b74fc41d23c8"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/joshrotenberg/jpx"
 
 [workspace.dependencies]
 # Core dependencies
-jmespath = "0.4"
+jmespath = "0.5"
 serde = "1.0"
 serde_json = "1.0"
 
@@ -70,3 +70,7 @@ allow-dirty = ["ci"]
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[patch.crates-io]
+jmespath = { path = "../jmespath.rs/jmespath" }
+jmespath_extensions = { path = "../jmespath-extensions" }

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -32,9 +32,10 @@ schemars = { workspace = true, optional = true }
 arrow = { version = "54", optional = true, default-features = false, features = ["json"] }
 
 [features]
-default = []
+default = ["let-expr"]
 arrow = ["dep:arrow"]
 schema = ["schemars"]
+let-expr = ["jmespath/let-expr"]
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/jpx-engine/src/eval.rs
+++ b/crates/jpx-engine/src/eval.rs
@@ -49,6 +49,15 @@ impl JpxEngine {
             .compile(expression)
             .map_err(|e| EngineError::InvalidExpression(e.to_string()))?;
 
+        #[cfg(feature = "let-expr")]
+        if self.strict && crate::explain::has_let_nodes(expr.as_ast()) {
+            return Err(EngineError::InvalidExpression(
+                "Let expressions are not allowed in strict mode (standard JMESPath only). \
+                 Remove --strict or unset JPX_STRICT to use let expressions."
+                    .to_string(),
+            ));
+        }
+
         // Convert input Value to Variable for jmespath
         let var = jmespath::Variable::from_json(&input.to_string())
             .map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -214,5 +223,49 @@ mod tests {
         let invalid = engine.validate("users[*.name");
         assert!(!invalid.valid);
         assert!(invalid.error.is_some());
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_let_expression_evaluation() {
+        let engine = JpxEngine::new();
+        let input = json!({"name": "alice"});
+        let result = engine
+            .evaluate("let $n = name in upper($n)", &input)
+            .unwrap();
+        assert_eq!(result, json!("ALICE"));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_nested_let() {
+        let engine = JpxEngine::new();
+        let input = json!({"a": 1, "b": 2});
+        let result = engine
+            .evaluate("let $x = a, $y = b in add($x, $y)", &input)
+            .unwrap();
+        assert_eq!(result, json!(3.0));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_let_with_functions() {
+        let engine = JpxEngine::new();
+        let input = json!({"items": [1, 2, 3, 4, 5]});
+        let result = engine
+            .evaluate("let $threshold = `3` in items[? @ > $threshold]", &input)
+            .unwrap();
+        assert_eq!(result, json!([4, 5]));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_let_strict_mode_rejected() {
+        let engine = JpxEngine::strict();
+        let input = json!({});
+        let result = engine.evaluate("let $x = `1` in $x", &input);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("strict mode"));
     }
 }

--- a/crates/jpx-engine/src/explain.rs
+++ b/crates/jpx-engine/src/explain.rs
@@ -281,6 +281,32 @@ fn walk_ast(node: &Ast, functions: &mut Vec<String>) -> ExplainStep {
                 children: vec![inner],
             }
         }
+        #[cfg(feature = "let-expr")]
+        Ast::VariableRef { name, .. } => ExplainStep {
+            node_type: "variable_ref".into(),
+            description: format!("Reference variable ${}", name),
+            children: vec![],
+        },
+        #[cfg(feature = "let-expr")]
+        Ast::Let { bindings, expr, .. } => {
+            let mut children: Vec<ExplainStep> = bindings
+                .iter()
+                .map(|(name, value)| {
+                    let mut step = walk_ast(value, functions);
+                    step.description = format!("Bind ${} = {}", name, step.description);
+                    step
+                })
+                .collect();
+            children.push(walk_ast(expr, functions));
+            ExplainStep {
+                node_type: "let".into(),
+                description: format!(
+                    "Let binding: bind {} variable(s), then evaluate body",
+                    bindings.len()
+                ),
+                children,
+            }
+        }
     }
 }
 
@@ -327,6 +353,17 @@ fn ast_depth(node: &Ast) -> usize {
                 .unwrap_or(0)
         }
         Ast::Expref { ast, .. } => 1 + ast_depth(ast),
+        #[cfg(feature = "let-expr")]
+        Ast::VariableRef { .. } => 1,
+        #[cfg(feature = "let-expr")]
+        Ast::Let { bindings, expr, .. } => {
+            let binding_max = bindings
+                .iter()
+                .map(|(_, v)| ast_depth(v))
+                .max()
+                .unwrap_or(0);
+            1 + binding_max.max(ast_depth(expr))
+        }
     }
 }
 
@@ -354,6 +391,16 @@ fn count_functions(node: &Ast) -> usize {
             elements.iter().map(|kvp| count_functions(&kvp.value)).sum()
         }
         Ast::Expref { ast, .. } => count_functions(ast),
+        #[cfg(feature = "let-expr")]
+        Ast::VariableRef { .. } => 0,
+        #[cfg(feature = "let-expr")]
+        Ast::Let { bindings, expr, .. } => {
+            bindings
+                .iter()
+                .map(|(_, v)| count_functions(v))
+                .sum::<usize>()
+                + count_functions(expr)
+        }
     }
 }
 
@@ -377,6 +424,40 @@ fn uses_filter(node: &Ast) -> bool {
         Ast::MultiList { elements, .. } => elements.iter().any(uses_filter),
         Ast::MultiHash { elements, .. } => elements.iter().any(|kvp| uses_filter(&kvp.value)),
         Ast::Expref { ast, .. } => uses_filter(ast),
+        #[cfg(feature = "let-expr")]
+        Ast::VariableRef { .. } => false,
+        #[cfg(feature = "let-expr")]
+        Ast::Let { bindings, expr, .. } => {
+            bindings.iter().any(|(_, v)| uses_filter(v)) || uses_filter(expr)
+        }
+    }
+}
+
+/// Check if an AST contains any let expression or variable reference nodes.
+#[cfg(feature = "let-expr")]
+pub fn has_let_nodes(node: &Ast) -> bool {
+    match node {
+        Ast::VariableRef { .. } | Ast::Let { .. } => true,
+        Ast::Identity { .. }
+        | Ast::Field { .. }
+        | Ast::Index { .. }
+        | Ast::Slice { .. }
+        | Ast::Literal { .. } => false,
+        Ast::Subexpr { lhs, rhs, .. }
+        | Ast::Projection { lhs, rhs, .. }
+        | Ast::And { lhs, rhs, .. }
+        | Ast::Or { lhs, rhs, .. }
+        | Ast::Comparison { lhs, rhs, .. } => has_let_nodes(lhs) || has_let_nodes(rhs),
+        Ast::Condition {
+            predicate, then, ..
+        } => has_let_nodes(predicate) || has_let_nodes(then),
+        Ast::Not { node, .. } | Ast::Flatten { node, .. } | Ast::ObjectValues { node, .. } => {
+            has_let_nodes(node)
+        }
+        Ast::Function { args, .. } => args.iter().any(has_let_nodes),
+        Ast::MultiList { elements, .. } => elements.iter().any(has_let_nodes),
+        Ast::MultiHash { elements, .. } => elements.iter().any(|kvp| has_let_nodes(&kvp.value)),
+        Ast::Expref { ast, .. } => has_let_nodes(ast),
     }
 }
 
@@ -460,5 +541,34 @@ mod tests {
         let result = engine().explain("items[]").unwrap();
         // flatten wraps a field access
         assert!(!result.steps.is_empty());
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_explain_let_expression() {
+        let result = engine().explain("let $x = name in upper($x)").unwrap();
+        assert_eq!(result.steps[0].node_type, "let");
+        assert!(result.steps[0].description.contains("1 variable"));
+        assert!(result.functions_used.contains(&"upper".to_string()));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_explain_variable_ref() {
+        let result = engine().explain("let $x = `1` in $x").unwrap();
+        let let_step = &result.steps[0];
+        assert_eq!(let_step.node_type, "let");
+        // Body child should be a variable ref
+        let body = let_step.children.last().unwrap();
+        assert_eq!(body.node_type, "variable_ref");
+        assert!(body.description.contains("$x"));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn test_let_complexity() {
+        // A let expression with a function should be at least moderate
+        let result = engine().explain("let $x = name in upper($x)").unwrap();
+        assert!(result.complexity == "moderate" || result.complexity == "complex");
     }
 }

--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -244,6 +244,8 @@ pub use discovery::{
     ToolSpec,
 };
 pub use error::{EngineError, EvaluationErrorKind, Result};
+#[cfg(feature = "let-expr")]
+pub use explain::has_let_nodes;
 pub use explain::{ExplainResult, ExplainStep};
 pub use introspection::{FunctionDetail, SearchResult, SimilarFunctionsResult};
 pub use json_utils::{FieldAnalysis, PathInfo, StatsResult};

--- a/crates/jpx-mcp/Cargo.toml
+++ b/crates/jpx-mcp/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/lib.rs"
 name = "jpx-mcp"
 path = "src/main.rs"
 
+[features]
+default = ["let-expr"]
+let-expr = ["jpx-engine/let-expr"]
+
 [dependencies]
 # Engine
 jpx-engine = { workspace = true, features = ["schema"] }

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -904,6 +904,7 @@ pub fn build_router(strict: bool) -> Result<McpRouter, BoxError> {
                     "name": "jpx-mcp",
                     "version": env!("CARGO_PKG_VERSION"),
                     "strict_mode": engine.is_strict(),
+                    "let_expressions": cfg!(feature = "let-expr"),
                     "function_count": function_count,
                     "category_count": category_count,
                     "stored_queries": stored_queries,
@@ -928,6 +929,7 @@ pub fn build_router(strict: bool) -> Result<McpRouter, BoxError> {
             \n\nQUERYING: Use 'evaluate' to run JMESPath queries, 'evaluate_file' to query JSON files directly, \
             'batch_evaluate' for multiple expressions against the same input, 'validate' to check expression syntax, \
             'explain' to get a step-by-step breakdown of what an expression does. \
+            Let expressions (JEP-18) are supported: 'let $var = expr in body' for variable bindings. \
             \n\nJSON UTILITIES: Use 'format' to pretty-print JSON, 'diff' to generate RFC 6902 JSON Patches, \
             'patch' to apply RFC 6902 patches, 'merge' to apply RFC 7396 JSON Merge Patches."
         )

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -50,8 +50,9 @@ tabled = "0.17"
 parquet = { version = "54", optional = true, default-features = false, features = ["arrow", "snap"] }
 
 [features]
-default = []
+default = ["let-expr"]
 parquet = ["dep:parquet", "jpx-engine/arrow"]
+let-expr = ["jpx-engine/let-expr"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jpx/src/explain.rs
+++ b/crates/jpx/src/explain.rs
@@ -156,5 +156,24 @@ pub(crate) fn print_ast(node: &Ast, indent: usize) {
             println!("{}{}Expression reference (&):", prefix, connector);
             print_ast(ast, indent + 1);
         }
+        #[cfg(feature = "let-expr")]
+        Ast::VariableRef { name, .. } => {
+            println!("{}{}Variable: ${}", prefix, connector, name);
+        }
+        #[cfg(feature = "let-expr")]
+        Ast::Let { bindings, expr, .. } => {
+            println!(
+                "{}{}Let ({} binding(s)):",
+                prefix,
+                connector,
+                bindings.len()
+            );
+            for (name, value) in bindings {
+                println!("{}  ${} =", prefix, name);
+                print_ast(value, indent + 2);
+            }
+            println!("{}  in:", prefix);
+            print_ast(expr, indent + 2);
+        }
     }
 }

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -239,6 +239,17 @@ fn run() -> Result<()> {
             .compile(expression)
             .map_err(|e| input::expression_error(expression, e))?;
 
+        #[cfg(feature = "let-expr")]
+        if args.strict {
+            use jpx_engine::has_let_nodes;
+            if has_let_nodes(expr.as_ast()) {
+                return Err(anyhow::anyhow!(
+                    "Let expressions are not allowed in strict mode (standard JMESPath only).\n\
+                     Remove --strict or unset JPX_STRICT to use let expressions."
+                ));
+            }
+        }
+
         let step_start = Instant::now();
         result = match expr.search(&result) {
             Ok(r) => r,

--- a/crates/jpx/tests/integration.rs
+++ b/crates/jpx/tests/integration.rs
@@ -2411,6 +2411,43 @@ mod cli_diff_patch_merge {
     }
 }
 
+#[cfg(feature = "let-expr")]
+mod let_expressions {
+    use super::*;
+
+    #[test]
+    fn test_let_basic() {
+        let result = run_query(r#"{"name": "alice"}"#, "let $n = name in upper($n)");
+        assert_eq!(result, r#""ALICE""#);
+    }
+
+    #[test]
+    fn test_let_with_filter() {
+        let result = run_query(
+            r#"{"nums": [1, 2, 3, 4, 5]}"#,
+            "let $threshold = `3` in nums[? @ > $threshold]",
+        );
+        assert_eq!(result, "[\n  4,\n  5\n]");
+    }
+
+    #[test]
+    fn test_let_multiple_bindings() {
+        let result = run_query(
+            r#"{"first": "alice", "last": "smith"}"#,
+            "let $f = first, $l = last in join(' ', [$f, $l])",
+        );
+        assert_eq!(result, r#""alice smith""#);
+    }
+
+    #[test]
+    fn test_let_strict_mode_rejected() {
+        let output = run_with_args(&["--strict", "let $x = `1` in $x"], r#"{}"#);
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("strict mode"));
+    }
+}
+
 mod cli_query_file {
     use std::io::Write;
     use tempfile::NamedTempFile;


### PR DESCRIPTION
## Summary

- Wires `let-expr` Cargo feature through the full dependency chain: `jmespath` -> `jmespath_extensions` -> `jpx-engine` -> `jpx` CLI + `jpx-mcp`
- Handles new `Ast::VariableRef` and `Ast::Let` nodes in all exhaustive match functions (`walk_ast`, `ast_depth`, `count_functions`, `uses_filter`, `print_ast`)
- Adds `has_let_nodes()` function for detecting let expressions, used by both the engine's strict mode check and the CLI's strict mode check
- Rejects let expressions in strict mode with a clear error message
- Updates MCP `engine_info` to report `let_expressions: true` and adds let expression mention to server instructions

## Examples

```bash
# Variable binding
echo '{"name": "alice"}' | jpx 'let $n = name in upper($n)'
# "ALICE"

# Filter with threshold
echo '{"nums": [1,2,3,4,5]}' | jpx 'let $threshold = `3` in nums[? @ > $threshold]'
# [4, 5]

# Multiple bindings
echo '{"first": "alice", "last": "smith"}' | jpx 'let $f = first, $l = last in join('"'"' '"'"', [$f, $l])'
# "alice smith"

# Strict mode rejects let expressions
echo '{}' | jpx --strict 'let $x = `1` in $x'
# Error: Let expressions are not allowed in strict mode
```

## Test plan

- [x] 92 library tests pass (`cargo test --lib --all-features --workspace`)
- [x] 205 integration tests pass (`cargo test --test '*' --all-features`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke tests: let expressions work, strict mode rejects them

Closes #39