### PR TITLE
refactor: remove CLI direct dependency on jpx-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,6 @@ dependencies = [
  "colored_json",
  "csv",
  "dirs",
- "jpx-core",
  "jpx-engine",
  "json-patch",
  "parquet",

--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -289,6 +289,7 @@ use std::sync::{Arc, RwLock};
 
 // Re-export commonly used types from jpx-core
 pub use jpx_core::ast;
+pub use jpx_core::query_library;
 pub use jpx_core::{Category, Expression, FunctionInfo, FunctionRegistry, Runtime, compile, parse};
 
 /// The JMESPath query engine.

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -25,7 +25,6 @@ toml = "0.8"
 serde = { workspace = true, features = ["derive"] }
 
 [dependencies]
-jpx-core = { workspace = true, features = ["extensions"] }
 jpx-engine = { workspace = true }
 clap.workspace = true
 clap_complete.workspace = true
@@ -50,7 +49,7 @@ parquet = { version = "54", optional = true, default-features = false, features 
 
 [features]
 default = []
-let-expr = ["jpx-core/let-expr", "jpx-engine/let-expr"]
+let-expr = ["jpx-engine/let-expr"]
 parquet = ["dep:parquet", "jpx-engine/arrow"]
 
 [dev-dependencies]

--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -571,12 +571,12 @@ pub(crate) struct Args {
     pub(crate) warmup: u32,
 }
 
-/// Create a JMESPath runtime with all extension functions registered.
-pub(crate) fn create_runtime() -> jpx_core::Runtime {
-    let mut runtime = jpx_core::Runtime::new();
-    runtime.register_builtin_functions();
-    let mut registry = jpx_core::FunctionRegistry::new();
-    registry.register_all();
-    registry.apply(&mut runtime);
-    runtime
+/// Create a configured runtime and registry from engine config.
+/// If strict is true, extension functions are not applied to the runtime.
+pub(crate) fn create_configured_runtime(
+    engine_config: &jpx_engine::config::EngineConfig,
+    strict: bool,
+) -> (jpx_engine::Runtime, jpx_engine::FunctionRegistry) {
+    let effective_strict = strict || engine_config.engine.strict;
+    jpx_engine::config::build_runtime_from_config(&engine_config.functions, effective_strict)
 }

--- a/crates/jpx/src/bench.rs
+++ b/crates/jpx/src/bench.rs
@@ -2,7 +2,7 @@ use crate::args::ColorMode;
 use crate::stats::{format_bytes_human, format_with_commas};
 use anyhow::{Context, Result};
 use colored::Colorize;
-use jpx_core::Runtime;
+use jpx_engine::Runtime;
 use serde_json::Value;
 use std::io::{self, Write};
 use std::time::Instant;

--- a/crates/jpx/src/discovery.rs
+++ b/crates/jpx/src/discovery.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored::Colorize;
-use jpx_core::registry::{Category, FunctionInfo, FunctionRegistry};
+use jpx_engine::{Category, FunctionInfo, FunctionRegistry};
 
 pub(crate) fn print_functions(registry: &FunctionRegistry) {
     println!(

--- a/crates/jpx/src/explain.rs
+++ b/crates/jpx/src/explain.rs
@@ -1,4 +1,4 @@
-use jpx_core::ast::{Ast, Comparator};
+use jpx_engine::ast::{Ast, Comparator};
 use serde_json::Value;
 
 /// Describe a Value for verbose output

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use colored::Colorize;
-use jpx_core::{FunctionRegistry, Runtime};
+use jpx_engine::FunctionRegistry;
 use serde_json::Value;
 use std::io::{self, Write};
 use std::time::Instant;
@@ -44,15 +44,14 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
+    // Load engine config (jpx.toml discovery) and create runtime/registry
+    let engine_config = jpx_engine::config::EngineConfig::discover().unwrap_or_default();
+    let (runtime, registry) = args::create_configured_runtime(&engine_config, args.strict);
+
     // Handle REPL mode
     if args.repl || args.demo.is_some() {
-        return repl::run(args.demo.as_deref());
+        return repl::run(args.demo.as_deref(), runtime, registry);
     }
-
-    // Create registry for introspection
-    let mut registry = FunctionRegistry::new();
-    registry.register_all();
-    // Note: registry.apply(&runtime) is called below when creating the runtime
 
     if args.list_functions {
         discovery::print_functions(&registry);
@@ -124,7 +123,7 @@ fn run() -> Result<()> {
             .query_file
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("--check requires -Q/--query-file"))?;
-        return ops::check_queries(query_path, &args.color);
+        return ops::check_queries(query_path, &args.color, &runtime);
     }
 
     // Get expressions from positional args, -e flags, or file
@@ -155,8 +154,8 @@ fn run() -> Result<()> {
             }
             println!();
 
-            let ast =
-                jpx_core::parse(expression).map_err(|e| input::expression_error(expression, e))?;
+            let ast = jpx_engine::parse(expression)
+                .map_err(|e| input::expression_error(expression, e))?;
 
             explain::print_ast(&ast, 0);
             println!();
@@ -166,7 +165,7 @@ fn run() -> Result<()> {
 
     // Handle --stream: process input line by line (NDJSON/JSON Lines)
     if args.stream {
-        return streaming::run_streaming(&expressions, &args);
+        return streaming::run_streaming(&expressions, &args, &runtime);
     }
 
     // Get input data
@@ -190,13 +189,6 @@ fn run() -> Result<()> {
         #[cfg(not(feature = "parquet"))]
         input::read_input_as_value(&args)?
     };
-
-    // Create runtime with extensions (unless strict mode)
-    let mut runtime = Runtime::new();
-    runtime.register_builtin_functions();
-    if !args.strict {
-        registry.apply(&mut runtime);
-    }
 
     // Verbose mode: show input info
     if args.verbose {

--- a/crates/jpx/src/ops.rs
+++ b/crates/jpx/src/ops.rs
@@ -1,8 +1,9 @@
-use crate::args::{ColorMode, create_runtime};
+use crate::args::ColorMode;
 use crate::input::{self, read_json_from};
 use crate::output::output_json;
 use anyhow::{Context, Result};
 use colored::Colorize;
+use jpx_engine::Runtime;
 
 /// Generate JSON Patch (RFC 6902) from two files
 pub(crate) fn diff_files(
@@ -115,7 +116,11 @@ pub(crate) fn list_queries(query_path: &str, color_mode: &ColorMode) -> Result<(
 }
 
 /// Validate queries in a .jpx file without running them
-pub(crate) fn check_queries(query_path: &str, color_mode: &ColorMode) -> Result<()> {
+pub(crate) fn check_queries(
+    query_path: &str,
+    color_mode: &ColorMode,
+    runtime: &Runtime,
+) -> Result<()> {
     let (file_path, _) = jpx::query_library::parse_query_path(query_path);
     let content =
         std::fs::read_to_string(file_path).map_err(|e| input::file_read_error(file_path, &e))?;
@@ -128,9 +133,6 @@ pub(crate) fn check_queries(query_path: &str, color_mode: &ColorMode) -> Result<
         ColorMode::Never => false,
         ColorMode::Auto => atty::is(atty::Stream::Stdout),
     };
-
-    // Create runtime with all functions registered for proper validation
-    let runtime = create_runtime();
 
     let mut has_errors = false;
 

--- a/crates/jpx/src/query_library.rs
+++ b/crates/jpx/src/query_library.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result, anyhow};
 
 // Re-export core types for convenience
-pub use jpx_core::query_library::{NamedQuery, ParseError, QueryLibrary, is_query_library};
+pub use jpx_engine::query_library::{NamedQuery, ParseError, QueryLibrary, is_query_library};
 
 /// Parse a query file path that may contain a colon-separated query name.
 ///

--- a/crates/jpx/src/repl.rs
+++ b/crates/jpx/src/repl.rs
@@ -6,8 +6,7 @@
 #![allow(clippy::collapsible_if)]
 
 use anyhow::{Context, Result};
-use jpx_core::Runtime;
-use jpx_core::registry::{Category, FunctionRegistry};
+use jpx_engine::{Category, FunctionRegistry, Runtime};
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::{CmdKind, Highlighter};
@@ -70,10 +69,7 @@ pub struct JmespathHelper {
 }
 
 impl JmespathHelper {
-    pub fn new(data_fields: Rc<RefCell<Vec<String>>>) -> Self {
-        let mut registry = FunctionRegistry::new();
-        registry.register_all();
-
+    pub fn new(registry: &FunctionRegistry, data_fields: Rc<RefCell<Vec<String>>>) -> Self {
         let functions: HashSet<String> = registry.functions().map(|f| f.name.to_string()).collect();
 
         Self {
@@ -1255,11 +1251,11 @@ fn extract_fields(var: &Value) -> Vec<String> {
 }
 
 /// Run the REPL
-pub fn run(demo_name: Option<&str>) -> Result<()> {
+pub fn run(demo_name: Option<&str>, runtime: Runtime, registry: FunctionRegistry) -> Result<()> {
     // Shared state for data field completion
     let data_fields: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(vec![]));
 
-    let helper = JmespathHelper::new(Rc::clone(&data_fields));
+    let helper = JmespathHelper::new(&registry, Rc::clone(&data_fields));
     let mut rl: Editor<JmespathHelper, DefaultHistory> = Editor::new()?;
     rl.set_helper(Some(helper));
 
@@ -1270,13 +1266,6 @@ pub fn run(demo_name: Option<&str>) -> Result<()> {
         let _ = std::fs::create_dir_all(path.parent().unwrap());
         let _ = rl.load_history(path);
     }
-
-    // Create runtime with all extensions
-    let mut runtime = Runtime::new();
-    runtime.register_builtin_functions();
-    let mut registry = FunctionRegistry::new();
-    registry.register_all();
-    registry.apply(&mut runtime);
 
     // Current data
     let mut data: Option<Value> = None;

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -1,12 +1,12 @@
 use crate::args::Args;
 use crate::input;
 use anyhow::{Context, Result};
-use jpx_core::{FunctionRegistry, Runtime};
+use jpx_engine::Runtime;
 use serde_json::Value;
 use std::io::{self, BufRead, BufWriter, Write};
 
 /// Run streaming mode - process input line by line (NDJSON/JSON Lines)
-pub(crate) fn run_streaming(expressions: &[String], args: &Args) -> Result<()> {
+pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runtime) -> Result<()> {
     // Set up input reader
     let input: Box<dyn BufRead> = match &args.file {
         Some(path) => {
@@ -19,15 +19,6 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args) -> Result<()> {
     // Set up buffered output
     let stdout = io::stdout();
     let mut writer = BufWriter::new(stdout.lock());
-
-    // Create runtime with extensions (unless strict mode)
-    let mut runtime = Runtime::new();
-    runtime.register_builtin_functions();
-    if !args.strict {
-        let mut registry = FunctionRegistry::new();
-        registry.register_all();
-        registry.apply(&mut runtime);
-    }
 
     // Compile expressions once
     let compiled: Vec<_> = expressions


### PR DESCRIPTION
## Summary

- Remove the CLI's direct dependency on `jpx-core`, routing everything through `jpx-engine` re-exports
- Consolidate 4 runtime construction sites (main.rs, streaming.rs, repl.rs, ops.rs) into 1 shared `create_configured_runtime()` using `build_runtime_from_config()`
- Wire `EngineConfig::discover()` into the CLI so `jpx.toml` config files now apply to all CLI operations (strict mode, function filtering, etc.)
- Add `query_library` re-export to jpx-engine (was the only missing re-export)
- Net reduction: 37 insertions, 64 deletions across 12 files

## Test plan

- [x] `cargo check -p jpx --all-features` -- clean compile, no warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo test --lib --all-features --workspace` -- 180 tests pass
- [x] `cargo test --test '*' --all-features` -- 201 integration tests pass
- [x] `cargo tree -p jpx --depth 1` -- confirms jpx-core is NOT a direct dep
- [x] Smoke tests: `upper(name)` works, `--strict length(name)` works, `--strict upper(name)` errors