### PR TITLE
feat: wire EngineConfig into jpx-mcp server

### DIFF
--- a/crates/jpx-mcp/src/lib.rs
+++ b/crates/jpx-mcp/src/lib.rs
@@ -5,4 +5,4 @@
 
 mod tools;
 
-pub use tools::build_router;
+pub use tools::{build_router, build_router_from_config};

--- a/crates/jpx-mcp/src/main.rs
+++ b/crates/jpx-mcp/src/main.rs
@@ -68,8 +68,15 @@ async fn main() -> anyhow::Result<()> {
         "Starting jpx-mcp server"
     );
 
+    // Load engine config (jpx.toml discovery) and merge CLI flags
+    let mut engine_config = jpx_engine::config::EngineConfig::discover().unwrap_or_default();
+    if args.strict {
+        engine_config.engine.strict = true;
+    }
+
     // Build the router
-    let router = tools::build_router(args.strict).map_err(|e| anyhow::anyhow!("{}", e))?;
+    let router =
+        tools::build_router_from_config(engine_config).map_err(|e| anyhow::anyhow!("{}", e))?;
 
     match args.transport {
         Transport::Stdio => {

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -2,7 +2,9 @@
 //!
 //! This module wraps jpx_engine functionality in MCP tool handlers.
 
-use jpx_engine::{Category, DiscoverySpec, JpxEngine, ServerInfo as DiscoveryServerInfo, ToolSpec};
+use jpx_engine::{
+    Category, DiscoverySpec, EngineConfig, JpxEngine, ServerInfo as DiscoveryServerInfo, ToolSpec,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
@@ -278,12 +280,23 @@ fn error_result(message: impl Into<String>) -> CallToolResult {
 // =============================================================================
 
 /// Build the MCP router with all jpx tools registered.
+///
+/// For simple use, pass `strict: true/false`. For full config support
+/// (function filtering, query libraries, etc.), use [`build_router_from_config`].
+#[allow(dead_code)]
 pub fn build_router(strict: bool) -> Result<McpRouter, BoxError> {
-    let engine = if strict {
-        JpxEngine::strict()
-    } else {
-        JpxEngine::new()
-    };
+    let mut config = EngineConfig::default();
+    config.engine.strict = strict;
+    build_router_from_config(config)
+}
+
+/// Build the MCP router from an [`EngineConfig`].
+///
+/// This applies function filtering, query libraries, and other settings
+/// from the config. Use [`EngineConfig::discover`] to load from `jpx.toml`.
+pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxError> {
+    let engine = JpxEngine::from_config(config)
+        .map_err(|e| -> BoxError { format!("Failed to build engine: {}", e).into() })?;
     let engine = Arc::new(engine);
 
     // -- evaluate

--- a/crates/jpx-mcp/tests/tools.rs
+++ b/crates/jpx-mcp/tests/tools.rs
@@ -48,8 +48,8 @@ async fn test_list_tools() {
 
     let tools = client.list_tools().await;
 
-    // Should have 31 tools
-    assert_eq!(tools.len(), 31, "Expected 31 tools, got {}", tools.len());
+    // Should have 32 tools
+    assert_eq!(tools.len(), 32, "Expected 32 tools, got {}", tools.len());
 
     let tool_names: Vec<&str> = tools
         .iter()


### PR DESCRIPTION
## Summary

- Use `EngineConfig::discover()` and `JpxEngine::from_config()` in jpx-mcp so the MCP server respects `jpx.toml` configuration (function filtering, query libraries, strict mode)
- Add `build_router_from_config(EngineConfig)` alongside existing `build_router(bool)` convenience wrapper
- Fix pre-existing `test_list_tools` assertion count (31 -> 32, the `explain` tool was added in #42 but the count wasn't updated)

## Test plan

- [x] All 37 jpx-mcp tests pass
- [x] Full workspace library tests pass (180 tests)
- [x] All 201 integration tests pass
- [x] `cargo clippy -p jpx-mcp --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean