### PR TITLE
feat: engine configuration (jpx.toml) and doc audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ name = "jpx-engine"
 version = "0.2.0"
 dependencies = [
  "arrow",
+ "dirs",
  "jpx-core",
  "json-patch",
  "schemars",
@@ -1508,6 +1509,7 @@ dependencies = [
  "strsim",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -21,6 +21,10 @@ strsim = { workspace = true }
 # JSON utilities
 json-patch = { workspace = true }
 
+# Configuration
+toml = "0.8"
+dirs = "6.0.0"
+
 # Error handling
 thiserror = "2"
 

--- a/crates/jpx-engine/src/arrow.rs
+++ b/crates/jpx-engine/src/arrow.rs
@@ -361,14 +361,14 @@ mod tests {
         let input = json!([
             {
                 "int_val": 42,
-                "float_val": 3.14,
+                "float_val": 3.125,
                 "string_val": "hello",
                 "bool_val": true,
                 "null_val": null
             },
             {
                 "int_val": -100,
-                "float_val": 2.718,
+                "float_val": 2.75,
                 "string_val": "world",
                 "bool_val": false,
                 "null_val": null

--- a/crates/jpx-engine/src/config.rs
+++ b/crates/jpx-engine/src/config.rs
@@ -1,0 +1,636 @@
+//! Engine configuration via `jpx.toml`.
+//!
+//! Provides declarative configuration for the jpx engine, supporting function
+//! filtering, query libraries, and engine settings. Configuration is loaded
+//! from multiple sources with layered overrides:
+//!
+//! 1. **Defaults** -- `EngineConfig::default()` (strict=false, all functions enabled)
+//! 2. **Global** -- `~/.config/jpx/jpx.toml` (via `dirs::config_dir()`)
+//! 3. **Project-local** -- Walk up from CWD looking for `jpx.toml`
+//! 4. **Env override** -- `$JPX_CONFIG` points to a specific file
+//! 5. **Programmatic** -- CLI flags, MCP args, builder calls
+//!
+//! # Example
+//!
+//! ```toml
+//! [engine]
+//! strict = false
+//!
+//! [functions]
+//! disabled_categories = ["geo", "phonetic"]
+//! disabled_functions = ["env"]
+//!
+//! [queries]
+//! libraries = ["~/.config/jpx/common.jpx"]
+//!
+//! [queries.inline]
+//! active-users = { expression = "users[?active].name", description = "Get active user names" }
+//! ```
+
+use crate::JpxEngine;
+use crate::error::EngineError;
+use jpx_core::query_library::QueryLibrary;
+use jpx_core::{FunctionRegistry, Runtime};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+/// Top-level configuration for the jpx engine.
+///
+/// Parsed from `jpx.toml` files. All fields have sensible defaults.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct EngineConfig {
+    /// Engine-level settings.
+    pub engine: EngineSection,
+    /// Function filtering settings.
+    pub functions: FunctionsSection,
+    /// Query library and inline query settings.
+    pub queries: QueriesSection,
+}
+
+/// Engine-level settings.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct EngineSection {
+    /// If true, only standard JMESPath functions are available for evaluation.
+    pub strict: bool,
+}
+
+/// Function filtering configuration.
+///
+/// Supports two mutually exclusive approaches:
+/// - **Blocklist** (default): everything enabled, opt out with `disabled_categories`/`disabled_functions`
+/// - **Allowlist**: only specified categories enabled via `enabled_categories`
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct FunctionsSection {
+    /// Categories to disable (blocklist approach).
+    pub disabled_categories: Vec<String>,
+    /// Individual functions to disable.
+    pub disabled_functions: Vec<String>,
+    /// If set, only these categories are enabled (allowlist approach).
+    /// Mutually exclusive with `disabled_categories`.
+    pub enabled_categories: Option<Vec<String>>,
+}
+
+/// Query configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct QueriesSection {
+    /// Paths to `.jpx` query library files to load.
+    pub libraries: Vec<String>,
+    /// Inline named queries.
+    pub inline: HashMap<String, InlineQuery>,
+}
+
+/// An inline named query defined in the config file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InlineQuery {
+    /// The JMESPath expression.
+    pub expression: String,
+    /// Optional description.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl EngineConfig {
+    /// Parses an `EngineConfig` from a TOML file.
+    pub fn from_file(path: &Path) -> crate::Result<Self> {
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            EngineError::ConfigError(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+        toml::from_str(&content).map_err(|e| {
+            EngineError::ConfigError(format!("Failed to parse {}: {}", path.display(), e))
+        })
+    }
+
+    /// Discovers and merges configuration from standard locations.
+    ///
+    /// Loads configs in order (later overrides earlier):
+    /// 1. Global: `~/.config/jpx/jpx.toml`
+    /// 2. Project-local: `jpx.toml` found by walking up from CWD
+    /// 3. Env override: `$JPX_CONFIG`
+    pub fn discover() -> crate::Result<Self> {
+        let mut config = Self::default();
+
+        // 1. Global config
+        if let Some(global_path) = global_config_path()
+            && global_path.exists()
+        {
+            let global = Self::from_file(&global_path)?;
+            config = config.merge(global);
+        }
+
+        // 2. Project-local config (walk up from CWD)
+        if let Some(local_path) = find_project_config() {
+            let local = Self::from_file(&local_path)?;
+            config = config.merge(local);
+        }
+
+        // 3. Env override
+        if let Ok(env_path) = std::env::var("JPX_CONFIG") {
+            let path = PathBuf::from(&env_path);
+            if path.exists() {
+                let env_config = Self::from_file(&path)?;
+                config = config.merge(env_config);
+            }
+        }
+
+        Ok(config)
+    }
+
+    /// Merges another config into this one.
+    ///
+    /// Merge semantics:
+    /// - Scalars (`strict`): later wins
+    /// - `disabled_categories` / `disabled_functions`: union
+    /// - `enabled_categories`: later replaces
+    /// - `queries.libraries`: concatenate
+    /// - `queries.inline`: later keys override same-name
+    pub fn merge(mut self, other: Self) -> Self {
+        // Engine section: later wins
+        if other.engine.strict {
+            self.engine.strict = true;
+        }
+
+        // Functions section
+        if let Some(enabled) = other.functions.enabled_categories {
+            // Allowlist: later replaces entirely
+            self.functions.enabled_categories = Some(enabled);
+            // Clear blocklist when switching to allowlist
+            self.functions.disabled_categories.clear();
+        } else {
+            // Blocklist: union
+            for cat in other.functions.disabled_categories {
+                if !self.functions.disabled_categories.contains(&cat) {
+                    self.functions.disabled_categories.push(cat);
+                }
+            }
+        }
+        for func in other.functions.disabled_functions {
+            if !self.functions.disabled_functions.contains(&func) {
+                self.functions.disabled_functions.push(func);
+            }
+        }
+
+        // Queries section
+        self.queries.libraries.extend(other.queries.libraries);
+        self.queries.inline.extend(other.queries.inline);
+
+        self
+    }
+}
+
+/// Builds a `JpxEngine` from configuration with programmatic overrides.
+///
+/// # Example
+///
+/// ```rust
+/// use jpx_engine::config::EngineBuilder;
+///
+/// let engine = EngineBuilder::new()
+///     .strict(false)
+///     .disable_category("geo")
+///     .disable_function("env")
+///     .build()
+///     .unwrap();
+/// ```
+pub struct EngineBuilder {
+    config: EngineConfig,
+}
+
+impl EngineBuilder {
+    /// Creates a new builder with default configuration.
+    pub fn new() -> Self {
+        Self {
+            config: EngineConfig::default(),
+        }
+    }
+
+    /// Sets strict mode.
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.config.engine.strict = strict;
+        self
+    }
+
+    /// Adds a category to the disabled list.
+    pub fn disable_category(mut self, cat: &str) -> Self {
+        let cat = cat.to_string();
+        if !self.config.functions.disabled_categories.contains(&cat) {
+            self.config.functions.disabled_categories.push(cat);
+        }
+        self
+    }
+
+    /// Adds a function to the disabled list.
+    pub fn disable_function(mut self, name: &str) -> Self {
+        let name = name.to_string();
+        if !self.config.functions.disabled_functions.contains(&name) {
+            self.config.functions.disabled_functions.push(name);
+        }
+        self
+    }
+
+    /// Sets the allowlist of enabled categories (replaces any blocklist).
+    pub fn enable_categories(mut self, cats: Vec<String>) -> Self {
+        self.config.functions.enabled_categories = Some(cats);
+        self.config.functions.disabled_categories.clear();
+        self
+    }
+
+    /// Adds a query library path.
+    pub fn load_library(mut self, path: &str) -> Self {
+        self.config.queries.libraries.push(path.to_string());
+        self
+    }
+
+    /// Adds an inline query.
+    pub fn inline_query(mut self, name: &str, expr: &str, desc: Option<&str>) -> Self {
+        self.config.queries.inline.insert(
+            name.to_string(),
+            InlineQuery {
+                expression: expr.to_string(),
+                description: desc.map(|s| s.to_string()),
+            },
+        );
+        self
+    }
+
+    /// Applies an `EngineConfig` (merges into the builder's config).
+    pub fn config(mut self, config: EngineConfig) -> Self {
+        self.config = self.config.merge(config);
+        self
+    }
+
+    /// Builds the `JpxEngine`.
+    pub fn build(self) -> crate::Result<JpxEngine> {
+        JpxEngine::from_config(self.config)
+    }
+}
+
+impl Default for EngineBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Shared helpers for building Runtime + Registry from config
+// =============================================================================
+
+/// Builds a `Runtime` and `FunctionRegistry` from function configuration.
+///
+/// This is the shared logic used by both `JpxEngine::from_config` and the CLI's
+/// `create_configured_runtime`. It handles:
+/// - Registering builtin functions
+/// - Applying allowlist/blocklist filtering
+/// - Registering enabled extension functions on the runtime
+pub fn build_runtime_from_config(
+    functions_config: &FunctionsSection,
+    strict: bool,
+) -> (Runtime, FunctionRegistry) {
+    use crate::introspection::parse_category;
+
+    let mut runtime = Runtime::new();
+    runtime.register_builtin_functions();
+
+    let mut registry = FunctionRegistry::new();
+
+    if let Some(ref enabled_cats) = functions_config.enabled_categories {
+        // Allowlist mode: only register specified categories
+        for cat_name in enabled_cats {
+            if let Some(cat) = parse_category(cat_name) {
+                registry.register_category(cat);
+            }
+        }
+        // Always include Standard category
+        registry.register_category(jpx_core::Category::Standard);
+    } else {
+        // Default: register all, then disable
+        registry.register_all();
+
+        // Disable categories
+        for cat_name in &functions_config.disabled_categories {
+            if let Some(cat) = parse_category(cat_name) {
+                let names: Vec<String> = registry
+                    .functions_in_category(cat)
+                    .map(|f| f.name.to_string())
+                    .collect();
+                for name in &names {
+                    registry.disable_function(name);
+                }
+            }
+        }
+    }
+
+    // Disable individual functions
+    for func_name in &functions_config.disabled_functions {
+        registry.disable_function(func_name);
+    }
+
+    // Apply to runtime (unless strict)
+    if !strict {
+        registry.apply(&mut runtime);
+    }
+
+    (runtime, registry)
+}
+
+/// Loads query libraries and inline queries into a query store.
+pub fn load_queries_into_store(
+    queries_config: &QueriesSection,
+    runtime: &Runtime,
+    queries: &Arc<RwLock<crate::QueryStore>>,
+) -> crate::Result<()> {
+    // Load .jpx library files
+    for lib_path in &queries_config.libraries {
+        let expanded = expand_tilde(lib_path);
+        let path = Path::new(&expanded);
+        if !path.exists() {
+            continue; // silently skip missing libraries
+        }
+
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            EngineError::ConfigError(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+
+        let library = QueryLibrary::parse(&content).map_err(|e| {
+            EngineError::ConfigError(format!("Failed to parse {}: {}", path.display(), e))
+        })?;
+
+        let mut store = queries
+            .write()
+            .map_err(|e| EngineError::Internal(e.to_string()))?;
+
+        for named_query in library.list() {
+            // Validate expression
+            if runtime.compile(&named_query.expression).is_ok() {
+                store.define(crate::StoredQuery {
+                    name: named_query.name.clone(),
+                    expression: named_query.expression.clone(),
+                    description: named_query.description.clone(),
+                });
+            }
+        }
+    }
+
+    // Load inline queries
+    if !queries_config.inline.is_empty() {
+        let mut store = queries
+            .write()
+            .map_err(|e| EngineError::Internal(e.to_string()))?;
+
+        for (name, query) in &queries_config.inline {
+            // Validate expression
+            if runtime.compile(&query.expression).is_ok() {
+                store.define(crate::StoredQuery {
+                    name: name.clone(),
+                    expression: query.expression.clone(),
+                    description: query.description.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Path helpers
+// =============================================================================
+
+/// Returns the global config path: `~/.config/jpx/jpx.toml`
+fn global_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("jpx").join("jpx.toml"))
+}
+
+/// Walks up from CWD looking for `jpx.toml`.
+fn find_project_config() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let mut dir = cwd.as_path();
+    loop {
+        let candidate = dir.join("jpx.toml");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Expands `~` at the start of a path to the user's home directory.
+fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest).to_string_lossy().into_owned();
+    }
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = EngineConfig::default();
+        assert!(!config.engine.strict);
+        assert!(config.functions.disabled_categories.is_empty());
+        assert!(config.functions.disabled_functions.is_empty());
+        assert!(config.functions.enabled_categories.is_none());
+        assert!(config.queries.libraries.is_empty());
+        assert!(config.queries.inline.is_empty());
+    }
+
+    #[test]
+    fn test_parse_config() {
+        let toml = r#"
+[engine]
+strict = true
+
+[functions]
+disabled_categories = ["geo", "phonetic"]
+disabled_functions = ["env"]
+
+[queries]
+libraries = ["~/.config/jpx/common.jpx"]
+
+[queries.inline]
+active-users = { expression = "users[?active].name", description = "Get active user names" }
+"#;
+        let config: EngineConfig = toml::from_str(toml).unwrap();
+        assert!(config.engine.strict);
+        assert_eq!(
+            config.functions.disabled_categories,
+            vec!["geo", "phonetic"]
+        );
+        assert_eq!(config.functions.disabled_functions, vec!["env"]);
+        assert_eq!(config.queries.libraries.len(), 1);
+        assert!(config.queries.inline.contains_key("active-users"));
+    }
+
+    #[test]
+    fn test_merge_scalars() {
+        let base = EngineConfig::default();
+        let overlay = EngineConfig {
+            engine: EngineSection { strict: true },
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert!(merged.engine.strict);
+    }
+
+    #[test]
+    fn test_merge_disabled_union() {
+        let base = EngineConfig {
+            functions: FunctionsSection {
+                disabled_categories: vec!["geo".to_string()],
+                disabled_functions: vec!["env".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let overlay = EngineConfig {
+            functions: FunctionsSection {
+                disabled_categories: vec!["geo".to_string(), "phonetic".to_string()],
+                disabled_functions: vec!["uuid".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.functions.disabled_categories.len(), 2); // geo + phonetic (no dups)
+        assert_eq!(merged.functions.disabled_functions.len(), 2); // env + uuid
+    }
+
+    #[test]
+    fn test_merge_enabled_replaces() {
+        let base = EngineConfig {
+            functions: FunctionsSection {
+                disabled_categories: vec!["geo".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let overlay = EngineConfig {
+            functions: FunctionsSection {
+                enabled_categories: Some(vec!["string".to_string(), "math".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(
+            merged.functions.enabled_categories,
+            Some(vec!["string".to_string(), "math".to_string()])
+        );
+        assert!(merged.functions.disabled_categories.is_empty());
+    }
+
+    #[test]
+    fn test_merge_queries_concat() {
+        let base = EngineConfig {
+            queries: QueriesSection {
+                libraries: vec!["a.jpx".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let overlay = EngineConfig {
+            queries: QueriesSection {
+                libraries: vec!["b.jpx".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.queries.libraries, vec!["a.jpx", "b.jpx"]);
+    }
+
+    #[test]
+    fn test_builder() {
+        let engine = EngineBuilder::new()
+            .strict(false)
+            .disable_category("geo")
+            .disable_function("env")
+            .build()
+            .unwrap();
+
+        // Engine should work
+        let result = engine
+            .evaluate("length(@)", &serde_json::json!([1, 2, 3]))
+            .unwrap();
+        assert_eq!(result, serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_builder_strict() {
+        let engine = EngineBuilder::new().strict(true).build().unwrap();
+        assert!(engine.is_strict());
+    }
+
+    #[test]
+    fn test_from_config_with_disabled_functions() {
+        let config = EngineConfig {
+            functions: FunctionsSection {
+                disabled_functions: vec!["upper".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = JpxEngine::from_config(config).unwrap();
+
+        // upper should be disabled in introspection
+        assert!(engine.describe_function("upper").is_none());
+
+        // But standard functions still work
+        let result = engine
+            .evaluate("length(@)", &serde_json::json!([1, 2, 3]))
+            .unwrap();
+        assert_eq!(result, serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_from_config_with_inline_queries() {
+        let config = EngineConfig {
+            queries: QueriesSection {
+                inline: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "count".to_string(),
+                        InlineQuery {
+                            expression: "length(@)".to_string(),
+                            description: Some("Count items".to_string()),
+                        },
+                    );
+                    m
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = JpxEngine::from_config(config).unwrap();
+
+        let result = engine
+            .run_query("count", &serde_json::json!([1, 2, 3]))
+            .unwrap();
+        assert_eq!(result, serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_expand_tilde() {
+        let result = expand_tilde("/absolute/path");
+        assert_eq!(result, "/absolute/path");
+
+        let result = expand_tilde("relative/path");
+        assert_eq!(result, "relative/path");
+
+        // ~ expansion depends on home dir being available
+        let result = expand_tilde("~/some/path");
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(result, home.join("some/path").to_string_lossy().as_ref());
+        }
+    }
+}

--- a/crates/jpx-engine/src/error.rs
+++ b/crates/jpx-engine/src/error.rs
@@ -89,9 +89,9 @@ impl fmt::Display for EvaluationErrorKind {
     }
 }
 
-/// Parse a jmespath runtime error message into a structured kind.
+/// Parse a jpx-core runtime error message into a structured kind.
 ///
-/// The jmespath crate produces predictable error message patterns:
+/// The jpx-core runtime produces predictable error message patterns:
 /// - `"Call to undefined function <name>"` for unknown functions
 /// - `"Too many arguments: expected <n>, found <m>"` for argument count errors
 /// - `"Not enough arguments: expected <n>, found <m>"` for argument count errors
@@ -187,6 +187,12 @@ pub enum EngineError {
     /// or conflicts with an existing registration.
     #[error("Registration failed: {0}")]
     RegistrationFailed(String),
+
+    /// Configuration error (parse failure, invalid settings, etc.).
+    ///
+    /// Returned when loading or merging configuration files fails.
+    #[error("Config error: {0}")]
+    ConfigError(String),
 
     /// Internal error (lock poisoning, serialization failure, etc.).
     ///

--- a/crates/jpx-engine/src/eval.rs
+++ b/crates/jpx-engine/src/eval.rs
@@ -207,4 +207,54 @@ mod tests {
         assert!(!invalid.valid);
         assert!(invalid.error.is_some());
     }
+
+    #[test]
+    fn test_evaluate_extension_function() {
+        let engine = JpxEngine::new();
+        let result = engine
+            .evaluate("upper(name)", &json!({"name": "alice"}))
+            .unwrap();
+        assert_eq!(result, json!("ALICE"));
+    }
+
+    #[test]
+    fn test_evaluate_strict_rejects_extensions() {
+        let engine = JpxEngine::strict();
+        let result = engine.evaluate("upper(name)", &json!({"name": "alice"}));
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::EngineError::EvaluationFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_evaluate_invalid_expression() {
+        let engine = JpxEngine::new();
+        let result = engine.evaluate("users[*.name", &json!({}));
+        assert!(matches!(
+            result,
+            Err(crate::EngineError::InvalidExpression(_))
+        ));
+    }
+
+    #[test]
+    fn test_evaluate_str_invalid_json() {
+        let engine = JpxEngine::new();
+        let result = engine.evaluate_str("@", "not json");
+        assert!(matches!(result, Err(crate::EngineError::InvalidJson(_))));
+    }
+
+    #[test]
+    fn test_batch_evaluate_with_errors() {
+        let engine = JpxEngine::new();
+        let exprs = vec!["a".to_string(), "invalid[".to_string()];
+        let result = engine.batch_evaluate(&exprs, &json!({"a": 1}));
+
+        assert_eq!(result.results.len(), 2);
+        assert!(result.results[0].result.is_some());
+        assert!(result.results[0].error.is_none());
+        assert!(result.results[1].result.is_none());
+        assert!(result.results[1].error.is_some());
+    }
 }

--- a/crates/jpx-engine/src/json_utils.rs
+++ b/crates/jpx-engine/src/json_utils.rs
@@ -105,7 +105,28 @@ pub struct PathInfo {
 // =============================================================================
 
 impl JpxEngine {
-    /// Format JSON with indentation.
+    /// Format JSON with configurable indentation.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON string to format
+    /// * `indent` - Number of spaces per indentation level (0 = compact/minified)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    ///
+    /// // Pretty-print with 2-space indent
+    /// let pretty = engine.format_json(r#"{"a":1,"b":2}"#, 2).unwrap();
+    /// assert!(pretty.contains('\n'));
+    ///
+    /// // Compact/minified
+    /// let compact = engine.format_json(r#"{"a":  1, "b": 2}"#, 0).unwrap();
+    /// assert!(!compact.contains('\n'));
+    /// ```
     pub fn format_json(&self, input: &str, indent: usize) -> Result<String> {
         let value: Value =
             serde_json::from_str(input).map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -125,6 +146,25 @@ impl JpxEngine {
     }
 
     /// Generate a JSON Patch (RFC 6902) from source to target.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - Original JSON string
+    /// * `target` - Modified JSON string
+    ///
+    /// # Returns
+    ///
+    /// A JSON array of patch operations that transform `source` into `target`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let patch = engine.diff(r#"{"a": 1}"#, r#"{"a": 2}"#).unwrap();
+    /// assert!(!patch.as_array().unwrap().is_empty());
+    /// ```
     pub fn diff(&self, source: &str, target: &str) -> Result<Value> {
         let source_val: Value =
             serde_json::from_str(source).map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -136,6 +176,25 @@ impl JpxEngine {
     }
 
     /// Apply a JSON Patch (RFC 6902) to a document.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON document to patch
+    /// * `patch` - JSON array of patch operations
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    /// use serde_json::json;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let result = engine.patch(
+    ///     r#"{"a": 1}"#,
+    ///     r#"[{"op": "replace", "path": "/a", "value": 2}]"#,
+    /// ).unwrap();
+    /// assert_eq!(result, json!({"a": 2}));
+    /// ```
     pub fn patch(&self, input: &str, patch: &str) -> Result<Value> {
         let mut doc: Value =
             serde_json::from_str(input).map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -149,6 +208,30 @@ impl JpxEngine {
     }
 
     /// Apply a JSON Merge Patch (RFC 7396) to a document.
+    ///
+    /// Unlike JSON Patch (RFC 6902), merge patch uses a simple object overlay:
+    /// - Present keys with non-null values are set
+    /// - Present keys with null values are removed
+    /// - Absent keys are unchanged
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON document to merge into
+    /// * `patch` - JSON merge patch object
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    /// use serde_json::json;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let result = engine.merge(
+    ///     r#"{"a": 1, "b": 2}"#,
+    ///     r#"{"b": 3, "c": 4}"#,
+    /// ).unwrap();
+    /// assert_eq!(result, json!({"a": 1, "b": 3, "c": 4}));
+    /// ```
     pub fn merge(&self, input: &str, patch: &str) -> Result<Value> {
         let mut doc: Value =
             serde_json::from_str(input).map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -160,6 +243,27 @@ impl JpxEngine {
     }
 
     /// Extract keys from a JSON object.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON string (must be an object for non-recursive mode)
+    /// * `recursive` - If `true`, extracts all nested paths in dot notation
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    ///
+    /// // Top-level keys (sorted)
+    /// let keys = engine.keys(r#"{"b": 1, "a": {"c": 2}}"#, false).unwrap();
+    /// assert_eq!(keys, vec!["a", "b"]);
+    ///
+    /// // Recursive (dot-notation paths)
+    /// let keys = engine.keys(r#"{"a": {"c": 2}, "b": 1}"#, true).unwrap();
+    /// assert!(keys.contains(&"a.c".to_string()));
+    /// ```
     pub fn keys(&self, input: &str, recursive: bool) -> Result<Vec<String>> {
         let value: Value =
             serde_json::from_str(input).map_err(|e| EngineError::InvalidJson(e.to_string()))?;
@@ -174,7 +278,26 @@ impl JpxEngine {
         Ok(keys)
     }
 
-    /// Extract all paths from JSON data.
+    /// Extract all paths from a JSON document.
+    ///
+    /// Enumerates every path in the JSON structure, optionally including
+    /// type information and leaf values.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON string to analyze
+    /// * `include_types` - If `true`, each path includes its JSON type
+    /// * `include_values` - If `true`, leaf paths include their values
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let paths = engine.paths(r#"{"user": {"name": "alice"}}"#, true, false).unwrap();
+    /// assert!(paths.iter().any(|p| p.path == "user.name"));
+    /// ```
     pub fn paths(
         &self,
         input: &str,
@@ -189,7 +312,26 @@ impl JpxEngine {
         Ok(paths)
     }
 
-    /// Analyze JSON data and return statistics.
+    /// Analyze JSON data and return structural statistics.
+    ///
+    /// Returns type information, size, depth, and for arrays of objects,
+    /// per-field analysis including type distribution and null counts.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - JSON string to analyze
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let stats = engine.stats(r#"[{"name": "alice"}, {"name": "bob"}]"#).unwrap();
+    /// assert_eq!(stats.root_type, "array");
+    /// assert_eq!(stats.length, Some(2));
+    /// assert!(stats.fields.is_some());
+    /// ```
     pub fn stats(&self, input: &str) -> Result<StatsResult> {
         let value: Value =
             serde_json::from_str(input).map_err(|e| EngineError::InvalidJson(e.to_string()))?;

--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -15,6 +15,7 @@
 //! | **Introspection** | List functions, search by keyword, describe, find similar |
 //! | **Discovery** | Cross-server tool discovery with BM25 search indexing |
 //! | **Query Store** | Named queries for session-scoped reuse |
+//! | **Configuration** | Declarative `jpx.toml` config with layered discovery and merge |
 //! | **JSON Utilities** | Format, diff, patch, merge, stats, paths, keys |
 //! | **Arrow** | Apache Arrow conversion (optional, via `arrow` feature) |
 //!
@@ -23,6 +24,10 @@
 //! - **`arrow`** - Enables Apache Arrow support for columnar data conversion.
 //!   This adds the `arrow` module with functions to convert between Arrow
 //!   RecordBatches and JSON Values. Used by the CLI for Parquet I/O.
+//! - **`let-expr`** - Enables `let` expression support (variable bindings in
+//!   JMESPath expressions). Forwarded from jpx-core. Enabled by default.
+//! - **`schema`** - Derives `JsonSchema` on discovery types for JSON Schema
+//!   generation. Used by the MCP server for tool schemas.
 //!
 //! ## Quick Start
 //!
@@ -161,6 +166,27 @@
 //! assert_eq!(queries.len(), 1);
 //! ```
 //!
+//! ## Configuration
+//!
+//! Load engine settings from `jpx.toml` files with layered discovery:
+//!
+//! ```rust
+//! use jpx_engine::{JpxEngine, EngineConfig};
+//!
+//! // Discover config from standard locations
+//! // (~/.config/jpx/jpx.toml, ./jpx.toml, $JPX_CONFIG)
+//! let config = EngineConfig::discover().unwrap();
+//! let engine = JpxEngine::from_config(config).unwrap();
+//!
+//! // Or use the builder for programmatic configuration
+//! let engine = JpxEngine::builder()
+//!     .strict(false)
+//!     .disable_category("geo")
+//!     .disable_function("env")
+//!     .build()
+//!     .unwrap();
+//! ```
+//!
 //! ## Tool Discovery
 //!
 //! Register and search tools across multiple servers (for MCP integration):
@@ -209,13 +235,13 @@
 //! ## Architecture
 //!
 //! ```text
-//! jmespath-extensions    (400+ functions, registry)
+//!    jpx-core           (parser, runtime, 400+ functions, registry)
 //!         |
-//!    jpx-engine          (this crate - evaluation, search, discovery)
+//!    jpx-engine         (this crate - evaluation, search, discovery, config)
 //!         |
 //!    +----+----+
 //!    |         |
-//!   jpx    jpx-mcp    (CLI and MCP transport)
+//!   jpx    jpx-mcp     (CLI and MCP transport)
 //! ```
 //!
 //! ## Thread Safety
@@ -225,6 +251,7 @@
 //! registry is immutable after construction.
 
 mod bm25;
+pub mod config;
 mod discovery;
 mod error;
 mod eval;
@@ -238,6 +265,7 @@ mod types;
 pub mod arrow;
 
 pub use bm25::{Bm25Index, DocInfo, IndexOptions, SearchResult as Bm25SearchResult, TermInfo};
+pub use config::{EngineBuilder, EngineConfig, EngineSection, FunctionsSection, QueriesSection};
 pub use discovery::{
     CategoryInfo, CategorySummary, DiscoveryRegistry, DiscoverySpec, ExampleSpec, IndexStats,
     ParamSpec, RegistrationResult, ReturnSpec, ServerInfo, ServerSummary, ToolQueryResult,
@@ -401,6 +429,55 @@ impl JpxEngine {
     /// ```
     pub fn strict() -> Self {
         Self::with_options(true)
+    }
+
+    /// Creates a new engine from an [`EngineConfig`].
+    ///
+    /// Applies function filtering, loads query libraries and inline queries,
+    /// and sets engine options from the config.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::{JpxEngine, EngineConfig};
+    ///
+    /// let config = EngineConfig::default();
+    /// let engine = JpxEngine::from_config(config).unwrap();
+    /// ```
+    pub fn from_config(config: EngineConfig) -> Result<Self> {
+        let strict = config.engine.strict;
+        let (runtime, registry) = config::build_runtime_from_config(&config.functions, strict);
+
+        let discovery = Arc::new(RwLock::new(DiscoveryRegistryInner::new()));
+        let queries = Arc::new(RwLock::new(QueryStoreInner::new()));
+
+        // Load queries from config
+        config::load_queries_into_store(&config.queries, &runtime, &queries)?;
+
+        Ok(Self {
+            runtime,
+            registry,
+            discovery,
+            queries,
+            strict,
+        })
+    }
+
+    /// Returns a builder for constructing a `JpxEngine` with programmatic overrides.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::builder()
+    ///     .strict(false)
+    ///     .disable_category("geo")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn builder() -> config::EngineBuilder {
+        config::EngineBuilder::new()
     }
 
     /// Returns `true` if the engine is in strict mode.


### PR DESCRIPTION
## Summary

- Add declarative `jpx.toml` configuration system to jpx-engine with layered discovery, merge semantics, EngineBuilder, and function filtering
- Fix stale docs (jmespath -> jpx-core), add missing feature/method documentation, and improve eval test coverage

## Details

**Configuration system (`config.rs`):**
- `EngineConfig` struct parsed from TOML with `[engine]`, `[functions]`, and `[queries]` sections
- Layered discovery: global (`~/.config/jpx/jpx.toml`) -> project-local (`jpx.toml`) -> env (`$JPX_CONFIG`)
- Function filtering via blocklist (`disabled_categories`/`disabled_functions`) or allowlist (`enabled_categories`)
- Query library (`.jpx` files) and inline query loading
- `EngineBuilder` for programmatic construction with builder pattern
- `JpxEngine::from_config()` and `JpxEngine::builder()` entry points
- `build_runtime_from_config()` shared helper for consumers (CLI, MCP) to reuse
- 12 unit tests covering parsing, merge semantics, builder, and inline queries

**Doc audit fixes:**
- `error.rs`: "jmespath crate" -> "jpx-core runtime"
- `lib.rs`: Added Configuration to features table, documented `let-expr` and `schema` Cargo features, added Configuration section with examples
- `json_utils.rs`: Added `# Arguments` / `# Example` doc sections to all 7 public methods
- `eval.rs`: Added 5 new tests (extension fn, strict rejection, invalid expression, invalid JSON, batch errors)

**Note:** CLI and MCP wiring to use `EngineConfig::discover()` will follow in separate PRs.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p jpx-engine --all-targets --all-features -- -D warnings`
- [x] `cargo test -p jpx-engine --lib --all-features` (101 tests)
- [x] `cargo test -p jpx-engine --doc --all-features` (47 tests)
- [x] `cargo check --all-targets --all-features --workspace` (no downstream breakage)
- [x] `cargo doc -p jpx-engine --no-deps --all-features` (builds clean)