### PR TITLE
chore: add .mcp.json for local MCP server demo

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "jpx": {
+      "command": "cargo",
+      "args": ["run", "--quiet", "-p", "jpx-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Check in `.mcp.json` so the jpx-mcp server is pre-configured for anyone using Claude Code with this repo
- Uses `cargo run -p jpx-mcp` (workspace-relative) instead of an absolute path

## Test plan

- [x] Clone repo fresh, open with Claude Code, verify jpx MCP server starts automatically