### PR TITLE
test: comprehensive jpx-core test coverage (63 -> 985 tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1488,7 @@ dependencies = [
  "json-patch",
  "md-5",
  "nanoid",
+ "proptest",
  "rand 0.8.5",
  "regex",
  "rphonetic",
@@ -2079,6 +2095,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2303,6 +2353,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -3065,6 +3127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3223,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -56,6 +56,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }
 criterion = { workspace = true }
 jmespath = "0.3"
+proptest = "1.6"
 
 [[bench]]
 name = "vs_jmespath"

--- a/crates/jpx-core/src/error.rs
+++ b/crates/jpx-core/src/error.rs
@@ -118,3 +118,155 @@ pub enum RuntimeError {
         invocation: usize,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_single_line_expression() {
+        let err = JmespathError::new("foo.bar", 4, ErrorReason::Parse("test".into()));
+        assert_eq!(err.line(), 1);
+    }
+
+    #[test]
+    fn column_single_line_expression() {
+        let err = JmespathError::new("foo.bar", 4, ErrorReason::Parse("test".into()));
+        assert_eq!(err.column(), 4);
+    }
+
+    #[test]
+    fn line_multi_line_expression() {
+        let err = JmespathError::new("foo\nbar\nbaz", 8, ErrorReason::Parse("test".into()));
+        assert_eq!(err.line(), 3);
+    }
+
+    #[test]
+    fn column_multi_line_expression() {
+        let err = JmespathError::new("foo\nbar\nbaz", 8, ErrorReason::Parse("test".into()));
+        assert_eq!(err.column(), 0);
+    }
+
+    #[test]
+    fn column_mid_second_line() {
+        let err = JmespathError::new("foo\nbar.baz", 6, ErrorReason::Parse("test".into()));
+        assert_eq!(err.line(), 2);
+        assert_eq!(err.column(), 2);
+    }
+
+    #[test]
+    fn offset_beyond_expression_length() {
+        let err = JmespathError::new("foo", 100, ErrorReason::Parse("test".into()));
+        // line() clamps to expression length, so still line 1
+        assert_eq!(err.line(), 1);
+        // column() returns the raw offset when no newline is found
+        assert_eq!(err.column(), 100);
+    }
+
+    #[test]
+    fn display_format_parse_error() {
+        let err = JmespathError::new("foo.bar", 4, ErrorReason::Parse("bad token".into()));
+        let display = format!("{err}");
+        assert!(display.contains("Parse error: bad token"));
+        assert!(display.contains("foo.bar"));
+        assert!(display.contains("^"));
+    }
+
+    #[test]
+    fn display_format_runtime_error() {
+        let err = JmespathError::new(
+            "foo()",
+            0,
+            ErrorReason::Runtime(RuntimeError::UnknownFunction("foo".into())),
+        );
+        let display = format!("{err}");
+        assert!(display.contains("Runtime error"));
+        assert!(display.contains("Unknown function: foo"));
+    }
+
+    #[test]
+    fn runtime_error_invalid_slice_display() {
+        let err = RuntimeError::InvalidSlice;
+        assert_eq!(format!("{err}"), "Invalid slice: step cannot be 0");
+    }
+
+    #[test]
+    fn runtime_error_too_many_args_display() {
+        let err = RuntimeError::TooManyArguments {
+            expected: 2,
+            actual: 5,
+        };
+        assert_eq!(format!("{err}"), "Too many arguments: expected 2, got 5");
+    }
+
+    #[test]
+    fn runtime_error_not_enough_args_display() {
+        let err = RuntimeError::NotEnoughArguments {
+            expected: 3,
+            actual: 1,
+        };
+        assert_eq!(format!("{err}"), "Not enough arguments: expected 3, got 1");
+    }
+
+    #[test]
+    fn runtime_error_invalid_type_display() {
+        let err = RuntimeError::InvalidType {
+            expected: "string".into(),
+            actual: "number".into(),
+            position: 0,
+        };
+        let display = format!("{err}");
+        assert!(display.contains("expected string"));
+        assert!(display.contains("got number"));
+    }
+
+    #[test]
+    fn runtime_error_invalid_return_type_display() {
+        let err = RuntimeError::InvalidReturnType {
+            expected: "number".into(),
+            actual: "string".into(),
+            position: 1,
+            invocation: 2,
+        };
+        let display = format!("{err}");
+        assert!(display.contains("expected number"));
+        assert!(display.contains("got string"));
+        assert!(display.contains("position 1"));
+        assert!(display.contains("invocation 2"));
+    }
+
+    #[test]
+    fn error_reason_parse_display() {
+        let reason = ErrorReason::Parse("unexpected token".into());
+        assert_eq!(format!("{reason}"), "Parse error: unexpected token");
+    }
+
+    #[test]
+    fn error_reason_runtime_display() {
+        let reason = ErrorReason::Runtime(RuntimeError::InvalidSlice);
+        assert!(format!("{reason}").contains("Invalid slice"));
+    }
+
+    #[test]
+    fn from_ctx_uses_context_offset() {
+        let runtime = crate::Runtime::new();
+        let mut ctx = crate::Context::new("test_expr", &runtime);
+        ctx.offset = 5;
+        let err = JmespathError::from_ctx(&ctx, ErrorReason::Parse("test".into()));
+        assert_eq!(err.offset, 5);
+        assert_eq!(err.expression, "test_expr");
+    }
+
+    #[test]
+    fn jmespath_error_implements_std_error() {
+        let err = JmespathError::new("foo", 0, ErrorReason::Parse("test".into()));
+        let _: &dyn std::error::Error = &err;
+    }
+
+    #[test]
+    fn jmespath_error_clone_and_eq() {
+        let err = JmespathError::new("foo", 0, ErrorReason::Parse("test".into()));
+        let cloned = err.clone();
+        assert_eq!(err, cloned);
+    }
+}

--- a/crates/jpx-core/src/extensions/array.rs
+++ b/crates/jpx-core/src/extensions/array.rs
@@ -1849,3 +1849,1417 @@ impl Function for CycleFn {
         Ok(Value::Array(result))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_unique() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("unique(@)").unwrap();
+        let data = json!([1, 2, 1]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_first() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("first(@)").unwrap();
+        let data = json!([1, 2]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_last() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("last(@)").unwrap();
+        let data = json!([1, 2]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_range() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("range(`0`, `5`)").unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+    }
+
+    #[test]
+    fn test_butlast() {
+        // butlast is an alias for initial
+        let runtime = setup_runtime();
+        let expr = runtime.compile("butlast(@)").unwrap();
+        let data = json!([1, 2, 3]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_interpose() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("interpose(@, `0`)").unwrap();
+        let data = json!([1, 2, 3]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 0);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[3].as_f64().unwrap() as i64, 0);
+        assert_eq!(arr[4].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_interpose_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("interpose(@, `0`)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_interpose_single() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("interpose(@, `0`)").unwrap();
+        let data = json!([1]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_interpose_string_separator() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("interpose(@, `\"-\"`)").unwrap();
+        let data = json!(["a", "b", "c"]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[1].as_str().unwrap(), "-");
+        assert_eq!(arr[2].as_str().unwrap(), "b");
+        assert_eq!(arr[3].as_str().unwrap(), "-");
+        assert_eq!(arr[4].as_str().unwrap(), "c");
+    }
+
+    #[test]
+    fn test_zipmap() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("zipmap(`[\"a\", \"b\", \"c\"]`, `[1, 2, 3]`)")
+            .unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 3);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+        assert_eq!(obj.get("c").unwrap().as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_zipmap_unequal_lengths() {
+        let runtime = setup_runtime();
+        // Keys shorter than values
+        let expr = runtime
+            .compile("zipmap(`[\"x\", \"y\"]`, `[10, 20, 30]`)")
+            .unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("x").unwrap().as_f64().unwrap() as i64, 10);
+        assert_eq!(obj.get("y").unwrap().as_f64().unwrap() as i64, 20);
+    }
+
+    #[test]
+    fn test_zipmap_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("zipmap(`[]`, `[]`)").unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_partition_by() {
+        let runtime = setup_runtime();
+        // Test with objects - partition by "type" field
+        let expr = runtime.compile(r#"partition_by(@, `"type"`)"#).unwrap();
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"type": "a", "v": 1}, {"type": "a", "v": 2}, {"type": "b", "v": 3}, {"type": "a", "v": 4}]"#,
+        )
+        .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+
+        let partition1 = arr[0].as_array().unwrap();
+        assert_eq!(partition1.len(), 2); // Two "a" items
+
+        let partition2 = arr[1].as_array().unwrap();
+        assert_eq!(partition2.len(), 1); // One "b" item
+
+        let partition3 = arr[2].as_array().unwrap();
+        assert_eq!(partition3.len(), 1); // One more "a" item
+    }
+
+    #[test]
+    fn test_partition_by_primitives() {
+        let runtime = setup_runtime();
+        // For primitives, use any field name - it will use the value itself
+        let expr = runtime.compile(r#"partition_by(@, `"_"`)"#).unwrap();
+        let data = json!([1, 1, 2, 2, 1, 1]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+
+        let partition1 = arr[0].as_array().unwrap();
+        assert_eq!(partition1.len(), 2);
+        assert_eq!(partition1[0].as_f64().unwrap() as i64, 1);
+
+        let partition2 = arr[1].as_array().unwrap();
+        assert_eq!(partition2.len(), 2);
+        assert_eq!(partition2[0].as_f64().unwrap() as i64, 2);
+
+        let partition3 = arr[2].as_array().unwrap();
+        assert_eq!(partition3.len(), 2);
+        assert_eq!(partition3[0].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_partition_by_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile(r#"partition_by(@, `"type"`)"#).unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_partition_by_single() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile(r#"partition_by(@, `"type"`)"#).unwrap();
+        let data: serde_json::Value = serde_json::from_str(r#"[{"type": "a"}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let partition1 = arr[0].as_array().unwrap();
+        assert_eq!(partition1.len(), 1);
+    }
+
+    #[test]
+    fn test_dedupe() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data = json!([1, 1, 2, 2, 1, 1]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_dedupe_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_dedupe_no_consecutive() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data = json!([1, 2, 3]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_dedupe_strings() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data = json!(["a", "a", "b", "a"]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[1].as_str().unwrap(), "b");
+        assert_eq!(arr[2].as_str().unwrap(), "a");
+    }
+
+    #[test]
+    fn test_dedupe_objects() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"[{"x": 1}, {"x": 1}, {"x": 2}, {"x": 1}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_dedupe_all_same() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("dedupe(@)").unwrap();
+        let data = json!([1, 1, 1]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_zipmap_duplicate_keys() {
+        // Later key should overwrite earlier one
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("zipmap(`[\"a\", \"b\", \"a\"]`, `[1, 2, 3]`)")
+            .unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 3); // Last value wins
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_zipmap_values_longer() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("zipmap(`[\"a\"]`, `[1, 2, 3]`)").unwrap();
+        let data = json!(null);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_partition_by_missing_field() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile(r#"partition_by(@, `"type"`)"#).unwrap();
+        // Some objects have type, some don't
+        let data: serde_json::Value =
+            serde_json::from_str(r#"[{"type": "a"}, {"name": "no-type"}, {"type": "a"}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should partition into 3: [type:a], [no type -> null], [type:a]
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_partition_by_all_same() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile(r#"partition_by(@, `"type"`)"#).unwrap();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"[{"type": "a"}, {"type": "a"}, {"type": "a"}]"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let partition = arr[0].as_array().unwrap();
+        assert_eq!(partition.len(), 3);
+    }
+
+    #[test]
+    fn test_interpose_null_separator() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("interpose(@, `null`)").unwrap();
+        let data = json!([1, 2]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert!(arr[1].is_null());
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_interpose_object_separator() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile(r#"interpose(@, `{"sep": true}`)"#).unwrap();
+        let data = json!([1, 2]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert!(arr[1].as_object().is_some());
+    }
+
+    // =========================================================================
+    // zip tests
+    // =========================================================================
+
+    #[test]
+    fn test_zip_basic() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2, 3], "b": ["x", "y", "z"]}"#).unwrap();
+        let expr = runtime.compile("zip(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_array().unwrap()[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[0].as_array().unwrap()[1].as_str().unwrap(), "x");
+    }
+
+    #[test]
+    fn test_zip_unequal_lengths() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2], "b": ["x", "y", "z"]}"#).unwrap();
+        let expr = runtime.compile("zip(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Stops at shorter array
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_zip_empty_array() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(r#"{"a": [], "b": [1, 2, 3]}"#).unwrap();
+        let expr = runtime.compile("zip(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_zip_with_objects() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"names": ["Alice", "Bob"], "scores": [95, 87]}"#).unwrap();
+        let expr = runtime.compile("zip(names, scores)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_array().unwrap()[0].as_str().unwrap(), "Alice");
+        assert_eq!(arr[0].as_array().unwrap()[1].as_f64().unwrap() as i64, 95);
+    }
+
+    // =========================================================================
+    // chunk tests
+    // =========================================================================
+
+    #[test]
+    fn test_chunk_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("chunk(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // [1,2], [3,4], [5]
+        assert_eq!(arr[0].as_array().unwrap().len(), 2);
+        assert_eq!(arr[2].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_chunk_exact_fit() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5, 6]);
+        let expr = runtime.compile("chunk(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_array().unwrap().len(), 3);
+        assert_eq!(arr[1].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_chunk_size_larger_than_array() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("chunk(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_chunk_size_one() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("chunk(@, `1`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_chunk_and_process_pipeline() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let expr = runtime.compile("chunk(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // [1,2,3], [4,5,6], [7,8,9], [10]
+        assert_eq!(arr.len(), 4);
+    }
+
+    // =========================================================================
+    // take tests
+    // =========================================================================
+
+    #[test]
+    fn test_take_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("take(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_take_more_than_length() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2]);
+        let expr = runtime.compile("take(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_take_zero() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("take(@, `0`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // drop tests
+    // =========================================================================
+
+    #[test]
+    fn test_drop_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("drop(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_drop_more_than_length() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2]);
+        let expr = runtime.compile("drop(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_drop_zero() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("drop(@, `0`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    // =========================================================================
+    // flatten_deep tests
+    // =========================================================================
+
+    #[test]
+    fn test_flatten_deep_basic() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2], [3, 4]]);
+        let expr = runtime.compile("flatten_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+    }
+
+    #[test]
+    fn test_flatten_deep_nested() {
+        let runtime = setup_runtime();
+        let data = json!([1, [2, [3, [4, [5]]]]]);
+        let expr = runtime.compile("flatten_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[4].as_f64().unwrap() as i64, 5);
+    }
+
+    #[test]
+    fn test_flatten_deep_already_flat() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("flatten_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_flatten_deep_mixed() {
+        let runtime = setup_runtime();
+        let data = json!([1, [2, 3], [[4]], [[[5, 6]]]]);
+        let expr = runtime.compile("flatten_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 6);
+    }
+
+    // =========================================================================
+    // compact tests
+    // =========================================================================
+
+    #[test]
+    fn test_compact_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, null, 2, false, 3]);
+        let expr = runtime.compile("compact(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_compact_keeps_zero_and_empty_string() {
+        let runtime = setup_runtime();
+        let data = json!([0, "", null, true]);
+        let expr = runtime.compile("compact(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // 0, "", true
+    }
+
+    #[test]
+    fn test_compact_all_falsy() {
+        let runtime = setup_runtime();
+        let data = json!([null, false, null]);
+        let expr = runtime.compile("compact(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // index_at tests
+    // =========================================================================
+
+    #[test]
+    fn test_index_at_positive() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c", "d"]);
+        let expr = runtime.compile("index_at(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "c");
+    }
+
+    #[test]
+    fn test_index_at_negative() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c", "d"]);
+        let expr = runtime.compile("index_at(@, `-1`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "d");
+    }
+
+    #[test]
+    fn test_index_at_negative_second() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c", "d"]);
+        let expr = runtime.compile("index_at(@, `-2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "c");
+    }
+
+    #[test]
+    fn test_index_at_out_of_bounds() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c"]);
+        let expr = runtime.compile("index_at(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    // =========================================================================
+    // includes tests
+    // =========================================================================
+
+    #[test]
+    fn test_includes_number() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("includes(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_includes_not_found() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("includes(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_includes_string() {
+        let runtime = setup_runtime();
+        let data = json!(["apple", "banana", "cherry"]);
+        let expr = runtime.compile(r#"includes(@, `"banana"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_includes_object() {
+        let runtime = setup_runtime();
+        let data = json!([{"a": 1}, {"b": 2}]);
+        let expr = runtime.compile(r#"includes(@, `{"a": 1}`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // find_index tests
+    // =========================================================================
+
+    #[test]
+    fn test_find_index_found() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c", "d"]);
+        let expr = runtime.compile(r#"find_index(@, `"c"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_find_index_not_found() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c"]);
+        let expr = runtime.compile(r#"find_index(@, `"z"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, -1);
+    }
+
+    // =========================================================================
+    // group_by tests
+    // =========================================================================
+
+    #[test]
+    fn test_group_by_basic() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"type": "a", "v": 1}, {"type": "b", "v": 2}, {"type": "a", "v": 3}]"#,
+        )
+        .unwrap();
+        let expr = runtime.compile(r#"group_by(@, `"type"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("b").unwrap().as_array().unwrap().len(), 1);
+    }
+
+    // =========================================================================
+    // index_by tests
+    // =========================================================================
+
+    #[test]
+    fn test_index_by_basic() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"[{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]"#)
+                .unwrap();
+        let expr = runtime.compile(r#"index_by(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        // Keys are string versions of the id
+        let alice = obj.get("1").unwrap().as_object().unwrap();
+        assert_eq!(alice.get("name").unwrap().as_str().unwrap(), "alice");
+        let bob = obj.get("2").unwrap().as_object().unwrap();
+        assert_eq!(bob.get("name").unwrap().as_str().unwrap(), "bob");
+    }
+
+    #[test]
+    fn test_index_by_string_key() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"code": "US", "name": "United States"}, {"code": "UK", "name": "United Kingdom"}]"#,
+        )
+        .unwrap();
+        let expr = runtime.compile(r#"index_by(@, `"code"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        let us = obj.get("US").unwrap().as_object().unwrap();
+        assert_eq!(us.get("name").unwrap().as_str().unwrap(), "United States");
+    }
+
+    #[test]
+    fn test_index_by_duplicate_keys() {
+        // Last value wins for duplicate keys
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"type": "a", "v": 1}, {"type": "a", "v": 2}, {"type": "a", "v": 3}]"#,
+        )
+        .unwrap();
+        let expr = runtime.compile(r#"index_by(@, `"type"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        // Last value (v=3) wins
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(a.get("v").unwrap().as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_index_by_missing_key() {
+        // Items without the key field are skipped
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(
+            r#"[{"id": 1, "name": "alice"}, {"name": "bob"}, {"id": 3, "name": "charlie"}]"#,
+        )
+        .unwrap();
+        let expr = runtime.compile(r#"index_by(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("1"));
+        assert!(obj.contains_key("3"));
+        assert!(!obj.contains_key("2")); // bob was skipped
+    }
+
+    #[test]
+    fn test_index_by_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile(r#"index_by(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.is_empty());
+    }
+
+    // =========================================================================
+    // set operations tests
+    // =========================================================================
+
+    #[test]
+    fn test_difference() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2, 3, 4], "b": [2, 4]}"#).unwrap();
+        let expr = runtime.compile("difference(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // 1, 3
+    }
+
+    #[test]
+    fn test_intersection() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2, 3], "b": [2, 3, 4]}"#).unwrap();
+        let expr = runtime.compile("intersection(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // 2, 3
+    }
+
+    #[test]
+    fn test_union() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2], "b": [2, 3]}"#).unwrap();
+        let expr = runtime.compile("union(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // 1, 2, 3
+    }
+
+    // =========================================================================
+    // frequencies tests
+    // =========================================================================
+
+    #[test]
+    fn test_frequencies_basic() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "a", "c", "a", "b"]);
+        let expr = runtime.compile("frequencies(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 3);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+        assert_eq!(obj.get("c").unwrap().as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_frequencies_numbers() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 1, 1, 2, 3]);
+        let expr = runtime.compile("frequencies(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("1").unwrap().as_f64().unwrap() as i64, 3);
+        assert_eq!(obj.get("2").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    // =========================================================================
+    // mode tests
+    // =========================================================================
+
+    #[test]
+    fn test_mode_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 2, 3, 2, 4]);
+        let expr = runtime.compile("mode(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_mode_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("mode(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    // =========================================================================
+    // cartesian tests
+    // =========================================================================
+
+    #[test]
+    fn test_cartesian_basic() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2], "b": ["x", "y"]}"#).unwrap();
+        let expr = runtime.compile("cartesian(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4); // [1,x], [1,y], [2,x], [2,y]
+    }
+
+    #[test]
+    fn test_cartesian_empty() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(r#"{"a": [], "b": [1, 2]}"#).unwrap();
+        let expr = runtime.compile("cartesian(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_cartesian_n_way_two_arrays() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2], ["a", "b"]]);
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4); // [1,a], [1,b], [2,a], [2,b]
+    }
+
+    #[test]
+    fn test_cartesian_n_way_three_arrays() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2], ["a", "b"], [true, false]]);
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 8); // 2 * 2 * 2 = 8 combinations
+    }
+
+    #[test]
+    fn test_cartesian_n_way_single_array() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2, 3]]);
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // [1], [2], [3]
+    }
+
+    #[test]
+    fn test_cartesian_n_way_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("cartesian(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    #[test]
+    fn test_first_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("first(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_last_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("last(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_unique_preserves_order() {
+        let runtime = setup_runtime();
+        let data = json!(["c", "a", "b", "a", "c"]);
+        let expr = runtime.compile("unique(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "c");
+        assert_eq!(arr[1].as_str().unwrap(), "a");
+        assert_eq!(arr[2].as_str().unwrap(), "b");
+    }
+
+    #[test]
+    fn test_unique_different_types() {
+        let runtime = setup_runtime();
+        let data = json!([1, "1", 1, "1"]);
+        let expr = runtime.compile("unique(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // 1 and "1" are different
+    }
+
+    #[test]
+    fn test_range_with_step() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("range(`1`, `10`, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5); // 1, 3, 5, 7, 9
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[4].as_f64().unwrap() as i64, 9);
+    }
+
+    #[test]
+    fn test_range_descending() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("range(`5`, `0`, `-1`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5); // 5, 4, 3, 2, 1
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 5);
+        assert_eq!(arr[4].as_f64().unwrap() as i64, 1);
+    }
+
+    // =========================================================================
+    // Pipeline patterns with arrays
+    // =========================================================================
+
+    #[test]
+    fn test_pipeline_unique_sort() {
+        let runtime = setup_runtime();
+        let data = json!(["redis", "database", "redis", "nosql", "database"]);
+        let expr = runtime.compile("unique(@) | sort(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "database");
+        assert_eq!(arr[1].as_str().unwrap(), "nosql");
+        assert_eq!(arr[2].as_str().unwrap(), "redis");
+    }
+
+    #[test]
+    fn test_pipeline_filter_take() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let expr = runtime.compile("[?@ > `3`] | take(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 4);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 5);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 6);
+    }
+
+    #[test]
+    fn test_pipeline_flatten_unique() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2], [2, 3], [3, 4]]);
+        let expr = runtime.compile("flatten_deep(@) | unique(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4); // 1, 2, 3, 4
+    }
+
+    #[test]
+    fn test_large_array_processing() {
+        let runtime = setup_runtime();
+        // Create array with 1000 elements
+        let items: Vec<i32> = (1..=1000).collect();
+        let json_str = serde_json::to_string(&items).unwrap();
+        let data: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        let expr = runtime.compile("length(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1000);
+    }
+
+    #[test]
+    fn test_transpose_basic() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2, 3], [4, 5, 6]]);
+        let expr = runtime.compile("transpose(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // First column: [1, 4]
+        let col0 = arr[0].as_array().unwrap();
+        assert_eq!(col0[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(col0[1].as_f64().unwrap() as i64, 4);
+        // Second column: [2, 5]
+        let col1 = arr[1].as_array().unwrap();
+        assert_eq!(col1[0].as_f64().unwrap() as i64, 2);
+        assert_eq!(col1[1].as_f64().unwrap() as i64, 5);
+    }
+
+    #[test]
+    fn test_transpose_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("transpose(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_transpose_unequal_rows() {
+        let runtime = setup_runtime();
+        let data = json!([[1, 2], [3, 4, 5], [6, 7]]);
+        let expr = runtime.compile("transpose(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should use minimum length (2)
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_pairwise_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4]);
+        let expr = runtime.compile("pairwise(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // First pair: [1, 2]
+        let pair0 = arr[0].as_array().unwrap();
+        assert_eq!(pair0[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(pair0[1].as_f64().unwrap() as i64, 2);
+        // Second pair: [2, 3]
+        let pair1 = arr[1].as_array().unwrap();
+        assert_eq!(pair1[0].as_f64().unwrap() as i64, 2);
+        assert_eq!(pair1[1].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_pairwise_short_array() {
+        let runtime = setup_runtime();
+        let data = json!([1]);
+        let expr = runtime.compile("pairwise(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_sliding_window_alias() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("sliding_window(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // First window: [1, 2, 3]
+        let win0 = arr[0].as_array().unwrap();
+        assert_eq!(win0.len(), 3);
+        assert_eq!(win0[0].as_f64().unwrap() as i64, 1);
+    }
+
+    // indices_array tests
+    #[test]
+    fn test_indices_array_found() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 2, 4, 2]);
+        let expr = runtime.compile("indices_array(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 3);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 5);
+    }
+
+    #[test]
+    fn test_indices_array_not_found() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("indices_array(@, `5`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_indices_array_strings() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "a", "c", "a"]);
+        let expr = runtime.compile(r#"indices_array(@, `"a"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 0);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 4);
+    }
+
+    // inside_array tests
+    #[test]
+    fn test_inside_array_true() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 2], "b": [1, 2, 3, 4]}"#).unwrap();
+        let expr = runtime.compile("inside_array(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_inside_array_false() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value =
+            serde_json::from_str(r#"{"a": [1, 5], "b": [1, 2, 3, 4]}"#).unwrap();
+        let expr = runtime.compile("inside_array(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_inside_array_empty() {
+        let runtime = setup_runtime();
+        let data: serde_json::Value = serde_json::from_str(r#"{"a": [], "b": [1, 2, 3]}"#).unwrap();
+        let expr = runtime.compile("inside_array(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    // bsearch tests
+    #[test]
+    fn test_bsearch_found() {
+        let runtime = setup_runtime();
+        let data = json!([1, 3, 5, 7, 9]);
+        let expr = runtime.compile("bsearch(@, `5`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_bsearch_not_found_middle() {
+        let runtime = setup_runtime();
+        let data = json!([1, 3, 5, 7, 9]);
+        let expr = runtime.compile("bsearch(@, `4`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, -3);
+    }
+
+    #[test]
+    fn test_bsearch_not_found_start() {
+        let runtime = setup_runtime();
+        let data = json!([1, 3, 5, 7, 9]);
+        let expr = runtime.compile("bsearch(@, `0`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, -1);
+    }
+
+    #[test]
+    fn test_bsearch_not_found_end() {
+        let runtime = setup_runtime();
+        let data = json!([1, 3, 5, 7, 9]);
+        let expr = runtime.compile("bsearch(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, -6);
+    }
+
+    #[test]
+    fn test_bsearch_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("bsearch(@, `5`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, -1);
+    }
+
+    // repeat_array tests
+    #[test]
+    fn test_repeat_array_basic() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("repeat_array(`1`, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_repeat_array_string() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile(r#"repeat_array(`"x"`, `4`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_str().unwrap(), "x");
+        assert_eq!(arr[3].as_str().unwrap(), "x");
+    }
+
+    #[test]
+    fn test_repeat_array_zero() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("repeat_array(`1`, `0`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_repeat_array_object() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile(r#"repeat_array(`{"a": 1}`, `2`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("a")
+                .unwrap()
+                .as_f64()
+                .unwrap() as i64,
+            1
+        );
+    }
+
+    // cycle tests
+    #[test]
+    fn test_cycle_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("cycle(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 6);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[2].as_f64().unwrap() as i64, 3);
+        assert_eq!(arr[3].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[4].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[5].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_cycle_strings() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b"]);
+        let expr = runtime.compile("cycle(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 6);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[1].as_str().unwrap(), "b");
+        assert_eq!(arr[2].as_str().unwrap(), "a");
+    }
+
+    #[test]
+    fn test_cycle_zero() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("cycle(@, `0`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_cycle_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("cycle(@, `5`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_cycle_once() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2]);
+        let expr = runtime.compile("cycle(@, `1`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 2);
+    }
+}

--- a/crates/jpx-core/src/extensions/color.rs
+++ b/crates/jpx-core/src/extensions/color.rs
@@ -359,3 +359,77 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(ColorComplementFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_parse_hex_color() {
+        assert_eq!(parse_hex_color("#ff5500"), Some((255, 85, 0)));
+        assert_eq!(parse_hex_color("ff5500"), Some((255, 85, 0)));
+        assert_eq!(parse_hex_color("#f50"), Some((255, 85, 0)));
+        assert_eq!(parse_hex_color("#000000"), Some((0, 0, 0)));
+        assert_eq!(parse_hex_color("#ffffff"), Some((255, 255, 255)));
+        assert_eq!(parse_hex_color("invalid"), None);
+    }
+
+    #[test]
+    fn test_rgb_to_hsl_roundtrip() {
+        let colors = [
+            (255, 0, 0),
+            (0, 255, 0),
+            (0, 0, 255),
+            (128, 128, 128),
+            (255, 128, 64),
+        ];
+        for (r, g, b) in colors {
+            let (h, s, l) = super::rgb_to_hsl(r, g, b);
+            let (r2, g2, b2) = super::hsl_to_rgb(h, s, l);
+            assert!(
+                (r as i16 - r2 as i16).abs() <= 1,
+                "Red mismatch: {} vs {}",
+                r,
+                r2
+            );
+            assert!(
+                (g as i16 - g2 as i16).abs() <= 1,
+                "Green mismatch: {} vs {}",
+                g,
+                g2
+            );
+            assert!(
+                (b as i16 - b2 as i16).abs() <= 1,
+                "Blue mismatch: {} vs {}",
+                b,
+                b2
+            );
+        }
+    }
+
+    #[test]
+    fn test_hex_to_rgb() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hex_to_rgb('#ff5500')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!({"r": 255, "g": 85, "b": 0}));
+    }
+
+    #[test]
+    fn test_rgb_to_hex() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("rgb_to_hex(`255`, `85`, `0`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "#ff5500");
+    }
+
+    use super::parse_hex_color;
+}

--- a/crates/jpx-core/src/extensions/computing.rs
+++ b/crates/jpx-core/src/extensions/computing.rs
@@ -299,3 +299,89 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(BitShiftRightFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_parse_bytes() {
+        use super::{BINARY_UNITS, DECIMAL_UNITS, format_bytes_with_units, parse_bytes_str};
+
+        assert_eq!(parse_bytes_str("100"), Some(100.0));
+        assert_eq!(parse_bytes_str("100 B"), Some(100.0));
+        assert_eq!(parse_bytes_str("1 KB"), Some(1000.0));
+        assert_eq!(parse_bytes_str("1.5 KB"), Some(1500.0));
+        assert_eq!(parse_bytes_str("1 MB"), Some(1_000_000.0));
+        assert_eq!(parse_bytes_str("1.5 GB"), Some(1_500_000_000.0));
+        assert_eq!(parse_bytes_str("1 TB"), Some(1_000_000_000_000.0));
+        assert_eq!(parse_bytes_str("1 KiB"), Some(1024.0));
+        assert_eq!(parse_bytes_str("1 MiB"), Some(1_048_576.0));
+        assert_eq!(parse_bytes_str("1 GiB"), Some(1_073_741_824.0));
+        assert_eq!(parse_bytes_str("1 gb"), Some(1_000_000_000.0));
+        assert_eq!(parse_bytes_str(""), None);
+        assert_eq!(parse_bytes_str("invalid"), None);
+
+        // Also verify format_bytes_with_units helper
+        assert_eq!(format_bytes_with_units(0.0, DECIMAL_UNITS), "0 B");
+        assert_eq!(format_bytes_with_units(500.0, DECIMAL_UNITS), "500 B");
+        assert_eq!(format_bytes_with_units(1000.0, DECIMAL_UNITS), "1 KB");
+        assert_eq!(format_bytes_with_units(1500.0, DECIMAL_UNITS), "1.5 KB");
+        assert_eq!(
+            format_bytes_with_units(1_500_000_000.0, DECIMAL_UNITS),
+            "1.5 GB"
+        );
+        assert_eq!(format_bytes_with_units(1024.0, BINARY_UNITS), "1 KiB");
+        assert_eq!(format_bytes_with_units(1536.0, BINARY_UNITS), "1.5 KiB");
+        assert_eq!(
+            format_bytes_with_units(1_073_741_824.0, BINARY_UNITS),
+            "1 GiB"
+        );
+    }
+
+    #[test]
+    fn test_format_bytes_via_runtime() {
+        let runtime = setup_runtime();
+
+        let expr = runtime.compile("format_bytes(`1500`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1.5 KB");
+
+        let expr = runtime.compile("format_bytes_binary(`1024`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1 KiB");
+    }
+
+    #[test]
+    fn test_bitwise_ops() {
+        let runtime = setup_runtime();
+
+        let expr = runtime.compile("bit_and(`12`, `10`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(8)); // 1100 & 1010 = 1000
+
+        let expr = runtime.compile("bit_or(`12`, `10`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(14)); // 1100 | 1010 = 1110
+
+        let expr = runtime.compile("bit_xor(`12`, `10`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(6)); // 1100 ^ 1010 = 0110
+
+        let expr = runtime.compile("bit_shift_left(`1`, `4`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(16)); // 1 << 4 = 16
+
+        let expr = runtime.compile("bit_shift_right(`16`, `2`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(4)); // 16 >> 2 = 4
+    }
+}

--- a/crates/jpx-core/src/extensions/datetime.rs
+++ b/crates/jpx-core/src/extensions/datetime.rs
@@ -958,3 +958,929 @@ impl Function for ParseNaturalDateFn {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_now() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("now()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let ts = result.as_f64().unwrap();
+        // Should be a reasonable timestamp (after 2020)
+        assert!(ts > 1577836800.0);
+    }
+
+    #[test]
+    fn test_now_millis() {
+        let runtime = setup_runtime();
+        // now_millis is registered as epoch_ms in jpx-core
+        let expr = runtime.compile("epoch_ms()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let ts = result.as_f64().unwrap();
+        // Should be a reasonable timestamp in millis (after 2020)
+        assert!(ts > 1577836800000.0);
+    }
+
+    #[test]
+    fn test_format_date() {
+        let runtime = setup_runtime();
+        // 1720000000 = 2024-07-03T10:26:40Z
+        let expr = runtime
+            .compile("format_date(`1720000000`, '%Y-%m-%d')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2024-07-03");
+    }
+
+    #[test]
+    fn test_format_date_with_time() {
+        let runtime = setup_runtime();
+        // Use a known timestamp and verify output format
+        let expr = runtime
+            .compile("format_date(`0`, '%Y-%m-%dT%H:%M:%S')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1970-01-01T00:00:00");
+    }
+
+    #[test]
+    fn test_parse_date_iso() {
+        let runtime = setup_runtime();
+        let data = json!("1970-01-01T00:00:00Z");
+        let expr = runtime.compile("parse_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_parse_date_date_only() {
+        let runtime = setup_runtime();
+        let data = json!("2024-07-03");
+        let expr = runtime.compile("parse_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Should parse as midnight UTC
+        assert_eq!(result.as_f64().unwrap(), 1719964800.0);
+    }
+
+    #[test]
+    fn test_parse_date_with_format() {
+        let runtime = setup_runtime();
+        // Use datetime format for custom parsing
+        let data = json!("03/07/2024 00:00:00");
+        let expr = runtime
+            .compile("parse_date(@, '%d/%m/%Y %H:%M:%S')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Should parse as 2024-07-03 midnight UTC
+        assert_eq!(result.as_f64().unwrap(), 1719964800.0);
+    }
+
+    #[test]
+    fn test_parse_date_invalid() {
+        let runtime = setup_runtime();
+        let data = json!("not a date");
+        let expr = runtime.compile("parse_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_date_add_days() {
+        let runtime = setup_runtime();
+        // Add 7 days to 1720000000
+        let expr = runtime
+            .compile("date_add(`1720000000`, `7`, 'days')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1720604800.0);
+    }
+
+    #[test]
+    fn test_date_add_hours() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("date_add(`1720000000`, `24`, 'hours')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1720086400.0);
+    }
+
+    #[test]
+    fn test_date_add_negative() {
+        let runtime = setup_runtime();
+        // Subtract 1 day
+        let expr = runtime
+            .compile("date_add(`1720000000`, `-1`, 'day')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1719913600.0);
+    }
+
+    #[test]
+    fn test_date_diff_days() {
+        let runtime = setup_runtime();
+        // 7 days apart
+        let expr = runtime
+            .compile("date_diff(`1720604800`, `1720000000`, 'days')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 7.0);
+    }
+
+    #[test]
+    fn test_date_diff_hours() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("date_diff(`1720086400`, `1720000000`, 'hours')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 24.0);
+    }
+
+    #[test]
+    fn test_date_diff_negative() {
+        let runtime = setup_runtime();
+        // Earlier timestamp first
+        let expr = runtime
+            .compile("date_diff(`1720000000`, `1720604800`, 'days')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), -7.0);
+    }
+
+    #[test]
+    fn test_date_add_invalid_unit() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("date_add(`1720000000`, `1`, 'invalid')")
+            .unwrap();
+        let result = expr.search(&json!(null));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_timezone_convert_ny_to_london() {
+        let runtime = setup_runtime();
+        let data = json!("2024-01-15T10:00:00");
+        let expr = runtime
+            .compile("timezone_convert(@, 'America/New_York', 'Europe/London')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // NY is UTC-5 in January, London is UTC+0, so 10:00 NY = 15:00 London
+        assert_eq!(result.as_str().unwrap(), "2024-01-15T15:00:00");
+    }
+
+    #[test]
+    fn test_timezone_convert_tokyo_to_la() {
+        let runtime = setup_runtime();
+        let data = json!("2024-07-15T09:00:00");
+        let expr = runtime
+            .compile("timezone_convert(@, 'Asia/Tokyo', 'America/Los_Angeles')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Tokyo is UTC+9, LA is UTC-7 in July (PDT), so 9:00 Tokyo = 17:00 previous day LA
+        assert_eq!(result.as_str().unwrap(), "2024-07-14T17:00:00");
+    }
+
+    #[test]
+    fn test_timezone_convert_invalid_tz() {
+        let runtime = setup_runtime();
+        let data = json!("2024-01-15T10:00:00");
+        let expr = runtime
+            .compile("timezone_convert(@, 'Invalid/Zone', 'Europe/London')")
+            .unwrap();
+        let result = expr.search(&data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_weekend_saturday() {
+        let runtime = setup_runtime();
+        // 2024-01-13 is a Saturday - timestamp: 1705104000
+        let expr = runtime.compile("is_weekend(`1705104000`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_weekend_sunday() {
+        let runtime = setup_runtime();
+        // 2024-01-14 is a Sunday - timestamp: 1705190400
+        let expr = runtime.compile("is_weekend(`1705190400`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_weekend_monday() {
+        let runtime = setup_runtime();
+        // 2024-01-15 is a Monday - timestamp: 1705276800
+        let expr = runtime.compile("is_weekend(`1705276800`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_weekday_monday() {
+        let runtime = setup_runtime();
+        // 2024-01-15 is a Monday - timestamp: 1705276800
+        let expr = runtime.compile("is_weekday(`1705276800`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_weekday_saturday() {
+        let runtime = setup_runtime();
+        // 2024-01-13 is a Saturday - timestamp: 1705104000
+        let expr = runtime.compile("is_weekday(`1705104000`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_business_days_between() {
+        let runtime = setup_runtime();
+        // 2024-01-01 (Mon) to 2024-01-15 (Mon) - 10 business days
+        // ts1: 1704067200 (2024-01-01)
+        // ts2: 1705276800 (2024-01-15)
+        let expr = runtime
+            .compile("business_days_between(`1704067200`, `1705276800`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_business_days_between_reversed() {
+        let runtime = setup_runtime();
+        // Same dates but reversed - should be negative
+        let expr = runtime
+            .compile("business_days_between(`1705276800`, `1704067200`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), -10.0);
+    }
+
+    #[test]
+    fn test_business_days_between_same_day() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("business_days_between(`1705276800`, `1705276800`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_quarter_q1() {
+        let runtime = setup_runtime();
+        // January 15, 2024 - timestamp: 1705276800
+        let expr = runtime.compile("quarter(`1705276800`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_quarter_q2() {
+        let runtime = setup_runtime();
+        // April 15, 2024 - timestamp: 1713139200
+        let expr = runtime.compile("quarter(`1713139200`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_quarter_q3() {
+        let runtime = setup_runtime();
+        // July 15, 2024 - timestamp: 1721001600
+        let expr = runtime.compile("quarter(`1721001600`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_quarter_q4() {
+        let runtime = setup_runtime();
+        // October 15, 2024 - timestamp: 1728950400
+        let expr = runtime.compile("quarter(`1728950400`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_relative_time_past() {
+        let runtime = setup_runtime();
+        // Use a timestamp far in the past (1 year ago)
+        let one_year_ago = Utc::now().timestamp() - 31536000;
+        let expr_str = format!("relative_time(`{}`)", one_year_ago);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_str().unwrap().contains("ago"));
+    }
+
+    #[test]
+    fn test_relative_time_future() {
+        let runtime = setup_runtime();
+        // Use a timestamp in the future (1 day from now)
+        let one_day_future = Utc::now().timestamp() + 86400;
+        let expr_str = format!("relative_time(`{}`)", one_day_future);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_str().unwrap().starts_with("in "));
+    }
+
+    // Tests for is_after
+
+    #[test]
+    fn test_is_after_with_timestamps() {
+        let runtime = setup_runtime();
+        // 1720000000 is after 1710000000
+        let expr = runtime
+            .compile("is_after(`1720000000`, `1710000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_with_timestamps_false() {
+        let runtime = setup_runtime();
+        // 1710000000 is not after 1720000000
+        let expr = runtime
+            .compile("is_after(`1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_with_date_strings() {
+        let runtime = setup_runtime();
+        let data = json!({"d1": "2024-07-15", "d2": "2024-01-01"});
+        let expr = runtime.compile("is_after(d1, d2)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_with_iso_strings() {
+        let runtime = setup_runtime();
+        let data = json!({"d1": "2024-07-15T10:30:00Z", "d2": "2024-07-15T08:00:00Z"});
+        let expr = runtime.compile("is_after(d1, d2)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_mixed_types() {
+        let runtime = setup_runtime();
+        // 1720000000 = 2024-07-03T10:26:40Z, which is after 2024-01-01
+        let data = json!({"d": "2024-01-01"});
+        let expr = runtime.compile("is_after(`1720000000`, d)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_equal_dates() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("is_after(`1720000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_after_invalid_date() {
+        let runtime = setup_runtime();
+        let data = json!({"d": "not-a-date"});
+        let expr = runtime.compile("is_after(d, `1720000000`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    // Tests for is_before
+
+    #[test]
+    fn test_is_before_with_timestamps() {
+        let runtime = setup_runtime();
+        // 1710000000 is before 1720000000
+        let expr = runtime
+            .compile("is_before(`1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_before_with_timestamps_false() {
+        let runtime = setup_runtime();
+        // 1720000000 is not before 1710000000
+        let expr = runtime
+            .compile("is_before(`1720000000`, `1710000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_before_with_date_strings() {
+        let runtime = setup_runtime();
+        let data = json!({"d1": "2024-01-01", "d2": "2024-07-15"});
+        let expr = runtime.compile("is_before(d1, d2)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_before_equal_dates() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("is_before(`1720000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // Tests for is_between
+
+    #[test]
+    fn test_is_between_with_timestamps_true() {
+        let runtime = setup_runtime();
+        // 1715000000 is between 1710000000 and 1720000000
+        let expr = runtime
+            .compile("is_between(`1715000000`, `1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_between_with_timestamps_false() {
+        let runtime = setup_runtime();
+        // 1700000000 is not between 1710000000 and 1720000000
+        let expr = runtime
+            .compile("is_between(`1700000000`, `1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_between_with_date_strings() {
+        let runtime = setup_runtime();
+        let data = json!({"d": "2024-06-15", "start": "2024-01-01", "end": "2024-12-31"});
+        let expr = runtime.compile("is_between(d, start, end)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_between_inclusive_start() {
+        let runtime = setup_runtime();
+        // Date equals start - should be true (inclusive)
+        let expr = runtime
+            .compile("is_between(`1710000000`, `1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_between_inclusive_end() {
+        let runtime = setup_runtime();
+        // Date equals end - should be true (inclusive)
+        let expr = runtime
+            .compile("is_between(`1720000000`, `1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_between_outside_range() {
+        let runtime = setup_runtime();
+        // Date is after end
+        let expr = runtime
+            .compile("is_between(`1730000000`, `1710000000`, `1720000000`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // Tests for time_ago
+
+    #[test]
+    fn test_time_ago_with_timestamp() {
+        let runtime = setup_runtime();
+        // Use a timestamp 1 hour ago
+        let one_hour_ago = Utc::now().timestamp() - 3600;
+        let expr_str = format!("time_ago(`{}`)", one_hour_ago);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1 hour ago");
+    }
+
+    #[test]
+    fn test_time_ago_with_date_string() {
+        let runtime = setup_runtime();
+        // Use a date far in the past (over 1 year)
+        let data = json!("2020-01-01");
+        let expr = runtime.compile("time_ago(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_str().unwrap().contains("years ago"));
+    }
+
+    #[test]
+    fn test_time_ago_plural() {
+        let runtime = setup_runtime();
+        // Use a timestamp 2 days ago
+        let two_days_ago = Utc::now().timestamp() - 172800;
+        let expr_str = format!("time_ago(`{}`)", two_days_ago);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2 days ago");
+    }
+
+    #[test]
+    fn test_time_ago_singular() {
+        let runtime = setup_runtime();
+        // Use a timestamp 1 day ago
+        let one_day_ago = Utc::now().timestamp() - 86400;
+        let expr_str = format!("time_ago(`{}`)", one_day_ago);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1 day ago");
+    }
+
+    #[test]
+    fn test_time_ago_future() {
+        let runtime = setup_runtime();
+        // Future dates show "in X"
+        let one_day_future = Utc::now().timestamp() + 86400;
+        let expr_str = format!("time_ago(`{}`)", one_day_future);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_str().unwrap().starts_with("in "));
+    }
+
+    #[test]
+    fn test_time_ago_invalid_date() {
+        let runtime = setup_runtime();
+        let data = json!("not-a-date");
+        let expr = runtime.compile("time_ago(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_from_epoch() {
+        let runtime = setup_runtime();
+        // 2023-12-13T00:00:00Z
+        let expr = runtime.compile("from_epoch(`1702425600`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-12-13T00:00:00Z");
+    }
+
+    #[test]
+    fn test_from_epoch_ms() {
+        let runtime = setup_runtime();
+        // 2023-12-13T00:00:00.500Z
+        let expr = runtime.compile("from_epoch_ms(`1702425600500`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-12-13T00:00:00.500Z");
+    }
+
+    #[test]
+    fn test_to_epoch() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T00:00:00Z");
+        let expr = runtime.compile("to_epoch(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1702425600);
+    }
+
+    #[test]
+    fn test_to_epoch_ms() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T00:00:00Z");
+        let expr = runtime.compile("to_epoch_ms(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1702425600000);
+    }
+
+    #[test]
+    fn test_to_epoch_from_number() {
+        let runtime = setup_runtime();
+        // Pass through if already a number
+        let expr = runtime.compile("to_epoch(`1702425600`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 1702425600);
+    }
+
+    #[test]
+    fn test_duration_since() {
+        let runtime = setup_runtime();
+        // Use a timestamp 2 days ago
+        let two_days_ago = Utc::now().timestamp() - 172800;
+        let expr_str = format!("duration_since(`{}`)", two_days_ago);
+        let expr = runtime.compile(&expr_str).unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("days").unwrap().as_i64().unwrap(), 2);
+        assert!(!obj.get("is_future").unwrap().as_bool().unwrap());
+        assert!(
+            obj.get("human")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .contains("2 days ago")
+        );
+    }
+
+    #[test]
+    fn test_start_of_day() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T15:30:45Z");
+        let expr = runtime.compile("start_of_day(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-12-13T00:00:00Z");
+    }
+
+    #[test]
+    fn test_end_of_day() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T15:30:45Z");
+        let expr = runtime.compile("end_of_day(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-12-13T23:59:59Z");
+    }
+
+    #[test]
+    fn test_start_of_week() {
+        let runtime = setup_runtime();
+        // 2023-12-13 is a Wednesday
+        let data = json!("2023-12-13T15:30:45Z");
+        let expr = runtime.compile("start_of_week(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Monday is 2023-12-11
+        assert_eq!(result.as_str().unwrap(), "2023-12-11T00:00:00Z");
+    }
+
+    #[test]
+    fn test_start_of_month() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T15:30:45Z");
+        let expr = runtime.compile("start_of_month(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-12-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_start_of_year() {
+        let runtime = setup_runtime();
+        let data = json!("2023-12-13T15:30:45Z");
+        let expr = runtime.compile("start_of_year(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "2023-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_is_same_day_true() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile(r#"is_same_day(`"2023-12-13T10:00:00Z"`, `"2023-12-13T23:00:00Z"`)"#)
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_same_day_false() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile(r#"is_same_day(`"2023-12-13T10:00:00Z"`, `"2023-12-14T10:00:00Z"`)"#)
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_epoch_ms_alias() {
+        let runtime = setup_runtime();
+        // epoch_ms should work like now_millis
+        let expr = runtime.compile("epoch_ms()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let ts = result.as_f64().unwrap() as i64;
+        // Should be a reasonable current timestamp in milliseconds
+        assert!(ts > 1700000000000);
+    }
+
+    // =========================================================================
+    // parse_datetime tests (structured formats)
+    // =========================================================================
+
+    #[test]
+    fn test_parse_datetime_iso_date() {
+        let runtime = setup_runtime();
+        let data = json!("2024-01-15");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024-01-15"), "Expected 2024-01-15 in {}", s);
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_iso_datetime() {
+        let runtime = setup_runtime();
+        let data = json!("2024-01-15T10:30:00Z");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert_eq!(s, "2024-01-15T10:30:00Z");
+    }
+
+    #[test]
+    fn test_parse_datetime_iso_with_offset() {
+        let runtime = setup_runtime();
+        let data = json!("2024-01-15T10:30:00+05:00");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        // Should convert to UTC (10:30 +05:00 = 05:30 UTC)
+        assert!(s.contains("2024-01-15"), "Expected 2024-01-15 in {}", s);
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_human_month_day_year() {
+        let runtime = setup_runtime();
+        let data = json!("Jan 15, 2024");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024-01-15"), "Expected 2024-01-15 in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_human_full_month() {
+        let runtime = setup_runtime();
+        let data = json!("January 15, 2024");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024-01-15"), "Expected 2024-01-15 in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_us_format() {
+        let runtime = setup_runtime();
+        let data = json!("01/15/2024");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024"), "Expected year 2024 in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_rfc2822() {
+        let runtime = setup_runtime();
+        let data = json!("Mon, 15 Jan 2024 10:30:00 +0000");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024-01-15"), "Expected 2024-01-15 in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_unix_timestamp() {
+        let runtime = setup_runtime();
+        // 1705363200 = 2024-01-16T00:00:00Z
+        let data = json!("1705363200");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("2024-01-16"), "Expected 2024-01-16 in {}", s);
+    }
+
+    #[test]
+    fn test_parse_datetime_invalid() {
+        let runtime = setup_runtime();
+        let data = json!("not a date at all xyz123");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null(), "Invalid date should return null");
+    }
+
+    #[test]
+    fn test_parse_datetime_empty() {
+        let runtime = setup_runtime();
+        let data = json!("");
+        let expr = runtime.compile("parse_datetime(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null(), "Empty string should return null");
+    }
+
+    // =========================================================================
+    // parse_natural_date tests (natural language, relative to now)
+    // =========================================================================
+
+    #[test]
+    fn test_parse_natural_date_yesterday() {
+        let runtime = setup_runtime();
+        let data = json!("yesterday");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+        assert!(
+            s.contains('T'),
+            "Expected ISO format with T separator in {}",
+            s
+        );
+    }
+
+    #[test]
+    fn test_parse_natural_date_tomorrow() {
+        let runtime = setup_runtime();
+        let data = json!("tomorrow");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_days_ago() {
+        let runtime = setup_runtime();
+        let data = json!("3 days ago");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_weeks_ago() {
+        let runtime = setup_runtime();
+        let data = json!("2 weeks ago");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_next_weekday() {
+        let runtime = setup_runtime();
+        let data = json!("next friday");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_last_weekday() {
+        let runtime = setup_runtime();
+        let data = json!("last monday");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_hours() {
+        let runtime = setup_runtime();
+        let data = json!("5 hours ago");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.ends_with('Z'), "Expected UTC timezone marker in {}", s);
+    }
+
+    #[test]
+    fn test_parse_natural_date_invalid() {
+        let runtime = setup_runtime();
+        let data = json!("not a natural date expression");
+        let expr = runtime.compile("parse_natural_date(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null(), "Invalid expression should return null");
+    }
+}

--- a/crates/jpx-core/src/extensions/discovery.rs
+++ b/crates/jpx-core/src/extensions/discovery.rs
@@ -243,3 +243,235 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(FuzzyScoreFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_fuzzy_search_exact_match() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "get_user", "description": "Get a user by ID"},
+            {"name": "create_user", "description": "Create a new user"},
+            {"name": "delete_user", "description": "Delete a user"}
+        ]);
+
+        let expr = runtime
+            .compile("fuzzy_search(@, 'name,description', 'get_user')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 1);
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(first.get("match_type").unwrap().as_str().unwrap(), "exact");
+    }
+
+    #[test]
+    fn test_fuzzy_search_prefix_match() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "get_user", "description": "Get a user"},
+            {"name": "get_cluster", "description": "Get cluster info"},
+            {"name": "create_user", "description": "Create user"}
+        ]);
+
+        let expr = runtime.compile("fuzzy_search(@, 'name', 'get')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 2);
+        for item in arr {
+            let obj = item.as_object().unwrap();
+            assert_eq!(obj.get("match_type").unwrap().as_str().unwrap(), "prefix");
+        }
+    }
+
+    #[test]
+    fn test_fuzzy_search_contains_match() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "get_user_info", "description": "Get user information"},
+            {"name": "create_user", "description": "Create a user"},
+            {"name": "list_items", "description": "List all items"}
+        ]);
+
+        let expr = runtime.compile("fuzzy_search(@, 'name', 'user')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_fuzzy_search_description_match() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "foo", "description": "Manage database connections"},
+            {"name": "bar", "description": "Handle user requests"},
+            {"name": "baz", "description": "Process data"}
+        ]);
+
+        let expr = runtime
+            .compile("fuzzy_search(@, 'name,description', 'database')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 1);
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(
+            first.get("matched_field").unwrap().as_str().unwrap(),
+            "description"
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_search_with_weights() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "user_search", "description": "Search for items"},
+            {"name": "item_list", "description": "List all users"}
+        ]);
+
+        // With higher weight on name, "user_search" should rank higher
+        let expr = runtime
+            .compile("fuzzy_search(@, `{\"name\": 10, \"description\": 5}`, 'user')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 2);
+        let first = arr[0].as_object().unwrap();
+        let first_item = first.get("item").unwrap().as_object().unwrap();
+        assert_eq!(
+            first_item.get("name").unwrap().as_str().unwrap(),
+            "user_search"
+        );
+    }
+
+    #[test]
+    fn test_fuzzy_search_no_results() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "foo", "description": "bar"},
+            {"name": "baz", "description": "qux"}
+        ]);
+
+        let expr = runtime
+            .compile("fuzzy_search(@, 'name,description', 'nonexistent')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn test_fuzzy_search_with_tags_array() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "tool1", "tags": ["database", "sql"]},
+            {"name": "tool2", "tags": ["cache", "redis"]},
+            {"name": "tool3", "tags": ["api", "rest"]}
+        ]);
+
+        let expr = runtime
+            .compile("fuzzy_search(@, 'name,tags', 'redis')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        assert_eq!(arr.len(), 1);
+        let first = arr[0].as_object().unwrap();
+        let first_item = first.get("item").unwrap().as_object().unwrap();
+        assert_eq!(first_item.get("name").unwrap().as_str().unwrap(), "tool2");
+    }
+
+    #[test]
+    fn test_fuzzy_match_exact() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("fuzzy_match('hello', 'hello')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let obj = result.as_object().unwrap();
+
+        assert!(obj.get("matches").unwrap().as_bool().unwrap());
+        assert_eq!(obj.get("match_type").unwrap().as_str().unwrap(), "exact");
+        assert_eq!(obj.get("score").unwrap().as_f64().unwrap() as i32, 1000);
+    }
+
+    #[test]
+    fn test_fuzzy_match_prefix() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("fuzzy_match('hello_world', 'hello')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let obj = result.as_object().unwrap();
+
+        assert!(obj.get("matches").unwrap().as_bool().unwrap());
+        assert_eq!(obj.get("match_type").unwrap().as_str().unwrap(), "prefix");
+    }
+
+    #[test]
+    fn test_fuzzy_match_no_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("fuzzy_match('hello', 'xyz')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let obj = result.as_object().unwrap();
+
+        assert!(!obj.get("matches").unwrap().as_bool().unwrap());
+        assert_eq!(obj.get("match_type").unwrap().as_str().unwrap(), "none");
+    }
+
+    #[test]
+    fn test_fuzzy_score() {
+        let runtime = setup_runtime();
+
+        // Exact match should score highest
+        let expr = runtime.compile("fuzzy_score('hello', 'hello')").unwrap();
+        let exact = expr.search(&json!(null)).unwrap();
+
+        // Prefix should score lower
+        let expr = runtime
+            .compile("fuzzy_score('hello_world', 'hello')")
+            .unwrap();
+        let prefix = expr.search(&json!(null)).unwrap();
+
+        // Contains should score even lower
+        let expr = runtime
+            .compile("fuzzy_score('say_hello_world', 'hello')")
+            .unwrap();
+        let contains = expr.search(&json!(null)).unwrap();
+
+        assert!(exact.as_f64().unwrap() > prefix.as_f64().unwrap());
+        assert!(prefix.as_f64().unwrap() > contains.as_f64().unwrap());
+    }
+
+    #[test]
+    fn test_fuzzy_search_case_insensitive() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "GetUser", "description": "GET user data"},
+            {"name": "createuser", "description": "create USER"}
+        ]);
+
+        let expr = runtime
+            .compile("fuzzy_search(@, 'name,description', 'USER')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+
+        // Should find both (case-insensitive)
+        assert_eq!(arr.len(), 2);
+    }
+}

--- a/crates/jpx-core/src/extensions/duration.rs
+++ b/crates/jpx-core/src/extensions/duration.rs
@@ -218,3 +218,103 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(DurationSecondsFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    use super::{format_duration_secs, parse_duration_str};
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_parse_duration() {
+        assert_eq!(parse_duration_str("1h"), Some(3600));
+        assert_eq!(parse_duration_str("30m"), Some(1800));
+        assert_eq!(parse_duration_str("45s"), Some(45));
+        assert_eq!(parse_duration_str("1h30m"), Some(5400));
+        assert_eq!(parse_duration_str("2h30m45s"), Some(9045));
+        assert_eq!(parse_duration_str("1d"), Some(86400));
+        assert_eq!(parse_duration_str("1w"), Some(604800));
+        assert_eq!(parse_duration_str("1w2d3h4m5s"), Some(788645));
+        assert_eq!(parse_duration_str("1 hour 30 minutes"), Some(5400));
+        assert_eq!(parse_duration_str(""), None);
+        assert_eq!(parse_duration_str("invalid"), None);
+    }
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration_secs(0), "0s");
+        assert_eq!(format_duration_secs(45), "45s");
+        assert_eq!(format_duration_secs(60), "1m");
+        assert_eq!(format_duration_secs(3600), "1h");
+        assert_eq!(format_duration_secs(5400), "1h30m");
+        assert_eq!(format_duration_secs(86400), "1d");
+        assert_eq!(format_duration_secs(90061), "1d1h1m1s");
+        assert_eq!(format_duration_secs(788645), "1w2d3h4m5s");
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let values = [0, 45, 60, 3600, 5400, 86400, 90061, 788645];
+        for &v in &values {
+            let formatted = format_duration_secs(v);
+            let parsed = parse_duration_str(&formatted).unwrap_or(0);
+            assert_eq!(
+                parsed, v,
+                "Roundtrip failed for {}: {} -> {}",
+                v, formatted, parsed
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_duration_via_runtime() {
+        let runtime = setup_runtime();
+        let data = json!("1h30m");
+        let expr = runtime.compile("parse_duration(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 5400.0);
+    }
+
+    #[test]
+    fn test_format_duration_via_runtime() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("format_duration(`5400`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1h30m");
+    }
+
+    #[test]
+    fn test_duration_hours_via_runtime() {
+        let runtime = setup_runtime();
+        // 90061 seconds = 1d 1h 1m 1s -> hours component is 1
+        let expr = runtime.compile("duration_hours(`90061`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_duration_minutes_via_runtime() {
+        let runtime = setup_runtime();
+        // 90061 seconds = 1d 1h 1m 1s -> minutes component is 1
+        let expr = runtime.compile("duration_minutes(`90061`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_duration_seconds_via_runtime() {
+        let runtime = setup_runtime();
+        // 90061 seconds = 1d 1h 1m 1s -> seconds component is 1
+        let expr = runtime.compile("duration_seconds(`90061`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+    }
+}

--- a/crates/jpx-core/src/extensions/encoding.rs
+++ b/crates/jpx-core/src/extensions/encoding.rs
@@ -319,3 +319,264 @@ impl Function for ShellEscapeFn {
         Ok(Value::String(escaped))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_base64_encode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64_encode(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("aGVsbG8="));
+    }
+
+    #[test]
+    fn test_base64_decode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64_decode(@)").unwrap();
+        let data = json!("aGVsbG8=");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hex_encode(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("68656c6c6f"));
+    }
+
+    #[test]
+    fn test_hex_decode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hex_decode(@)").unwrap();
+        let data = json!("68656c6c6f");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn test_hex_decode_invalid_returns_null() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hex_decode(@)").unwrap();
+        let data = json!("invalid");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn test_hex_decode_odd_length_returns_null() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hex_decode(@)").unwrap();
+        let data = json!("123");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+    }
+
+    // =========================================================================
+    // JWT function tests
+    // =========================================================================
+
+    // Test JWT from jwt.io: {"sub": "1234567890", "name": "John Doe", "iat": 1516239022}
+    const TEST_JWT: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    #[test]
+    fn test_jwt_decode_payload() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_decode(@)").unwrap();
+        let data = json!(TEST_JWT);
+        let result = expr.search(&data).unwrap();
+
+        // Check it's an object with expected claims
+        assert_eq!(result["sub"], json!("1234567890"));
+        assert_eq!(result["name"], json!("John Doe"));
+        assert_eq!(result["iat"], json!(1516239022));
+    }
+
+    #[test]
+    fn test_jwt_decode_extract_claim() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_decode(@).sub").unwrap();
+        let data = json!(TEST_JWT);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("1234567890"));
+    }
+
+    #[test]
+    fn test_jwt_header() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_header(@)").unwrap();
+        let data = json!(TEST_JWT);
+        let result = expr.search(&data).unwrap();
+
+        // Check header fields
+        assert_eq!(result["alg"], json!("HS256"));
+        assert_eq!(result["typ"], json!("JWT"));
+    }
+
+    #[test]
+    fn test_jwt_header_extract_alg() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_header(@).alg").unwrap();
+        let data = json!(TEST_JWT);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("HS256"));
+    }
+
+    #[test]
+    fn test_jwt_decode_invalid_format() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_decode(@)").unwrap();
+
+        // Not a valid JWT (no dots)
+        let data = json!("not-a-jwt");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+
+        // Only two parts
+        let data = json!("part1.part2");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn test_jwt_decode_invalid_base64() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_decode(@)").unwrap();
+
+        // Three parts but invalid base64
+        let data = json!("!!!.@@@.###");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn test_jwt_decode_invalid_json() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jwt_decode(@)").unwrap();
+
+        // Valid base64 but not valid JSON - "not json" encoded
+        let data = json!("eyJhbGciOiJIUzI1NiJ9.bm90IGpzb24.sig");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn test_html_escape_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("html_escape(@)").unwrap();
+        let data = json!("<div class=\"test\">Hello & goodbye</div>");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!("&lt;div class=&quot;test&quot;&gt;Hello &amp; goodbye&lt;/div&gt;")
+        );
+    }
+
+    #[test]
+    fn test_html_escape_quotes() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("html_escape(@)").unwrap();
+        let data = json!("It's a \"test\"");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("It&#x27;s a &quot;test&quot;"));
+    }
+
+    #[test]
+    fn test_html_escape_no_change() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("html_escape(@)").unwrap();
+        let data = json!("Hello World");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("Hello World"));
+    }
+
+    #[test]
+    fn test_html_unescape_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("html_unescape(@)").unwrap();
+        let data = json!("&lt;div class=&quot;test&quot;&gt;Hello &amp; goodbye&lt;/div&gt;");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("<div class=\"test\">Hello & goodbye</div>"));
+    }
+
+    #[test]
+    fn test_html_unescape_quotes() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("html_unescape(@)").unwrap();
+        let data = json!("It&#x27;s a &quot;test&quot;");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("It's a \"test\""));
+    }
+
+    #[test]
+    fn test_html_roundtrip() {
+        let runtime = setup_runtime();
+        let escape = runtime.compile("html_escape(@)").unwrap();
+        let unescape = runtime.compile("html_unescape(@)").unwrap();
+        let original = "<script>alert('xss')</script>";
+        let data = json!(original);
+        let escaped = escape.search(&data).unwrap();
+        let roundtrip = unescape.search(&escaped).unwrap();
+        assert_eq!(roundtrip, json!(original));
+    }
+
+    #[test]
+    fn test_shell_escape_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let data = json!("hello world");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("'hello world'"));
+    }
+
+    #[test]
+    fn test_shell_escape_with_single_quote() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let data = json!("it's here");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("'it'\\''s here'"));
+    }
+
+    #[test]
+    fn test_shell_escape_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let data = json!("$HOME; rm -rf /");
+        let result = expr.search(&data).unwrap();
+        // Should be safely quoted
+        assert_eq!(result, json!("'$HOME; rm -rf /'"));
+    }
+
+    #[test]
+    fn test_shell_escape_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("''"));
+    }
+
+    #[test]
+    fn test_shell_escape_multiple_quotes() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let data = json!("don't say 'hello'");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("'don'\\''t say '\\''hello'\\'''"));
+    }
+}

--- a/crates/jpx-core/src/extensions/expression.rs
+++ b/crates/jpx-core/src/extensions/expression.rs
@@ -1329,3 +1329,1677 @@ impl Function for UntilExprFn {
         Ok(current)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_map_expr_field() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "Alice"}, {"name": "Bob"}]);
+        let expr = runtime.compile("map_expr(&name, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "Alice");
+        assert_eq!(arr[1].as_str().unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_map_expr_transform() {
+        let runtime = setup_runtime();
+        let data = json!(["hello", "world"]);
+        let expr = runtime.compile("map_expr(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_f64().unwrap(), 5.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 5.0);
+    }
+
+    #[test]
+    fn test_filter_expr() {
+        let runtime = setup_runtime();
+        let data = json!([{"age": 25}, {"age": 17}, {"age": 30}]);
+        let expr = runtime.compile("filter_expr(&(age >= `18`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("filter_expr(&(@ > `10`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_any_expr_true() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": false}, {"active": true}]);
+        let expr = runtime.compile("any_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_any_expr_false() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": false}, {"active": false}]);
+        let expr = runtime.compile("any_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_all_expr_true() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": true}, {"active": true}]);
+        let expr = runtime.compile("all_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_all_expr_false() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": true}, {"active": false}]);
+        let expr = runtime.compile("all_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_all_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("all_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap()); // vacuous truth
+    }
+
+    #[test]
+    fn test_find_expr_found() {
+        let runtime = setup_runtime();
+        let data = json!([{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]);
+        let expr = runtime.compile("find_expr(&(id == `2`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_find_expr_not_found() {
+        let runtime = setup_runtime();
+        let data = json!([{"id": 1}, {"id": 2}]);
+        let expr = runtime.compile("find_expr(&(id == `99`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_sort_by_expr_numbers() {
+        let runtime = setup_runtime();
+        let data = json!([{"val": 3}, {"val": 1}, {"val": 2}]);
+        let expr = runtime.compile("sort_by_expr(&val, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("val")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            1.0
+        );
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("val")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            2.0
+        );
+        assert_eq!(
+            arr[2]
+                .as_object()
+                .unwrap()
+                .get("val")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            3.0
+        );
+    }
+
+    #[test]
+    fn test_sort_by_expr_strings() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "Charlie"}, {"name": "Alice"}, {"name": "Bob"}]);
+        let expr = runtime.compile("sort_by_expr(&name, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Alice"
+        );
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Bob"
+        );
+        assert_eq!(
+            arr[2]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Charlie"
+        );
+    }
+
+    #[test]
+    fn test_find_index_expr_found() {
+        let runtime = setup_runtime();
+        let data = json!([{"id": 1}, {"id": 2}, {"id": 3}]);
+        let expr = runtime.compile("find_index_expr(&(id == `2`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_find_index_expr_not_found() {
+        let runtime = setup_runtime();
+        let data = json!([{"id": 1}, {"id": 2}]);
+        let expr = runtime
+            .compile("find_index_expr(&(id == `99`), @)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), -1.0);
+    }
+
+    #[test]
+    fn test_count_expr() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": true}, {"active": false}, {"active": true}]);
+        let expr = runtime.compile("count_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_count_expr_none() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("count_expr(&(@ > `10`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_group_by_expr() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"type": "a", "val": 1},
+            {"type": "b", "val": 2},
+            {"type": "a", "val": 3}
+        ]);
+        let expr = runtime.compile("group_by_expr(&type, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("b").unwrap().as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_partition_expr() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("partition_expr(&(@ > `3`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let matches = arr[0].as_array().unwrap();
+        let non_matches = arr[1].as_array().unwrap();
+        assert_eq!(matches.len(), 2); // 4, 5
+        assert_eq!(non_matches.len(), 3); // 1, 2, 3
+    }
+
+    #[test]
+    fn test_min_by_expr() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]);
+        let expr = runtime.compile("min_by_expr(&age, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_min_by_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("min_by_expr(&age, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_max_by_expr() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]);
+        let expr = runtime.compile("max_by_expr(&age, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "Alice");
+    }
+
+    #[test]
+    fn test_unique_by_expr() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"type": "a", "val": 1},
+            {"type": "b", "val": 2},
+            {"type": "a", "val": 3}
+        ]);
+        let expr = runtime.compile("unique_by_expr(&type, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // First "a" and first "b"
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("val")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            1.0
+        );
+    }
+
+    #[test]
+    fn test_flat_map_expr() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"tags": ["a", "b"]},
+            {"tags": ["c"]},
+            {"tags": ["d", "e"]}
+        ]);
+        let expr = runtime.compile("flat_map_expr(&tags, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[4].as_str().unwrap(), "e");
+    }
+
+    #[test]
+    fn test_flat_map_expr_non_array() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "Alice"}, {"name": "Bob"}]);
+        let expr = runtime.compile("flat_map_expr(&name, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "Alice");
+    }
+
+    #[test]
+    fn test_some_alias() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("some(&(@ > `3`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_every_alias() {
+        let runtime = setup_runtime();
+        let data = json!([2, 4, 6]);
+        let expr = runtime.compile("every(&(@ > `0`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_none_true() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("none(&(@ > `5`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap()); // No element > 5
+    }
+
+    #[test]
+    fn test_none_false() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 10]);
+        let expr = runtime.compile("none(&(@ > `5`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap()); // 10 > 5
+    }
+
+    #[test]
+    fn test_none_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("none(&(@ > `0`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap()); // Vacuously true
+    }
+
+    #[test]
+    fn test_none_objects() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": false}, {"active": false}]);
+        let expr = runtime.compile("none(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap()); // No active elements
+    }
+
+    #[test]
+    fn test_mapcat_alias() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"tags": ["a", "b"]},
+            {"tags": ["c"]},
+            {"tags": ["d", "e"]}
+        ]);
+        let expr = runtime.compile("mapcat(&tags, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[4].as_str().unwrap(), "e");
+    }
+
+    #[test]
+    fn test_reductions_alias() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4]);
+        let expr = runtime
+            .compile("reductions(&sum([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Running sum: [1, 3, 6, 10]
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 3.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 6.0);
+        assert_eq!(arr[3].as_f64().unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_reject() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("reject(&(@ > `2`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // 1, 2
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_reject_objects() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": true}, {"active": false}, {"active": true}]);
+        let expr = runtime.compile("reject(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1); // Only the inactive one
+    }
+
+    #[test]
+    fn test_map_keys() {
+        let runtime = setup_runtime();
+        // Use length to transform key to its length (as string)
+        let data = json!({"abc": 1, "de": 2});
+        let expr = runtime.compile("map_keys(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        // "abc" -> 3, "de" -> 2 (converted to string keys)
+        assert!(obj.contains_key("3") || obj.contains_key("2"));
+    }
+
+    #[test]
+    fn test_map_values_add() {
+        let runtime = setup_runtime();
+        // Use sum to get sum of a literal array
+        let data = json!({"a": 1, "b": 2, "c": 3});
+        let expr = runtime.compile("map_values(&sum(`[1]`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        // Each value becomes 1 (sum of [1])
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_map_values_length() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "city": "boston"});
+        let expr = runtime.compile("map_values(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_f64().unwrap(), 5.0); // "alice" = 5 chars
+        assert_eq!(obj.get("city").unwrap().as_f64().unwrap(), 6.0); // "boston" = 6 chars
+    }
+
+    #[test]
+    fn test_map_values_with_string_fns() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "city": "boston"});
+        let expr = runtime.compile("map_values(&upper(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "ALICE");
+        assert_eq!(obj.get("city").unwrap().as_str().unwrap(), "BOSTON");
+    }
+
+    #[test]
+    fn test_map_keys_with_string_fns() {
+        let runtime = setup_runtime();
+        let data = json!({"hello": 1, "world": 2});
+        let expr = runtime.compile("map_keys(&upper(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("HELLO"));
+        assert!(obj.contains_key("WORLD"));
+    }
+
+    #[test]
+    fn test_order_by_single_field_asc() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "Charlie", "age": 30},
+            {"name": "Alice", "age": 25},
+            {"name": "Bob", "age": 35}
+        ]);
+        let expr = runtime
+            .compile(r#"order_by(@, `[["name", "asc"]]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Alice"
+        );
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Bob"
+        );
+        assert_eq!(
+            arr[2]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Charlie"
+        );
+    }
+
+    #[test]
+    fn test_order_by_single_field_desc() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "Alice", "age": 25},
+            {"name": "Bob", "age": 35},
+            {"name": "Charlie", "age": 30}
+        ]);
+        let expr = runtime
+            .compile(r#"order_by(@, `[["age", "desc"]]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("age")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            35.0
+        );
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("age")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            30.0
+        );
+        assert_eq!(
+            arr[2]
+                .as_object()
+                .unwrap()
+                .get("age")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            25.0
+        );
+    }
+
+    #[test]
+    fn test_order_by_multiple_fields() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"dept": "sales", "name": "Bob"},
+            {"dept": "eng", "name": "Alice"},
+            {"dept": "sales", "name": "Alice"}
+        ]);
+        let expr = runtime
+            .compile(r#"order_by(@, `[["dept", "asc"], ["name", "asc"]]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // eng comes first, then sales (sorted by dept)
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("dept")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "eng"
+        );
+        // Within sales, Alice comes before Bob
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Alice"
+        );
+        assert_eq!(
+            arr[2]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Bob"
+        );
+    }
+
+    #[test]
+    fn test_reduce_expr_sum() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime
+            .compile("reduce_expr(&sum([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 15.0);
+    }
+
+    #[test]
+    fn test_reduce_expr_max() {
+        let runtime = setup_runtime();
+        let data = json!([3, 1, 4, 1, 5, 9, 2, 6]);
+        let expr = runtime
+            .compile("reduce_expr(&max([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 9.0);
+    }
+
+    #[test]
+    fn test_reduce_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime
+            .compile("reduce_expr(&sum([accumulator, current]), @, `42`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 42.0); // Returns initial value
+    }
+
+    #[test]
+    #[ignore] // fold alias not registered: missing standalone entry in functions.toml
+    fn test_fold_alias() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime
+            .compile("fold(&sum([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 6.0);
+    }
+
+    #[test]
+    fn test_scan_expr_running_sum() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4]);
+        let expr = runtime
+            .compile("scan_expr(&sum([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Running sum: [1, 3, 6, 10]
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 3.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 6.0);
+        assert_eq!(arr[3].as_f64().unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_scan_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime
+            .compile("scan_expr(&sum([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_reduce_expr_with_index() {
+        let runtime = setup_runtime();
+        // Access the index in the reduce expression
+        let data = json!([10, 20, 30]);
+        let expr = runtime
+            .compile("reduce_expr(&sum([accumulator, index]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // 0 + 1 + 2 = 3
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_count_by_objects() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"type": "a"},
+            {"type": "b"},
+            {"type": "a"},
+            {"type": "a"}
+        ]);
+        let expr = runtime.compile("count_by(&type, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 3.0);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_count_by_strings() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "a", "c", "a"]);
+        let expr = runtime.compile("count_by(&@, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 3.0);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(obj.get("c").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_count_by_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("count_by(&type, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.is_empty());
+    }
+
+    #[test]
+    fn test_count_by_numbers() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 1, 3, 1, 2]);
+        let expr = runtime.compile("count_by(&@, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("1").unwrap().as_f64().unwrap(), 3.0);
+        assert_eq!(obj.get("2").unwrap().as_f64().unwrap(), 2.0);
+        assert_eq!(obj.get("3").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    // =============================================================================
+    // Partial application tests
+    // =============================================================================
+
+    #[test]
+    fn test_partial_creates_object() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("partial('length')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.get("__partial__").unwrap().as_bool().unwrap());
+        assert_eq!(obj.get("fn").unwrap().as_str().unwrap(), "length");
+        assert!(obj.get("args").unwrap().as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_partial_with_args() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("partial('contains', `\"hello world\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.get("__partial__").unwrap().as_bool().unwrap());
+        assert_eq!(obj.get("fn").unwrap().as_str().unwrap(), "contains");
+        let args = obj.get("args").unwrap().as_array().unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_apply_with_fn_name() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("apply('length', `\"hello\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 5.0);
+    }
+
+    #[test]
+    fn test_apply_with_partial() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        // Create partial with first arg, then apply with second arg
+        let expr = runtime
+            .compile("apply(partial('contains', `\"hello world\"`), `\"world\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_apply_partial_not_found() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("apply(partial('contains', `\"hello world\"`), `\"xyz\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_partial_with_multiple_prefilled_args() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        // partial with 2 args pre-filled
+        let expr = runtime.compile("partial('join', `\"-\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let args = obj.get("args").unwrap().as_array().unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str().unwrap(), "-");
+    }
+
+    #[test]
+    fn test_apply_partial_join() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        // Create a join with "-" separator, then apply to array
+        let expr = runtime
+            .compile("apply(partial('join', `\"-\"`), `[\"a\", \"b\", \"c\"]`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "a-b-c");
+    }
+
+    // =========================================================================
+    // Pipeline pattern tests
+    // =========================================================================
+
+    #[test]
+    fn test_pipeline_filter_sort_products() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "products": [
+                {"name": "A", "price": 30, "in_stock": true},
+                {"name": "B", "price": 10, "in_stock": true},
+                {"name": "C", "price": 20, "in_stock": false},
+                {"name": "D", "price": 5, "in_stock": true}
+            ]
+        });
+        let expr = runtime
+            .compile("products | filter_expr(&in_stock, @) | sort_by_expr(&price, @)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "D"
+        ); // $5
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "B"
+        ); // $10
+    }
+
+    #[test]
+    fn test_pipeline_funnel_errors() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "events": [
+                {"level": "error", "timestamp": 1704067300, "message": "Disk full"},
+                {"level": "info", "timestamp": 1704067200, "message": "Started"},
+                {"level": "error", "timestamp": 1704067400, "message": "Connection lost"},
+                {"level": "warn", "timestamp": 1704067350, "message": "High memory"}
+            ]
+        });
+        let expr = runtime
+            .compile(
+                r#"events | filter_expr(&(level == `"error"`), @) | sort_by_expr(&timestamp, @)"#,
+            )
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Sorted by timestamp ascending
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("message")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Disk full"
+        );
+    }
+
+    #[test]
+    fn test_pipeline_transactions_completed() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "transactions": [
+                {"amount": 100, "status": "completed"},
+                {"amount": 50, "status": "completed"},
+                {"amount": 75, "status": "pending"},
+                {"amount": 200, "status": "completed"}
+            ]
+        });
+        let expr = runtime
+            .compile(
+                r#"transactions | filter_expr(&(status == `"completed"`), @) | map_expr(&amount, @)"#,
+            )
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap(), 100.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 50.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 200.0);
+    }
+
+    #[test]
+    fn test_pipeline_fork_join() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "items": [
+                {"name": "A", "price": 150},
+                {"name": "B", "price": 50},
+                {"name": "C", "price": 200},
+                {"name": "D", "price": 25}
+            ]
+        });
+        let expr = runtime
+            .compile(
+                r#"@.{
+                    expensive: items | filter_expr(&(price > `100`), @),
+                    cheap: items | filter_expr(&(price <= `100`), @)
+                }"#,
+            )
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("expensive").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("cheap").unwrap().as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_pipeline_nested_users() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "users": [
+                {"name": "Alice", "orders": [{"total": 100}, {"total": 50}]},
+                {"name": "Bob", "orders": [{"total": 200}]},
+                {"name": "Carol", "orders": []}
+            ]
+        });
+        // Filter users with orders, then map to get names
+        let expr = runtime
+            .compile("users | filter_expr(&(length(orders) > `0`), @) | map_expr(&name, @)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "Alice");
+        assert_eq!(arr[1].as_str().unwrap(), "Bob");
+    }
+
+    #[test]
+    fn test_pipeline_rag_chunks() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "chunks": [
+                {"content": "Redis is fast", "score": 0.9},
+                {"content": "Redis is in-memory", "score": 0.85},
+                {"content": "Unrelated content", "score": 0.5},
+                {"content": "Redis supports modules", "score": 0.75}
+            ]
+        });
+        let expr = runtime
+            .compile("chunks | filter_expr(&(score > `0.7`), @) | sort_by_expr(&score, @)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // Sorted ascending by score
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("score")
+                .unwrap()
+                .as_f64()
+                .unwrap(),
+            0.75
+        );
+    }
+
+    // =========================================================================
+    // Additional reduce_expr/scan_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_reduce_expr_product() {
+        let runtime = setup_runtime();
+        // Test reduce with min (similar to existing max test but finds minimum)
+        let data = json!([5, 3, 8, 1, 9]);
+        let expr = runtime
+            .compile("reduce_expr(&min([accumulator, current]), @, `100`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_scan_expr_running_balance() {
+        let runtime = setup_runtime();
+        // Test scan with running max - shows progressive maximum
+        let data = json!([3, 1, 4, 1, 5, 9]);
+        let expr = runtime
+            .compile("scan_expr(&max([accumulator, current]), @, `0`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Running max: 3, 3, 4, 4, 5, 9
+        assert_eq!(arr[0].as_f64().unwrap(), 3.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 3.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 4.0);
+        assert_eq!(arr[3].as_f64().unwrap(), 4.0);
+        assert_eq!(arr[4].as_f64().unwrap(), 5.0);
+        assert_eq!(arr[5].as_f64().unwrap(), 9.0);
+    }
+
+    // =========================================================================
+    // Additional order_by tests
+    // =========================================================================
+
+    #[test]
+    fn test_order_by_three_fields() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"dept": "Engineering", "level": "senior", "name": "Charlie"},
+            {"dept": "Engineering", "level": "junior", "name": "Alice"},
+            {"dept": "Engineering", "level": "senior", "name": "Bob"},
+            {"dept": "Sales", "level": "senior", "name": "David"}
+        ]);
+        let expr = runtime
+            .compile(r#"order_by(@, `[["dept", "asc"], ["level", "desc"], ["name", "asc"]]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Engineering seniors first (alphabetical), then Engineering juniors, then Sales
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Bob"
+        );
+        assert_eq!(
+            arr[1]
+                .as_object()
+                .unwrap()
+                .get("name")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Charlie"
+        );
+    }
+
+    #[test]
+    fn test_order_by_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime
+            .compile(r#"order_by(@, `[["name", "asc"]]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+
+    // =========================================================================
+    // Additional partition_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_partition_expr_scores() {
+        let runtime = setup_runtime();
+        let data = json!([85, 42, 91, 67, 55, 78, 33, 99]);
+        let expr = runtime.compile("partition_expr(&(@ >= `60`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let passing = arr[0].as_array().unwrap();
+        let failing = arr[1].as_array().unwrap();
+        assert_eq!(passing.len(), 5); // 85, 91, 67, 78, 99
+        assert_eq!(failing.len(), 3); // 42, 55, 33
+    }
+
+    #[test]
+    fn test_partition_expr_active() {
+        let runtime = setup_runtime();
+        let data = json!([{"active": true}, {"active": false}, {"active": true}]);
+        let expr = runtime.compile("partition_expr(&active, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_array().unwrap().len(), 2);
+        assert_eq!(arr[1].as_array().unwrap().len(), 1);
+    }
+
+    // =========================================================================
+    // Additional map_values/map_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_map_values_discount() {
+        let runtime = setup_runtime();
+        // Test with string transformation since nested expressions don't have extension math functions
+        let data = json!({"apple": "FRUIT", "banana": "ITEM"});
+        let expr = runtime.compile("map_values(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("apple").unwrap().as_f64().unwrap(), 5.0);
+        assert_eq!(obj.get("banana").unwrap().as_f64().unwrap(), 4.0);
+    }
+
+    // =========================================================================
+    // Additional group_by_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_group_by_expr_type() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"type": "fruit", "name": "apple"},
+            {"type": "vegetable", "name": "carrot"},
+            {"type": "fruit", "name": "banana"}
+        ]);
+        let expr = runtime.compile("group_by_expr(&type, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("fruit").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("vegetable").unwrap().as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_group_by_expr_computed() {
+        let runtime = setup_runtime();
+        // Group strings by their length using built-in length function
+        let data = json!(["a", "bb", "ccc", "dd", "eee", "f"]);
+        let expr = runtime
+            .compile("group_by_expr(&to_string(length(@)), @)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("1")); // "a", "f"
+        assert!(obj.contains_key("2")); // "bb", "dd"
+        assert!(obj.contains_key("3")); // "ccc", "eee"
+        assert_eq!(obj.get("1").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("2").unwrap().as_array().unwrap().len(), 2);
+        assert_eq!(obj.get("3").unwrap().as_array().unwrap().len(), 2);
+    }
+
+    // =========================================================================
+    // Additional unique_by_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_unique_by_expr_id() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"id": 1, "v": "a"},
+            {"id": 2, "v": "b"},
+            {"id": 1, "v": "c"}
+        ]);
+        let expr = runtime.compile("unique_by_expr(&id, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Keeps first occurrence
+        assert_eq!(
+            arr[0]
+                .as_object()
+                .unwrap()
+                .get("v")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "a"
+        );
+    }
+
+    // =========================================================================
+    // Edge case tests
+    // =========================================================================
+
+    #[test]
+    fn test_any_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("any_expr(&(@ > `0`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_max_by_expr_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("max_by_expr(&age, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_flat_map_expr_duplicate() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        // Duplicate each element
+        let expr = runtime.compile("flat_map_expr(&[@, @], @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 6);
+    }
+
+    #[test]
+    fn test_reject_greater_than() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5, 6]);
+        let expr = runtime.compile("reject(&(@ > `3`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3); // 1, 2, 3
+    }
+
+    #[test]
+    fn test_every_false_case() {
+        let runtime = setup_runtime();
+        let data = json!([1, -1, 3]);
+        let expr = runtime.compile("every(&(@ > `0`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_count_expr_all_match() {
+        let runtime = setup_runtime();
+        let data = json!([5, 10, 15, 20]);
+        let expr = runtime.compile("count_expr(&(@ > `0`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_find_expr_first_match() {
+        let runtime = setup_runtime();
+        let data = json!([1, 5, 10, 15]);
+        let expr = runtime.compile("find_expr(&(@ > `3`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 5.0);
+    }
+
+    #[test]
+    fn test_find_index_expr_first_match() {
+        let runtime = setup_runtime();
+        let data = json!([1, 5, 10, 15]);
+        let expr = runtime.compile("find_index_expr(&(@ > `3`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_take_while_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 5, 1, 2]);
+        let expr = runtime.compile("take_while(&(@ < `4`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 2.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_take_while_all_match() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("take_while(&(@ < `10`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_take_while_none_match() {
+        let runtime = setup_runtime();
+        let data = json!([5, 6, 7]);
+        let expr = runtime.compile("take_while(&(@ < `4`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_drop_while_basic() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 5, 1, 2]);
+        let expr = runtime.compile("drop_while(&(@ < `4`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap(), 5.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_drop_while_all_match() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("drop_while(&(@ < `10`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_drop_while_none_match() {
+        let runtime = setup_runtime();
+        let data = json!([5, 6, 7]);
+        let expr = runtime.compile("drop_while(&(@ < `4`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_zip_with_add() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("zip_with(&add([0], [1]), `[1, 2, 3]`, `[10, 20, 30]`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap(), 11.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 22.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 33.0);
+    }
+
+    #[test]
+    fn test_zip_with_unequal_lengths() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("zip_with(&add([0], [1]), `[1, 2, 3, 4, 5]`, `[10, 20]`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap(), 11.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 22.0);
+    }
+
+    #[test]
+    fn test_zip_with_multiply() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("zip_with(&multiply([0], [1]), `[2, 3, 4]`, `[5, 6, 7]`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap(), 10.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 18.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 28.0);
+    }
+
+    // =========================================================================
+    // walk tests
+    // =========================================================================
+
+    #[test]
+    fn test_walk_identity() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, 2, 3], "b": {"c": 4}});
+        let expr = runtime.compile("walk(&@, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Identity should return the same structure
+        assert!(result.is_object());
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("a"));
+        assert!(obj.contains_key("b"));
+    }
+
+    #[test]
+    fn test_walk_type_of_all() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 5, "b": [1, 2]});
+        // type() works on everything - shows bottom-up processing
+        let expr = runtime.compile("walk(&type(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // After walking, everything becomes its type string, and the final result
+        // is type of the top-level result
+        assert_eq!(result.as_str().unwrap(), "object");
+    }
+
+    #[test]
+    fn test_walk_nested_arrays() {
+        let runtime = setup_runtime();
+        // Use only arrays (no scalars inside) so length works at every level
+        let data = json!([[[], []], [[]]]);
+        // length works on arrays - get lengths at each level
+        let expr = runtime.compile("walk(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Inner [] -> 0, outer arrays get lengths, top level has 2 elements
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_walk_scalar() {
+        let runtime = setup_runtime();
+        let data = json!(5);
+        // Double the number
+        let expr = runtime.compile("walk(&multiply(@, `2`), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_walk_length_all() {
+        let runtime = setup_runtime();
+        let data = json!({"items": ["a", "bb", "ccc"]});
+        // Get length of everything (works for strings, arrays, objects)
+        let expr = runtime.compile("walk(&length(@), @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Top level object has 1 key
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_walk_preserves_structure() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, {"b": 2}], "c": "hello"});
+        // Identity transform - should preserve structure
+        let expr = runtime.compile("walk(&@, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("a"));
+        assert!(obj.contains_key("c"));
+        let arr = obj.get("a").unwrap().as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_walk_empty_structures() {
+        let runtime = setup_runtime();
+
+        // Empty array
+        let data = json!([]);
+        let expr = runtime.compile("walk(&@, @)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_array().unwrap().is_empty());
+
+        // Empty object
+        let data = json!({});
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_object().unwrap().is_empty());
+    }
+
+    // =========================================================================
+    // recurse tests
+    // =========================================================================
+
+    #[test]
+    fn test_recurse_nested_object() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}});
+        let expr = runtime.compile("recurse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should have: {a: {b: 1}}, {b: 1}, 1
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_recurse_nested_array() {
+        let runtime = setup_runtime();
+        let data = json!([1, [2, 3]]);
+        let expr = runtime.compile("recurse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should have: [1, [2, 3]], 1, [2, 3], 2, 3
+        assert_eq!(arr.len(), 5);
+    }
+
+    #[test]
+    fn test_recurse_scalar() {
+        let runtime = setup_runtime();
+        let data = json!(42);
+        let expr = runtime.compile("recurse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Just the scalar itself
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_f64().unwrap(), 42.0);
+    }
+
+    #[test]
+    fn test_recurse_with_field() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"a": {"a": null}}});
+        let expr = runtime.compile("recurse_with(@, &a)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should have: {a: {a: {a: null}}}, {a: {a: null}}, {a: null}
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_recurse_with_children() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "name": "root",
+            "children": [
+                {"name": "child1", "children": []},
+                {"name": "child2", "children": []}
+            ]
+        });
+        let expr = runtime.compile("recurse_with(@, &children[])").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should have: root, child1, child2
+        assert_eq!(arr.len(), 3);
+    }
+
+    // =========================================================================
+    // while_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_while_expr_doubling() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("while_expr(`1`, &(@ < `100`), &multiply(@, `2`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // 1 -> 2 -> 4 -> 8 -> 16 -> 32 -> 64 -> 128 (stops because 128 >= 100)
+        assert_eq!(result.as_f64().unwrap(), 128.0);
+    }
+
+    #[test]
+    fn test_while_expr_counter() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("while_expr(`0`, &(@ < `5`), &add(@, `1`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // 0 -> 1 -> 2 -> 3 -> 4 -> 5 (stops because 5 >= 5)
+        assert_eq!(result.as_f64().unwrap(), 5.0);
+    }
+
+    #[test]
+    fn test_while_expr_immediate_false() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("while_expr(`100`, &(@ < `10`), &add(@, `1`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Condition is false immediately, return initial value
+        assert_eq!(result.as_f64().unwrap(), 100.0);
+    }
+
+    // =========================================================================
+    // until_expr tests
+    // =========================================================================
+
+    #[test]
+    fn test_until_expr_doubling() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("until_expr(`1`, &(@ >= `100`), &multiply(@, `2`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // 1 -> 2 -> 4 -> 8 -> 16 -> 32 -> 64 -> 128 (stops because 128 >= 100)
+        assert_eq!(result.as_f64().unwrap(), 128.0);
+    }
+
+    #[test]
+    fn test_until_expr_counter() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("until_expr(`0`, &(@ == `5`), &add(@, `1`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // 0 -> 1 -> 2 -> 3 -> 4 -> 5 (stops because 5 == 5)
+        assert_eq!(result.as_f64().unwrap(), 5.0);
+    }
+
+    #[test]
+    fn test_until_expr_immediate_true() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime
+            .compile("until_expr(`100`, &(@ > `10`), &add(@, `1`))")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Condition is true immediately, return initial value
+        assert_eq!(result.as_f64().unwrap(), 100.0);
+    }
+}

--- a/crates/jpx-core/src/extensions/format.rs
+++ b/crates/jpx-core/src/extensions/format.rs
@@ -297,3 +297,330 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "from_csv", enabled, Box::new(FromCsvFn::new()));
     register_if_enabled(runtime, "from_tsv", enabled, Box::new(FromTsvFn::new()));
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    // =========================================================================
+    // to_csv tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["a", "b", "c"]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "a,b,c");
+    }
+
+    #[test]
+    fn test_to_csv_mixed_types() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["hello", 42, true, null]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello,42,true,");
+    }
+
+    #[test]
+    fn test_to_csv_with_comma() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["hello, world", "test"]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "\"hello, world\",test");
+    }
+
+    #[test]
+    fn test_to_csv_with_quotes() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["say \"hello\"", "test"]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "\"say \"\"hello\"\"\",test");
+    }
+
+    #[test]
+    fn test_to_csv_with_newline() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["line1\nline2", "test"]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "\"line1\nline2\",test");
+    }
+
+    #[test]
+    fn test_to_csv_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_with_leading_trailing_space() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv(@)").unwrap();
+        let data = json!(["  hello  ", "test"]);
+        let result = expr.search(&data).unwrap();
+        // csv crate quotes fields with leading/trailing whitespace to preserve them
+        assert!(result.as_str().unwrap().contains("hello"));
+    }
+
+    // =========================================================================
+    // to_tsv tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_tsv_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_tsv(@)").unwrap();
+        let data = json!(["a", "b", "c"]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "a\tb\tc");
+    }
+
+    #[test]
+    fn test_to_tsv_mixed_types() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_tsv(@)").unwrap();
+        let data = json!(["hello", 42, true, null]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello\t42\ttrue\t");
+    }
+
+    // =========================================================================
+    // to_csv_rows tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_rows_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = json!([[1, 2, 3], [4, 5, 6]]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1,2,3\n4,5,6");
+    }
+
+    #[test]
+    fn test_to_csv_rows_with_strings() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = json!([["a", "b"], ["c", "d"]]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "a,b\nc,d");
+    }
+
+    #[test]
+    fn test_to_csv_rows_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_rows_with_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let data = json!([["hello, world", "test"], ["a\"b", "c"]]);
+        let result = expr.search(&data).unwrap();
+        // Should properly escape commas and quotes
+        assert!(result.as_str().unwrap().contains("\"hello, world\""));
+        assert!(result.as_str().unwrap().contains("\"a\"\"b\""));
+    }
+
+    // =========================================================================
+    // to_csv_table tests
+    // =========================================================================
+
+    #[test]
+    fn test_to_csv_table_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data = json!([{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]);
+        let result = expr.search(&data).unwrap();
+        // Keys are sorted alphabetically
+        assert_eq!(result.as_str().unwrap(), "age,name\n30,alice\n25,bob");
+    }
+
+    #[test]
+    fn test_to_csv_table_with_columns() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("to_csv_table(@, `[\"name\", \"age\"]`)")
+            .unwrap();
+        let data = json!([{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]);
+        let result = expr.search(&data).unwrap();
+        // Columns in specified order
+        assert_eq!(result.as_str().unwrap(), "name,age\nalice,30\nbob,25");
+    }
+
+    #[test]
+    fn test_to_csv_table_missing_field() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("to_csv_table(@, `[\"name\", \"age\", \"email\"]`)")
+            .unwrap();
+        let data = json!([{"name": "alice", "age": 30}, {"name": "bob"}]);
+        let result = expr.search(&data).unwrap();
+        // Missing fields are empty
+        assert_eq!(result.as_str().unwrap(), "name,age,email\nalice,30,\nbob,,");
+    }
+
+    #[test]
+    fn test_to_csv_table_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_to_csv_table_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_csv_table(@)").unwrap();
+        let data = json!([{"name": "O'Brien, Jr.", "note": "said \"hi\""}]);
+        let result = expr.search(&data).unwrap();
+        // Should properly escape commas and quotes
+        assert!(result.as_str().unwrap().contains("\"O'Brien, Jr.\""));
+        assert!(result.as_str().unwrap().contains("\"said \"\"hi\"\"\""));
+    }
+
+    // =========================================================================
+    // from_csv tests
+    // =========================================================================
+
+    #[test]
+    fn test_from_csv_simple() {
+        let runtime = setup_runtime();
+        let data = json!({"csv": "a,b,c\n1,2,3"});
+        let expr = runtime.compile("from_csv(csv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // First row
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0[0].as_str().unwrap(), "a");
+        assert_eq!(row0[1].as_str().unwrap(), "b");
+        assert_eq!(row0[2].as_str().unwrap(), "c");
+        // Second row
+        let row1 = arr[1].as_array().unwrap();
+        assert_eq!(row1[0].as_str().unwrap(), "1");
+        assert_eq!(row1[1].as_str().unwrap(), "2");
+        assert_eq!(row1[2].as_str().unwrap(), "3");
+    }
+
+    #[test]
+    fn test_from_csv_quoted() {
+        let runtime = setup_runtime();
+        let data = json!({"csv": "\"hello, world\",test"});
+        let expr = runtime.compile("from_csv(csv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0[0].as_str().unwrap(), "hello, world");
+        assert_eq!(row0[1].as_str().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_from_csv_empty() {
+        let runtime = setup_runtime();
+        let data = json!({"csv": ""});
+        let expr = runtime.compile("from_csv(csv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_from_csv_single_row() {
+        let runtime = setup_runtime();
+        let data = json!({"csv": "a,b,c"});
+        let expr = runtime.compile("from_csv(csv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0.len(), 3);
+    }
+
+    // =========================================================================
+    // from_tsv tests
+    // =========================================================================
+
+    #[test]
+    fn test_from_tsv_simple() {
+        let runtime = setup_runtime();
+        let data = json!({"tsv": "a\tb\tc\n1\t2\t3"});
+        let expr = runtime.compile("from_tsv(tsv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // First row
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0[0].as_str().unwrap(), "a");
+        assert_eq!(row0[1].as_str().unwrap(), "b");
+        assert_eq!(row0[2].as_str().unwrap(), "c");
+    }
+
+    #[test]
+    fn test_from_tsv_empty() {
+        let runtime = setup_runtime();
+        let data = json!({"tsv": ""});
+        let expr = runtime.compile("from_tsv(tsv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_from_tsv_spaces_preserved() {
+        let runtime = setup_runtime();
+        let data = json!({"tsv": "hello world\ttest"});
+        let expr = runtime.compile("from_tsv(tsv)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0[0].as_str().unwrap(), "hello world");
+        assert_eq!(row0[1].as_str().unwrap(), "test");
+    }
+
+    // =========================================================================
+    // roundtrip tests
+    // =========================================================================
+
+    #[test]
+    fn test_csv_roundtrip() {
+        let runtime = setup_runtime();
+        // to_csv_rows then from_csv should give back similar structure
+        let data = json!([["a", "b"], ["1", "2"]]);
+        let expr = runtime.compile("to_csv_rows(@)").unwrap();
+        let csv_result = expr.search(&data).unwrap();
+
+        // Now parse it back
+        let parse_data = json!({"csv": csv_result.as_str().unwrap()});
+        let parse_expr = runtime.compile("from_csv(csv)").unwrap();
+        let parsed = parse_expr.search(&parse_data).unwrap();
+
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let row0 = arr[0].as_array().unwrap();
+        assert_eq!(row0[0].as_str().unwrap(), "a");
+        assert_eq!(row0[1].as_str().unwrap(), "b");
+    }
+}

--- a/crates/jpx-core/src/extensions/fuzzy.rs
+++ b/crates/jpx-core/src/extensions/fuzzy.rs
@@ -183,3 +183,183 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(OsaDistanceFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_levenshtein() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("levenshtein('kitten', 'sitting')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_levenshtein_identical() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("levenshtein('hello', 'hello')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_normalized_levenshtein() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("normalized_levenshtein('hello', 'hello')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_normalized_levenshtein_different() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("normalized_levenshtein('hello', 'world')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let sim = result.as_f64().unwrap();
+        assert!(sim > 0.0 && sim < 1.0);
+    }
+
+    #[test]
+    fn test_damerau_levenshtein() {
+        let runtime = setup_runtime();
+        // Transposition: "ab" -> "ba" is 1 edit in Damerau-Levenshtein
+        let expr = runtime.compile("damerau_levenshtein('ab', 'ba')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_jaro() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jaro('hello', 'hallo')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let sim = result.as_f64().unwrap();
+        assert!(sim > 0.8);
+    }
+
+    #[test]
+    fn test_jaro_identical() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("jaro('test', 'test')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler() {
+        let runtime = setup_runtime();
+        // Jaro-Winkler boosts common prefixes
+        let expr = runtime
+            .compile("jaro_winkler('prefix_abc', 'prefix_xyz')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let sim = result.as_f64().unwrap();
+        assert!(sim > 0.7);
+    }
+
+    #[test]
+    fn test_jaro_winkler_vs_jaro() {
+        let runtime = setup_runtime();
+        // Jaro-Winkler should be >= Jaro for strings with common prefix
+        let jw_expr = runtime.compile("jaro_winkler('hello', 'hella')").unwrap();
+        let j_expr = runtime.compile("jaro('hello', 'hella')").unwrap();
+        let jw = jw_expr.search(&json!(null)).unwrap();
+        let j = j_expr.search(&json!(null)).unwrap();
+        assert!(jw.as_f64().unwrap() >= j.as_f64().unwrap());
+    }
+
+    #[test]
+    fn test_sorensen_dice() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sorensen_dice('night', 'nacht')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let sim = result.as_f64().unwrap();
+        assert!(sim > 0.0 && sim < 1.0);
+    }
+
+    #[test]
+    fn test_sorensen_dice_identical() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sorensen_dice('test', 'test')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_normalized_damerau_levenshtein() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("normalized_damerau_levenshtein('hello', 'hello')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_normalized_damerau_levenshtein_transposition() {
+        let runtime = setup_runtime();
+        // "ab" vs "ba" - transposition
+        let expr = runtime
+            .compile("normalized_damerau_levenshtein('ab', 'ba')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let sim = result.as_f64().unwrap();
+        assert!(sim > 0.0 && sim < 1.0);
+    }
+
+    #[test]
+    fn test_hamming() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hamming('karolin', 'kathrin')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_hamming_identical() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hamming('hello', 'hello')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_hamming_different_lengths() {
+        let runtime = setup_runtime();
+        // Different lengths should return null
+        let expr = runtime.compile("hamming('hello', 'hi')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_osa_distance() {
+        let runtime = setup_runtime();
+        // OSA allows transpositions
+        let expr = runtime.compile("osa_distance('ab', 'ba')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_osa_distance_identical() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("osa_distance('hello', 'hello')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+}

--- a/crates/jpx-core/src/extensions/geo.rs
+++ b/crates/jpx-core/src/extensions/geo.rs
@@ -156,3 +156,82 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(GeoBearingFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_geo_distance() {
+        let runtime = setup_runtime();
+        // NYC to LA: approximately 3940 km
+        let data = json!({"nyc": [40.7128, -74.0060], "la": [34.0522, -118.2437]});
+        let expr = runtime
+            .compile("geo_distance(nyc[0], nyc[1], la[0], la[1])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let meters = result.as_f64().unwrap();
+        // Should be approximately 3940000 meters
+        assert!(meters > 3900000.0 && meters < 4000000.0);
+    }
+
+    #[test]
+    fn test_geo_distance_km() {
+        let runtime = setup_runtime();
+        let data = json!({"nyc": [40.7128, -74.0060], "la": [34.0522, -118.2437]});
+        let expr = runtime
+            .compile("geo_distance_km(nyc[0], nyc[1], la[0], la[1])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let km = result.as_f64().unwrap();
+        // Should be approximately 3940 km
+        assert!(km > 3900.0 && km < 4000.0);
+    }
+
+    #[test]
+    fn test_geo_distance_miles() {
+        let runtime = setup_runtime();
+        let data = json!({"nyc": [40.7128, -74.0060], "la": [34.0522, -118.2437]});
+        let expr = runtime
+            .compile("geo_distance_miles(nyc[0], nyc[1], la[0], la[1])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let miles = result.as_f64().unwrap();
+        // Should be approximately 2450 miles
+        assert!(miles > 2400.0 && miles < 2500.0);
+    }
+
+    #[test]
+    fn test_geo_bearing() {
+        let runtime = setup_runtime();
+        // NYC to LA should be roughly west (270 degrees)
+        let data = json!({"nyc": [40.7128, -74.0060], "la": [34.0522, -118.2437]});
+        let expr = runtime
+            .compile("geo_bearing(nyc[0], nyc[1], la[0], la[1])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let bearing = result.as_f64().unwrap();
+        // Should be roughly 273 degrees (west-southwest)
+        assert!(bearing > 260.0 && bearing < 290.0);
+    }
+
+    #[test]
+    fn test_geo_distance_same_point() {
+        let runtime = setup_runtime();
+        let data = json!([40.7128, -74.0060]);
+        let expr = runtime
+            .compile("geo_distance(@[0], @[1], @[0], @[1])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let meters = result.as_f64().unwrap();
+        assert!(meters < 1.0); // Should be essentially 0
+    }
+}

--- a/crates/jpx-core/src/extensions/hash.rs
+++ b/crates/jpx-core/src/extensions/hash.rs
@@ -313,3 +313,179 @@ impl Function for Crc32Fn {
         Ok(Value::Number(serde_json::Number::from(checksum)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    // =========================================================================
+    // Hash function tests
+    // =========================================================================
+
+    #[test]
+    fn test_md5() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("md5(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("5d41402abc4b2a76b9719d911017c592"));
+    }
+
+    #[test]
+    fn test_md5_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("md5(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("d41d8cd98f00b204e9800998ecf8427e"));
+    }
+
+    #[test]
+    fn test_sha1() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sha1(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"));
+    }
+
+    #[test]
+    fn test_sha256() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sha256(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        );
+    }
+
+    #[test]
+    fn test_sha512() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sha512(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!(
+                "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043"
+            )
+        );
+    }
+
+    #[test]
+    fn test_sha512_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sha512(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!(
+                "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+            )
+        );
+    }
+
+    // =========================================================================
+    // HMAC function tests
+    // =========================================================================
+
+    #[test]
+    fn test_hmac_md5() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_md5(@, `\"secret\"`)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("bade63863c61ed0b3165806ecd6acefc"));
+    }
+
+    #[test]
+    fn test_hmac_sha1() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_sha1(@, `\"secret\"`)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("5112055c05f944f85755efc5cd8970e194e9f45b"));
+    }
+
+    #[test]
+    fn test_hmac_sha256() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_sha256(@, `\"secret\"`)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!("88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b")
+        );
+    }
+
+    #[test]
+    fn test_hmac_sha512() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_sha512(@, `\"secret\"`)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!(
+                "db1595ae88a62fd151ec1cba81b98c39df82daae7b4cb9820f446d5bf02f1dcfca6683d88cab3e273f5963ab8ec469a746b5b19086371239f67d1e5f99a79440"
+            )
+        );
+    }
+
+    #[test]
+    fn test_hmac_sha256_empty_message() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_sha256(@, `\"key\"`)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result,
+            json!("5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")
+        );
+    }
+
+    #[test]
+    fn test_hmac_sha256_empty_key() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("hmac_sha256(@, `\"\"`)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        // HMAC with empty key is valid
+        assert!(!result.as_str().unwrap().is_empty());
+    }
+
+    // =========================================================================
+    // CRC32 tests
+    // =========================================================================
+
+    #[test]
+    fn test_crc32() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("crc32(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(907060870));
+    }
+
+    #[test]
+    fn test_crc32_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("crc32(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(0));
+    }
+}

--- a/crates/jpx-core/src/extensions/ids.rs
+++ b/crates/jpx-core/src/extensions/ids.rs
@@ -76,3 +76,104 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(UlidTimestampFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_nanoid_default() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("nanoid()").unwrap();
+        let result = expr.search(&data).unwrap();
+        let id = result.as_str().unwrap();
+        assert_eq!(id.len(), 21);
+    }
+
+    #[test]
+    fn test_nanoid_custom_size() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("nanoid(`10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let id = result.as_str().unwrap();
+        assert_eq!(id.len(), 10);
+    }
+
+    #[test]
+    fn test_nanoid_unique() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("nanoid()").unwrap();
+        let id1 = expr.search(&data).unwrap();
+        let id2 = expr.search(&data).unwrap();
+        assert_ne!(id1.as_str().unwrap(), id2.as_str().unwrap());
+    }
+
+    #[test]
+    fn test_ulid() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("ulid()").unwrap();
+        let result = expr.search(&data).unwrap();
+        let id = result.as_str().unwrap();
+        // ULID is 26 characters
+        assert_eq!(id.len(), 26);
+    }
+
+    #[test]
+    fn test_ulid_unique() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("ulid()").unwrap();
+        let id1 = expr.search(&data).unwrap();
+        let id2 = expr.search(&data).unwrap();
+        assert_ne!(id1.as_str().unwrap(), id2.as_str().unwrap());
+    }
+
+    #[test]
+    fn test_ulid_timestamp() {
+        let runtime = setup_runtime();
+        // Generate a ULID and extract its timestamp
+        let ulid = ulid::Ulid::new();
+        let ulid_str = ulid.to_string();
+        let expected_ts = ulid.timestamp_ms();
+
+        let data = json!(ulid_str);
+        let expr = runtime.compile("ulid_timestamp(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), expected_ts as f64);
+    }
+
+    #[test]
+    fn test_ulid_timestamp_invalid() {
+        let runtime = setup_runtime();
+        let data = json!("not-a-ulid");
+        let expr = runtime.compile("ulid_timestamp(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_ulid_format() {
+        let runtime = setup_runtime();
+        let data = json!(null);
+        let expr = runtime.compile("ulid()").unwrap();
+        let result = expr.search(&data).unwrap();
+        let id = result.as_str().unwrap();
+
+        // ULID should be 26 characters of Crockford's Base32
+        assert_eq!(id.len(), 26);
+        // All characters should be valid Base32
+        assert!(id.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+}

--- a/crates/jpx-core/src/extensions/jsonpatch.rs
+++ b/crates/jpx-core/src/extensions/jsonpatch.rs
@@ -82,3 +82,174 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     );
     register_if_enabled(runtime, "json_diff", enabled, Box::new(JsonDiffFn::new()));
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_json_patch_add() {
+        let runtime = setup_runtime();
+        let data = json!({"doc": {"a": 1}, "patch": [{"op": "add", "path": "/b", "value": 2}]});
+        let expr = runtime.compile("json_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_json_patch_remove() {
+        let runtime = setup_runtime();
+        let data = json!({"doc": {"a": 1, "b": 2}, "patch": [{"op": "remove", "path": "/b"}]});
+        let expr = runtime.compile("json_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert!(obj.get("b").is_none());
+    }
+
+    #[test]
+    fn test_json_patch_replace() {
+        let runtime = setup_runtime();
+        let data =
+            json!({"doc": {"a": 1}, "patch": [{"op": "replace", "path": "/a", "value": 99}]});
+        let expr = runtime.compile("json_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 99);
+    }
+
+    #[test]
+    fn test_json_patch_multiple_ops() {
+        let runtime = setup_runtime();
+        let data = json!({
+            "doc": {"a": 1},
+            "patch": [
+                {"op": "add", "path": "/b", "value": 2},
+                {"op": "replace", "path": "/a", "value": 10}
+            ]
+        });
+        let expr = runtime.compile("json_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 10);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_json_merge_patch_simple() {
+        let runtime = setup_runtime();
+        let data = json!({"doc": {"a": 1, "b": 2}, "patch": {"b": 3, "c": 4}});
+        let expr = runtime.compile("json_merge_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 3);
+        assert_eq!(obj.get("c").unwrap().as_f64().unwrap() as i64, 4);
+    }
+
+    #[test]
+    fn test_json_merge_patch_remove_with_null() {
+        let runtime = setup_runtime();
+        let data = json!({"doc": {"a": 1, "b": 2}, "patch": {"b": null}});
+        let expr = runtime.compile("json_merge_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert!(obj.get("b").is_none());
+    }
+
+    #[test]
+    fn test_json_merge_patch_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"doc": {"a": {"x": 1}}, "patch": {"a": {"y": 2}}});
+        let expr = runtime.compile("json_merge_patch(doc, patch)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(a.get("x").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(a.get("y").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_json_diff_add() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 1, "y": 2}});
+        let expr = runtime.compile("json_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let op = arr[0].as_object().unwrap();
+        assert_eq!(op.get("op").unwrap().as_str().unwrap(), "add");
+        assert_eq!(op.get("path").unwrap().as_str().unwrap(), "/y");
+    }
+
+    #[test]
+    fn test_json_diff_remove() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1, "y": 2}, "b": {"x": 1}});
+        let expr = runtime.compile("json_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let op = arr[0].as_object().unwrap();
+        assert_eq!(op.get("op").unwrap().as_str().unwrap(), "remove");
+        assert_eq!(op.get("path").unwrap().as_str().unwrap(), "/y");
+    }
+
+    #[test]
+    fn test_json_diff_replace() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 2}});
+        let expr = runtime.compile("json_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let op = arr[0].as_object().unwrap();
+        assert_eq!(op.get("op").unwrap().as_str().unwrap(), "replace");
+        assert_eq!(op.get("path").unwrap().as_str().unwrap(), "/x");
+    }
+
+    #[test]
+    fn test_json_diff_no_changes() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 1}});
+        let expr = runtime.compile("json_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_json_diff_roundtrip() {
+        // Generate a diff and apply it - should get the same result
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 2, "y": 3}});
+
+        // First get the diff
+        let diff_expr = runtime.compile("json_diff(a, b)").unwrap();
+        let diff_result = diff_expr.search(&data).unwrap();
+
+        // Now apply the diff to a
+        let data_with_patch = json!({
+            "doc": {"x": 1},
+            "patch": diff_result
+        });
+        let patch_expr = runtime.compile("json_patch(doc, patch)").unwrap();
+        let patched = patch_expr.search(&data_with_patch).unwrap();
+
+        // Should equal b
+        let obj = patched.as_object().unwrap();
+        assert_eq!(obj.get("x").unwrap().as_f64().unwrap() as i64, 2);
+        assert_eq!(obj.get("y").unwrap().as_f64().unwrap() as i64, 3);
+    }
+}

--- a/crates/jpx-core/src/extensions/language.rs
+++ b/crates/jpx-core/src/extensions/language.rs
@@ -163,3 +163,159 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(DetectLanguageInfoFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_detect_language_english() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language('This is a test of the language detection system.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "English");
+    }
+
+    #[test]
+    fn test_detect_language_spanish() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language('Esto es una prueba del sistema de deteccion de idiomas.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_str().unwrap(), "Espa\u{f1}ol");
+    }
+
+    #[test]
+    fn test_detect_language_french() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language('Ceci est un test du systeme de detection de langue.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_str().unwrap(), "Fran\u{e7}ais");
+    }
+
+    #[test]
+    fn test_detect_language_german() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language('Dies ist ein Test des Spracherkennungssystems.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // whatlang returns native language names
+        assert_eq!(result.as_str().unwrap(), "Deutsch");
+    }
+
+    #[test]
+    fn test_detect_language_iso_english() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language_iso('This is English text.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "eng");
+    }
+
+    #[test]
+    fn test_detect_language_iso_spanish() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language_iso('Este es un texto en espanol.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "spa");
+    }
+
+    #[test]
+    fn test_detect_script_latin() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("detect_script('Hello world')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Latin");
+    }
+
+    #[test]
+    fn test_detect_script_cyrillic() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile(
+                "detect_script('\u{41f}\u{440}\u{438}\u{432}\u{435}\u{442} \u{43c}\u{438}\u{440}')",
+            )
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Cyrillic");
+    }
+
+    #[test]
+    fn test_detect_script_arabic() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_script('\u{645}\u{631}\u{62d}\u{628}\u{627} \u{628}\u{627}\u{644}\u{639}\u{627}\u{644}\u{645}')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Arabic");
+    }
+
+    #[test]
+    fn test_detect_language_confidence() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language_confidence('This is definitely English text for testing.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let confidence = result.as_f64().unwrap();
+        assert!(confidence > 0.5);
+    }
+
+    #[test]
+    fn test_detect_language_info() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("detect_language_info('This is a test.')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let obj = result.as_object().unwrap();
+
+        assert!(obj.contains_key("language"));
+        assert!(obj.contains_key("code"));
+        assert!(obj.contains_key("script"));
+        assert!(obj.contains_key("confidence"));
+        assert!(obj.contains_key("reliable"));
+
+        assert_eq!(obj.get("language").unwrap().as_str().unwrap(), "English");
+        assert_eq!(obj.get("code").unwrap().as_str().unwrap(), "eng");
+        assert_eq!(obj.get("script").unwrap().as_str().unwrap(), "Latin");
+    }
+
+    #[test]
+    fn test_detect_language_empty_string() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("detect_language('')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // Empty string may return null or a guess
+        // Just verify it doesn't crash
+        assert!(result.is_null() || result.as_str().is_some());
+    }
+
+    #[test]
+    fn test_detect_language_short_text() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("detect_language('Hi')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // Short text may have low confidence but should still work
+        assert!(result.is_null() || result.as_str().is_some());
+    }
+}

--- a/crates/jpx-core/src/extensions/math.rs
+++ b/crates/jpx-core/src/extensions/math.rs
@@ -1471,3 +1471,377 @@ impl Function for CumulativeSumFn {
         Ok(Value::Array(cumsum))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn test_round() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("round(`3.14159`, `2`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!((result.as_f64().unwrap() - 3.14_f64).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sqrt(`16`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 4);
+    }
+
+    #[test]
+    fn test_clamp() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("clamp(`5`, `0`, `3`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_add() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("add(`1`, `2`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_subtract() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("subtract(`10`, `3`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 7);
+    }
+
+    #[test]
+    fn test_multiply() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("multiply(`4`, `5`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 20);
+    }
+
+    #[test]
+    fn test_divide() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("divide(`10`, `4`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.5);
+    }
+
+    #[test]
+    fn test_mode_numbers() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("mode(`[1, 2, 2, 3]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_mode_strings() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("mode(`[\"a\", \"b\", \"a\", \"c\"]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "a");
+    }
+
+    #[test]
+    fn test_mode_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("mode(`[]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_to_fixed() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_fixed(`3.14159`, `2`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "3.14");
+    }
+
+    #[test]
+    fn test_to_fixed_padding() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_fixed(`3.1`, `3`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "3.100");
+    }
+
+    #[test]
+    fn test_format_number_with_separators() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("format_number(`1234567.89`, `2`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1,234,567.89");
+    }
+
+    #[test]
+    fn test_format_number_with_k_suffix() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("format_number(`1500`, `1`, 'k')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1.5k");
+    }
+
+    #[test]
+    fn test_format_number_with_m_suffix() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("format_number(`1500000`, `1`, 'M')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1.5M");
+    }
+
+    #[test]
+    fn test_format_number_auto_suffix() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("format_number(`1500000000`, `2`, 'auto')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1.50B");
+    }
+
+    #[test]
+    #[ignore] // histogram not yet in functions.toml
+    fn test_histogram() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("histogram(@, `3`)").unwrap();
+        let data = json!([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // Each bin should have 3 values
+        for bin in arr {
+            let obj = bin.as_object().unwrap();
+            assert!(obj.contains_key("min"));
+            assert!(obj.contains_key("max"));
+            assert!(obj.contains_key("count"));
+        }
+    }
+
+    #[test]
+    #[ignore] // normalize not yet in functions.toml
+    fn test_normalize() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("normalize(@)").unwrap();
+        let data = json!([0, 50, 100]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert!((arr[0].as_f64().unwrap() - 0.0).abs() < 0.001);
+        assert!((arr[1].as_f64().unwrap() - 0.5).abs() < 0.001);
+        assert!((arr[2].as_f64().unwrap() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    #[ignore] // z_score not yet in functions.toml
+    fn test_z_score() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("z_score(@)").unwrap();
+        let data = json!([1, 2, 3, 4, 5]);
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        // Middle value (3) should have z-score of 0
+        assert!((arr[2].as_f64().unwrap() - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    #[ignore] // correlation not yet in functions.toml
+    fn test_correlation_positive() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("correlation(`[1, 2, 3]`, `[1, 2, 3]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!((result.as_f64().unwrap() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    #[ignore] // correlation not yet in functions.toml
+    fn test_correlation_negative() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("correlation(`[1, 2, 3]`, `[3, 2, 1]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!((result.as_f64().unwrap() - (-1.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_quantile_median() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("quantile(`[1, 2, 3, 4, 5]`, `0.5`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_quantile_quartiles() {
+        let runtime = setup_runtime();
+        // First quartile
+        let expr = runtime
+            .compile("quantile(`[1, 2, 3, 4, 5]`, `0.25`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+
+        // Third quartile
+        let expr = runtime
+            .compile("quantile(`[1, 2, 3, 4, 5]`, `0.75`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_moving_avg() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("moving_avg(`[1, 2, 3, 4, 5, 6]`, `3`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 6);
+        assert!(arr[0].is_null());
+        assert!(arr[1].is_null());
+        assert_eq!(arr[2].as_f64().unwrap(), 2.0); // (1+2+3)/3
+        assert_eq!(arr[3].as_f64().unwrap(), 3.0); // (2+3+4)/3
+        assert_eq!(arr[4].as_f64().unwrap(), 4.0); // (3+4+5)/3
+        assert_eq!(arr[5].as_f64().unwrap(), 5.0); // (4+5+6)/3
+    }
+
+    #[test]
+    fn test_ewma() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("ewma(`[1, 2, 3, 4, 5]`, `0.5`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        // First value is just the first value
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        // Subsequent values: alpha * current + (1-alpha) * prev_ewma
+        assert_eq!(arr[1].as_f64().unwrap(), 1.5); // 0.5*2 + 0.5*1
+        assert_eq!(arr[2].as_f64().unwrap(), 2.25); // 0.5*3 + 0.5*1.5
+    }
+
+    #[test]
+    fn test_covariance() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("covariance(`[1, 2, 3]`, `[1, 2, 3]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // Variance of [1,2,3] is 2/3
+        assert!((result.as_f64().unwrap() - 0.666666).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_covariance_negative() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("covariance(`[1, 2, 3]`, `[3, 2, 1]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!((result.as_f64().unwrap() - (-0.666666)).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_standardize() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("standardize(`[10, 20, 30, 40, 50]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        // Mean is 30, std is ~14.14
+        // First value: (10-30)/14.14 ~ -1.41
+        assert!((arr[0].as_f64().unwrap() - (-1.414)).abs() < 0.01);
+        // Middle value should be 0
+        assert!(arr[2].as_f64().unwrap().abs() < 0.001);
+        // Last value: (50-30)/14.14 ~ 1.41
+        assert!((arr[4].as_f64().unwrap() - 1.414).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_trend_increasing() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("trend(`[1, 2, 3, 5, 8]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "increasing");
+    }
+
+    #[test]
+    fn test_trend_decreasing() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("trend(`[10, 9, 8, 7, 6]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "decreasing");
+    }
+
+    #[test]
+    fn test_trend_stable() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("trend(`[5, 5, 5, 5, 5]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "stable");
+    }
+
+    #[test]
+    fn test_trend_slope() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("trend_slope(`[0, 1, 2, 3, 4]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // Perfect linear increase with slope 1
+        assert!((result.as_f64().unwrap() - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_rate_of_change() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("rate_of_change(`[100, 110, 105]`)")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // 100 -> 110 = 10% increase
+        assert!((arr[0].as_f64().unwrap() - 10.0).abs() < 0.01);
+        // 110 -> 105 = -4.545% decrease
+        assert!((arr[1].as_f64().unwrap() - (-4.545)).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_cumulative_sum() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("cumulative_sum(`[1, 2, 3, 4]`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_f64().unwrap(), 1.0);
+        assert_eq!(arr[1].as_f64().unwrap(), 3.0);
+        assert_eq!(arr[2].as_f64().unwrap(), 6.0);
+        assert_eq!(arr[3].as_f64().unwrap(), 10.0);
+    }
+}

--- a/crates/jpx-core/src/extensions/multi_match.rs
+++ b/crates/jpx-core/src/extensions/multi_match.rs
@@ -386,3 +386,343 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     );
     register_if_enabled(runtime, "split_keep", enabled, Box::new(SplitKeepFn::new()));
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    // match_any tests
+
+    #[test]
+    fn test_match_any_found() {
+        let runtime = setup_runtime();
+        let data = json!("an error occurred in the system");
+        let expr = runtime
+            .compile("match_any(@, ['error', 'warning', 'critical'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_match_any_not_found() {
+        let runtime = setup_runtime();
+        let data = json!("everything is fine");
+        let expr = runtime
+            .compile("match_any(@, ['error', 'warning', 'critical'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_match_any_empty_patterns() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "some text", "patterns": []});
+        let expr = runtime.compile("match_any(text, patterns)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_match_any_multiple_matches() {
+        let runtime = setup_runtime();
+        let data = json!("error and warning detected");
+        let expr = runtime
+            .compile("match_any(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    // match_all tests
+
+    #[test]
+    fn test_match_all_all_found() {
+        let runtime = setup_runtime();
+        let data = json!("error and warning detected");
+        let expr = runtime
+            .compile("match_all(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_match_all_some_missing() {
+        let runtime = setup_runtime();
+        let data = json!("error detected");
+        let expr = runtime
+            .compile("match_all(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_match_all_empty_patterns() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "some text", "patterns": []});
+        let expr = runtime.compile("match_all(text, patterns)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    // match_which tests
+
+    #[test]
+    fn test_match_which_some_found() {
+        let runtime = setup_runtime();
+        let data = json!("error and warning detected");
+        let expr = runtime
+            .compile("match_which(@, ['error', 'warning', 'critical'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let strs: Vec<&str> = arr.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(strs.contains(&"error"));
+        assert!(strs.contains(&"warning"));
+    }
+
+    #[test]
+    fn test_match_which_none_found() {
+        let runtime = setup_runtime();
+        let data = json!("everything is fine");
+        let expr = runtime
+            .compile("match_which(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_match_which_preserves_order() {
+        let runtime = setup_runtime();
+        let data = json!("warning then error");
+        let expr = runtime
+            .compile("match_which(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should return in pattern order, not match order
+        assert_eq!(arr[0].as_str().unwrap(), "error");
+        assert_eq!(arr[1].as_str().unwrap(), "warning");
+    }
+
+    // match_count tests
+
+    #[test]
+    fn test_match_count_multiple() {
+        let runtime = setup_runtime();
+        let data = json!("error error warning error");
+        let expr = runtime
+            .compile("match_count(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_match_count_none() {
+        let runtime = setup_runtime();
+        let data = json!("everything is fine");
+        let expr = runtime
+            .compile("match_count(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_match_count_empty_patterns() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "some text", "patterns": []});
+        let expr = runtime.compile("match_count(text, patterns)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    // replace_many tests
+
+    #[test]
+    fn test_replace_many_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "hello world"});
+        let expr = runtime
+            .compile("replace_many(text, {hello: 'hi', world: 'there'})")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hi there");
+    }
+
+    #[test]
+    fn test_replace_many_no_matches() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "hello world"});
+        let expr = runtime.compile("replace_many(text, {foo: 'bar'})").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_replace_many_empty_replacements() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "hello world", "replacements": {}});
+        let expr = runtime.compile("replace_many(text, replacements)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_replace_many_multiple_occurrences() {
+        let runtime = setup_runtime();
+        let data = json!({"text": "error: connection error"});
+        let expr = runtime
+            .compile("replace_many(text, {error: 'ERROR', connection: 'CONN'})")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "ERROR: CONN ERROR");
+    }
+
+    // extract_all tests
+
+    #[test]
+    fn test_extract_all_basic() {
+        let runtime = setup_runtime();
+        let data = json!("error and warning detected");
+        let expr = runtime
+            .compile("extract_all(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(first.get("match").unwrap().as_str().unwrap(), "error");
+        assert!(first.get("start").is_some());
+        assert!(first.get("end").is_some());
+    }
+
+    #[test]
+    fn test_extract_all_empty() {
+        let runtime = setup_runtime();
+        let data = json!("no matches here");
+        let expr = runtime
+            .compile("extract_all(@, ['error', 'warning'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // match_positions tests
+
+    #[test]
+    fn test_match_positions_basic() {
+        let runtime = setup_runtime();
+        let data = json!("The quick brown fox");
+        let expr = runtime
+            .compile("match_positions(@, ['quick', 'fox'])")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(first.get("pattern").unwrap().as_str().unwrap(), "quick");
+        assert_eq!(first.get("start").unwrap().as_f64().unwrap() as i64, 4);
+        assert_eq!(first.get("end").unwrap().as_f64().unwrap() as i64, 9);
+    }
+
+    // mm_tokenize tests
+    // NOTE: mm_tokenize is registered under that name in code but functions.toml
+    // has it as "tokenize" (multimatch category), so register_if_enabled does not
+    // enable it. These tests are ignored until the naming mismatch is resolved.
+
+    #[test]
+    #[ignore = "mm_tokenize not in functions.toml (listed as tokenize)"]
+    fn test_mm_tokenize_basic() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, world! This is a test.");
+        let expr = runtime.compile("mm_tokenize(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr.len() >= 6);
+        assert_eq!(arr[0].as_str().unwrap(), "Hello");
+    }
+
+    #[test]
+    #[ignore = "mm_tokenize not in functions.toml (listed as tokenize)"]
+    fn test_mm_tokenize_with_options() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, world! A test.");
+        let expr = runtime
+            .compile("mm_tokenize(@, {lowercase: `true`, min_length: `2`})")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // Should have: hello, world, test (not "A" due to min_length)
+        let tokens: Vec<&str> = arr.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(tokens.contains(&"hello"));
+        assert!(tokens.contains(&"world"));
+        assert!(!tokens.iter().any(|t| t.len() < 2));
+    }
+
+    // extract_between tests
+
+    #[test]
+    fn test_extract_between_basic() {
+        let runtime = setup_runtime();
+        let data = json!("<title>Page Title</title>");
+        let expr = runtime
+            .compile("extract_between(@, '<title>', '</title>')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Page Title");
+    }
+
+    #[test]
+    fn test_extract_between_not_found() {
+        let runtime = setup_runtime();
+        let data = json!("no delimiters here");
+        let expr = runtime
+            .compile("extract_between(@, '<start>', '<end>')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    // split_keep tests
+
+    #[test]
+    fn test_split_keep_basic() {
+        let runtime = setup_runtime();
+        let data = json!("a-b-c");
+        let expr = runtime.compile("split_keep(@, '-')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+        assert_eq!(arr[1].as_str().unwrap(), "-");
+        assert_eq!(arr[2].as_str().unwrap(), "b");
+    }
+
+    #[test]
+    fn test_split_keep_no_delimiter() {
+        let runtime = setup_runtime();
+        let data = json!("no delimiters");
+        let expr = runtime.compile("split_keep(@, '-')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_str().unwrap(), "no delimiters");
+    }
+}

--- a/crates/jpx-core/src/extensions/network.rs
+++ b/crates/jpx-core/src/extensions/network.rs
@@ -186,3 +186,119 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(IsPrivateIpFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_ip_to_int() {
+        let runtime = setup_runtime();
+        let data = json!("192.168.1.1");
+        let expr = runtime.compile("ip_to_int(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // 192.168.1.1 = 192*256^3 + 168*256^2 + 1*256 + 1 = 3232235777
+        assert_eq!(result.as_f64().unwrap(), 3232235777.0);
+    }
+
+    #[test]
+    fn test_int_to_ip() {
+        let runtime = setup_runtime();
+        let data = json!(3232235777_u64);
+        let expr = runtime.compile("int_to_ip(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "192.168.1.1");
+    }
+
+    #[test]
+    fn test_ip_roundtrip() {
+        let runtime = setup_runtime();
+        let data = json!("10.0.0.1");
+        let expr = runtime.compile("int_to_ip(ip_to_int(@))").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "10.0.0.1");
+    }
+
+    #[test]
+    fn test_cidr_contains_true() {
+        let runtime = setup_runtime();
+        let data = json!({"cidr": "192.168.1.0/24", "ip": "192.168.1.100"});
+        let expr = runtime.compile("cidr_contains(cidr, ip)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_cidr_contains_false() {
+        let runtime = setup_runtime();
+        let data = json!({"cidr": "192.168.1.0/24", "ip": "192.168.2.1"});
+        let expr = runtime.compile("cidr_contains(cidr, ip)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_cidr_network() {
+        let runtime = setup_runtime();
+        let data = json!("192.168.1.100/24");
+        let expr = runtime.compile("cidr_network(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "192.168.1.0");
+    }
+
+    #[test]
+    fn test_cidr_broadcast() {
+        let runtime = setup_runtime();
+        let data = json!("192.168.1.0/24");
+        let expr = runtime.compile("cidr_broadcast(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "192.168.1.255");
+    }
+
+    #[test]
+    fn test_cidr_prefix() {
+        let runtime = setup_runtime();
+        let data = json!("10.0.0.0/8");
+        let expr = runtime.compile("cidr_prefix(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 8.0);
+    }
+
+    #[test]
+    fn test_is_private_ip_true() {
+        let runtime = setup_runtime();
+        // 192.168.x.x is private
+        let data = json!("192.168.1.1");
+        let expr = runtime.compile("is_private_ip(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_private_ip_10() {
+        let runtime = setup_runtime();
+        // 10.x.x.x is private
+        let data = json!("10.0.0.1");
+        let expr = runtime.compile("is_private_ip(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_private_ip_false() {
+        let runtime = setup_runtime();
+        // 8.8.8.8 is public (Google DNS)
+        let data = json!("8.8.8.8");
+        let expr = runtime.compile("is_private_ip(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+}

--- a/crates/jpx-core/src/extensions/object.rs
+++ b/crates/jpx-core/src/extensions/object.rs
@@ -2687,3 +2687,1437 @@ fn value_to_string(value: &Value) -> String {
         _ => serde_json::to_string(value).unwrap_or_default(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_items() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("items(@)").unwrap();
+        let data = json!({"a": 1, "b": 2});
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // JEP-013: Each item should be a [key, value] pair
+        let first = arr[0].as_array().unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].as_str().unwrap(), "a");
+        assert_eq!(first[1].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_items_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("items(@)").unwrap();
+        let data = json!({});
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_from_items() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("from_items(@)").unwrap();
+        let data = json!([["a", 1], ["b", 2]]);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_from_items_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("from_items(@)").unwrap();
+        let data = json!([]);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_from_items_duplicate_keys() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("from_items(@)").unwrap();
+        let data = json!([["x", 1], ["x", 2]]);
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        // Last value wins
+        assert_eq!(obj.get("x").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_items_from_items_roundtrip() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("from_items(items(@))").unwrap();
+        let data = json!({"a": 1, "b": "hello", "c": true});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 3);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_str().unwrap(), "hello");
+        assert!(obj.get("c").unwrap().as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_with_entries_identity() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[0], @[1]]')").unwrap();
+        let data = json!({"a": 1, "b": 2});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap() as i64, 2);
+    }
+
+    #[test]
+    fn test_with_entries_transform_keys() {
+        // Test that we can transform keys by prepending a prefix
+        // Using join to concatenate strings (built-in)
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile(r#"with_entries(@, '[join(`""`, [`"prefix_"`, @[0]]), @[1]]')"#)
+            .unwrap();
+        let data = json!({"a": 1, "b": 2});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("prefix_a"));
+        assert!(obj.contains_key("prefix_b"));
+    }
+
+    #[test]
+    fn test_with_entries_swap_key_value() {
+        // Test swapping keys and values (for string values)
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[1], @[0]]')").unwrap();
+        let data = json!({"a": "x", "b": "y"});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("x").unwrap().as_str().unwrap(), "a");
+        assert_eq!(obj.get("y").unwrap().as_str().unwrap(), "b");
+    }
+
+    #[test]
+    fn test_with_entries_filter_null() {
+        // Test that returning null from the expression skips entries
+        // This tests the filtering behavior of with_entries
+        let runtime = setup_runtime();
+        // Return null for all entries - result should be empty object
+        let expr = runtime.compile(r#"with_entries(@, '`null`')"#).unwrap();
+        let data = json!({"a": 1, "b": 2});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_with_entries_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("with_entries(@, '[@[0], @[1]]')").unwrap();
+        let data = json!({});
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_pick() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("pick(@, `[\"a\"]`)").unwrap();
+        let data = json!({"a": 1, "b": 2});
+        let result = expr.search(&data).unwrap();
+        let result_obj = result.as_object().unwrap();
+        assert_eq!(result_obj.len(), 1);
+        assert!(result_obj.contains_key("a"));
+    }
+
+    #[test]
+    fn test_deep_equals_objects() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}, "c": {"b": 1}});
+        let expr = runtime.compile("deep_equals(a, c)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_deep_equals_objects_different() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}, "c": {"b": 2}});
+        let expr = runtime.compile("deep_equals(a, c)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_deep_equals_arrays() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, [2, 3]], "b": [1, [2, 3]]});
+        let expr = runtime.compile("deep_equals(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_deep_equals_arrays_order_matters() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, 2], "b": [2, 1]});
+        let expr = runtime.compile("deep_equals(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_deep_equals_primitives() {
+        let runtime = setup_runtime();
+        let data = json!({"a": "hello", "b": "hello", "c": "world"});
+
+        let expr = runtime.compile("deep_equals(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+
+        let expr = runtime.compile("deep_equals(a, c)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_deep_diff_added() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 1, "y": 2}});
+        let expr = runtime.compile("deep_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let diff = result.as_object().unwrap();
+
+        let added = diff.get("added").unwrap().as_object().unwrap();
+        assert!(added.contains_key("y"));
+        assert!(diff.get("removed").unwrap().as_object().unwrap().is_empty());
+        assert!(diff.get("changed").unwrap().as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_deep_diff_removed() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1, "y": 2}, "b": {"x": 1}});
+        let expr = runtime.compile("deep_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let diff = result.as_object().unwrap();
+
+        let removed = diff.get("removed").unwrap().as_object().unwrap();
+        assert!(removed.contains_key("y"));
+        assert!(diff.get("added").unwrap().as_object().unwrap().is_empty());
+        assert!(diff.get("changed").unwrap().as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_deep_diff_changed() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 2}});
+        let expr = runtime.compile("deep_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let diff = result.as_object().unwrap();
+
+        let changed = diff.get("changed").unwrap().as_object().unwrap();
+        assert!(changed.contains_key("x"));
+        let x_change = changed.get("x").unwrap().as_object().unwrap();
+        assert!(x_change.contains_key("from"));
+        assert!(x_change.contains_key("to"));
+    }
+
+    #[test]
+    fn test_deep_diff_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": {"y": 1}}, "b": {"x": {"y": 2}}});
+        let expr = runtime.compile("deep_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let diff = result.as_object().unwrap();
+
+        // The change should be nested under x
+        let changed = diff.get("changed").unwrap().as_object().unwrap();
+        assert!(changed.contains_key("x"));
+    }
+
+    #[test]
+    fn test_deep_diff_no_changes() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 1}});
+        let expr = runtime.compile("deep_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let diff = result.as_object().unwrap();
+
+        assert!(diff.get("added").unwrap().as_object().unwrap().is_empty());
+        assert!(diff.get("removed").unwrap().as_object().unwrap().is_empty());
+        assert!(diff.get("changed").unwrap().as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": {"c": 1}}});
+        let expr = runtime.compile("get(@, 'a.b.c')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_get_with_default() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime.compile("get(@, 'b.c', 'default')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "default");
+    }
+
+    #[test]
+    fn test_get_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [{"b": 1}, {"b": 2}]});
+        let expr = runtime.compile("get(@, 'a[0].b')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_get_missing_returns_null() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime.compile("get(@, 'x.y.z')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_has_exists() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}});
+        let expr = runtime.compile("has(@, 'a.b')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_not_exists() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime.compile("has(@, 'a.b.c')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, 2, 3]});
+        let expr = runtime.compile("has(@, 'a[1]')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_array_index_out_of_bounds() {
+        let runtime = setup_runtime();
+        let data = json!({"a": [1, 2]});
+        let expr = runtime.compile("has(@, 'a[5]')").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_defaults_shallow() {
+        let runtime = setup_runtime();
+        let data = json!({"obj": {"a": 1}, "defs": {"a": 2, "b": 3}});
+        let expr = runtime.compile("defaults(obj, defs)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 1.0); // original kept
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 3.0); // default added
+    }
+
+    #[test]
+    fn test_defaults_empty_object() {
+        let runtime = setup_runtime();
+        let data = json!({"obj": {}, "defs": {"a": 1, "b": 2}});
+        let expr = runtime.compile("defaults(obj, defs)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_defaults_deep_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"obj": {"a": {"b": 1}}, "defs": {"a": {"b": 2, "c": 3}}});
+        let expr = runtime.compile("defaults_deep(obj, defs)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(a.get("b").unwrap().as_f64().unwrap(), 1.0); // original kept
+        assert_eq!(a.get("c").unwrap().as_f64().unwrap(), 3.0); // default added
+    }
+
+    #[test]
+    fn test_defaults_deep_new_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"obj": {"x": 1}, "defs": {"x": 2, "y": {"z": 3}}});
+        let expr = runtime.compile("defaults_deep(obj, defs)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("x").unwrap().as_f64().unwrap(), 1.0); // original kept
+        let y = obj.get("y").unwrap().as_object().unwrap();
+        assert_eq!(y.get("z").unwrap().as_f64().unwrap(), 3.0); // default added
+    }
+
+    #[test]
+    fn test_set_path_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": 2});
+        let expr = runtime.compile("set_path(@, '/c', `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 2.0);
+        assert_eq!(obj.get("c").unwrap().as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_set_path_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}});
+        let expr = runtime.compile("set_path(@, '/a/c', `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(a.get("b").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(a.get("c").unwrap().as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_set_path_create_nested() {
+        let runtime = setup_runtime();
+        let data = json!({});
+        let expr = runtime
+            .compile("set_path(@, '/a/b/c', `\"deep\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        let b = a.get("b").unwrap().as_object().unwrap();
+        assert_eq!(b.get("c").unwrap().as_str().unwrap(), "deep");
+    }
+
+    #[test]
+    fn test_set_path_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2, 3]});
+        let expr = runtime.compile("set_path(@, '/items/1', `99`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let items = obj.get("items").unwrap().as_array().unwrap();
+        assert_eq!(items[0].as_f64().unwrap(), 1.0);
+        assert_eq!(items[1].as_f64().unwrap(), 99.0);
+        assert_eq!(items[2].as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_delete_path_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": 2, "c": 3});
+        let expr = runtime.compile("delete_path(@, '/b')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("a"));
+        assert!(obj.contains_key("c"));
+        assert!(!obj.contains_key("b"));
+    }
+
+    #[test]
+    fn test_delete_path_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1, "c": 2}});
+        let expr = runtime.compile("delete_path(@, '/a/b')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(a.len(), 1);
+        assert!(a.contains_key("c"));
+        assert!(!a.contains_key("b"));
+    }
+
+    #[test]
+    fn test_delete_path_array() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2, 3]});
+        let expr = runtime.compile("delete_path(@, '/items/1')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let items = obj.get("items").unwrap().as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].as_f64().unwrap(), 1.0);
+        assert_eq!(items[1].as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_paths_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}, "c": 2});
+        let expr = runtime.compile("paths(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let paths = result.as_array().unwrap();
+        assert!(paths.len() >= 3); // /a, /a/b, /c
+    }
+
+    #[test]
+    fn test_paths_with_array() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2]});
+        let expr = runtime.compile("paths(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let paths: Vec<String> = result
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|p| p.as_str().unwrap().to_string())
+            .collect();
+        assert!(paths.contains(&"/items".to_string()));
+        assert!(paths.contains(&"/items/0".to_string()));
+        assert!(paths.contains(&"/items/1".to_string()));
+    }
+
+    #[test]
+    fn test_leaves_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": {"c": 2}, "d": [3, 4]});
+        let expr = runtime.compile("leaves(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let leaves = result.as_array().unwrap();
+        assert_eq!(leaves.len(), 4); // 1, 2, 3, 4
+    }
+
+    #[test]
+    fn test_leaves_strings() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "tags": ["a", "b"]});
+        let expr = runtime.compile("leaves(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let leaves = result.as_array().unwrap();
+        assert_eq!(leaves.len(), 3); // "alice", "a", "b"
+    }
+
+    #[test]
+    fn test_leaves_with_paths_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": {"c": 2}});
+        let expr = runtime.compile("leaves_with_paths(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let leaves = result.as_array().unwrap();
+        assert_eq!(leaves.len(), 2);
+        // Each leaf should have path and value
+        let first = leaves[0].as_object().unwrap();
+        assert!(first.contains_key("path"));
+        assert!(first.contains_key("value"));
+    }
+
+    #[test]
+    fn test_set_path_immutable() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime.compile("set_path(@, '/b', `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Original should be unchanged (immutable semantics)
+        let original = data.as_object().unwrap();
+        assert!(!original.contains_key("b"));
+        // Result should have the new key
+        let new_obj = result.as_object().unwrap();
+        assert!(new_obj.contains_key("b"));
+    }
+
+    // =========================================================================
+    // Dot notation path tests (for set_path, delete_path, get_path, has_path)
+    // =========================================================================
+
+    #[test]
+    fn test_set_path_dot_notation() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"c": 1}});
+        let expr = runtime.compile("set_path(@, `\"a.b\"`, `99`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let nested = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(nested.get("b").unwrap().as_f64().unwrap() as i64, 99);
+        assert_eq!(nested.get("c").unwrap().as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_set_path_dot_notation_deep() {
+        let runtime = setup_runtime();
+        let data = json!({});
+        let expr = runtime
+            .compile("set_path(@, `\"a.b.c\"`, `\"deep\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let a = obj.get("a").unwrap().as_object().unwrap();
+        let b = a.get("b").unwrap().as_object().unwrap();
+        assert_eq!(b.get("c").unwrap().as_str().unwrap(), "deep");
+    }
+
+    #[test]
+    fn test_set_path_dot_notation_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2, 3]});
+        let expr = runtime.compile("set_path(@, `\"items.1\"`, `99`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let items = obj.get("items").unwrap().as_array().unwrap();
+        assert_eq!(items[1].as_f64().unwrap() as i64, 99);
+    }
+
+    #[test]
+    fn test_delete_path_dot_notation() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1, "c": 2}});
+        let expr = runtime.compile("delete_path(@, `\"a.b\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let nested = obj.get("a").unwrap().as_object().unwrap();
+        assert!(!nested.contains_key("b"));
+        assert!(nested.contains_key("c"));
+    }
+
+    #[test]
+    fn test_delete_path_dot_notation_array() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2, 3]});
+        let expr = runtime.compile("delete_path(@, `\"items.1\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let items = obj.get("items").unwrap().as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].as_f64().unwrap() as i64, 1);
+        assert_eq!(items[1].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_get_path_alias() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": {"c": 42}}});
+        let expr = runtime.compile("get_path(@, `\"a.b.c\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 42);
+    }
+
+    #[test]
+    fn test_get_path_with_default() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime
+            .compile("get_path(@, `\"a.b.c\"`, `\"default\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "default");
+    }
+
+    #[test]
+    fn test_get_path_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"users": [{"name": "alice"}, {"name": "bob"}]});
+        let expr = runtime.compile("get_path(@, `\"users.0.name\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "alice");
+    }
+
+    #[test]
+    fn test_get_path_array_index_out_of_bounds() {
+        let runtime = setup_runtime();
+        let data = json!({"users": [{"name": "alice"}]});
+        let expr = runtime
+            .compile("get_path(@, `\"users.5.name\"`, `\"unknown\"`)")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "unknown");
+    }
+
+    #[test]
+    fn test_has_path_alias() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}});
+        let expr = runtime.compile("has_path(@, `\"a.b\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_path_missing() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": 1}});
+        let expr = runtime.compile("has_path(@, `\"a.c\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_path_array_index() {
+        let runtime = setup_runtime();
+        let data = json!({"items": [1, 2, 3]});
+        let expr = runtime.compile("has_path(@, `\"items.1\"`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // remove_nulls tests
+    // =========================================================================
+
+    #[test]
+    fn test_remove_nulls_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": null, "c": 2});
+        let expr = runtime.compile("remove_nulls(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("a"));
+        assert!(obj.contains_key("c"));
+        assert!(!obj.contains_key("b"));
+    }
+
+    #[test]
+    fn test_remove_nulls_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": {"c": null, "d": 2}});
+        let expr = runtime.compile("remove_nulls(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let nested = obj.get("b").unwrap().as_object().unwrap();
+        assert_eq!(nested.len(), 1);
+        assert!(nested.contains_key("d"));
+        assert!(!nested.contains_key("c"));
+    }
+
+    #[test]
+    fn test_remove_nulls_array() {
+        let runtime = setup_runtime();
+        let data = json!([1, null, 2, null, 3]);
+        let expr = runtime.compile("remove_nulls(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    // =========================================================================
+    // remove_empty tests
+    // =========================================================================
+
+    #[test]
+    fn test_remove_empty_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": "", "b": [], "c": {}, "d": null, "e": "hello"});
+        let expr = runtime.compile("remove_empty(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key("e"));
+    }
+
+    #[test]
+    fn test_remove_empty_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": "", "c": 1}, "d": []});
+        let expr = runtime.compile("remove_empty(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        let nested = obj.get("a").unwrap().as_object().unwrap();
+        assert_eq!(nested.len(), 1);
+        assert!(nested.contains_key("c"));
+    }
+
+    #[test]
+    fn test_remove_empty_array() {
+        let runtime = setup_runtime();
+        let data = json!(["", "hello", [], null, "world"]);
+        let expr = runtime.compile("remove_empty(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    // =========================================================================
+    // remove_empty_strings tests
+    // =========================================================================
+
+    #[test]
+    fn test_remove_empty_strings_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "bio": "", "age": 30});
+        let expr = runtime.compile("remove_empty_strings(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("age"));
+        assert!(!obj.contains_key("bio"));
+    }
+
+    #[test]
+    fn test_remove_empty_strings_array() {
+        let runtime = setup_runtime();
+        let data = json!(["hello", "", "world", ""]);
+        let expr = runtime.compile("remove_empty_strings(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    // =========================================================================
+    // compact_deep tests
+    // =========================================================================
+
+    #[test]
+    fn test_compact_deep_basic() {
+        let runtime = setup_runtime();
+        let data = json!([[1, null], [null, 2]]);
+        let expr = runtime.compile("compact_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let first = arr[0].as_array().unwrap();
+        assert_eq!(first.len(), 1);
+        let second = arr[1].as_array().unwrap();
+        assert_eq!(second.len(), 1);
+    }
+
+    #[test]
+    fn test_compact_deep_nested() {
+        let runtime = setup_runtime();
+        let data = json!([[1, null], [null, [2, null, 3]]]);
+        let expr = runtime.compile("compact_deep(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let second = arr[1].as_array().unwrap();
+        let inner = second[0].as_array().unwrap();
+        assert_eq!(inner.len(), 2); // [2, 3]
+    }
+
+    // =========================================================================
+    // completeness tests
+    // =========================================================================
+
+    #[test]
+    fn test_completeness_all_filled() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": "hello", "c": true});
+        let expr = runtime.compile("completeness(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let score = result.as_f64().unwrap();
+        assert_eq!(score, 100.0);
+    }
+
+    #[test]
+    fn test_completeness_with_nulls() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": null, "c": null});
+        let expr = runtime.compile("completeness(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let score = result.as_f64().unwrap();
+        // 1 out of 3 fields is non-null = 33.33%
+        assert!((score - 33.33).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_completeness_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": {"c": null, "d": 2}, "e": null});
+        let expr = runtime.compile("completeness(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let score = result.as_f64().unwrap();
+        // 5 total fields: a(1), b(obj), b.c(null), b.d(2), e(null)
+        // 3 non-null: a, b, b.d
+        // 3/5 = 60%
+        assert!((score - 60.0).abs() < 1.0);
+    }
+
+    // =========================================================================
+    // type_consistency tests
+    // =========================================================================
+
+    #[test]
+    fn test_type_consistency_consistent() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("type_consistency(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.get("consistent").unwrap().as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_type_consistency_inconsistent() {
+        let runtime = setup_runtime();
+        let data = json!([1, "two", 3]);
+        let expr = runtime.compile("type_consistency(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(!obj.get("consistent").unwrap().as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_type_consistency_object_array() {
+        let runtime = setup_runtime();
+        let data = json!([{"name": "alice", "age": 30}, {"name": "bob", "age": "unknown"}]);
+        let expr = runtime.compile("type_consistency(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(!obj.get("consistent").unwrap().as_bool().unwrap());
+        let inconsistencies = obj.get("inconsistencies").unwrap().as_array().unwrap();
+        assert_eq!(inconsistencies.len(), 1);
+    }
+
+    // =========================================================================
+    // data_quality_score tests
+    // =========================================================================
+
+    #[test]
+    fn test_data_quality_score_perfect() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": "hello"});
+        let expr = runtime.compile("data_quality_score(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let score = obj.get("score").unwrap().as_f64().unwrap();
+        assert_eq!(score, 100.0);
+        assert_eq!(obj.get("null_count").unwrap().as_f64().unwrap() as i64, 0);
+    }
+
+    #[test]
+    fn test_data_quality_score_with_issues() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1, "b": null, "c": ""});
+        let expr = runtime.compile("data_quality_score(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("null_count").unwrap().as_f64().unwrap() as i64, 1);
+        assert_eq!(
+            obj.get("empty_string_count").unwrap().as_f64().unwrap() as i64,
+            1
+        );
+        let issues = obj.get("issues").unwrap().as_array().unwrap();
+        assert_eq!(issues.len(), 2);
+    }
+
+    #[test]
+    fn test_data_quality_score_type_mismatch() {
+        let runtime = setup_runtime();
+        let data = json!({"users": [{"age": 30}, {"age": "thirty"}]});
+        let expr = runtime.compile("data_quality_score(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("type_inconsistencies").unwrap().as_f64().unwrap() as i64,
+            1
+        );
+    }
+
+    // =========================================================================
+    // redact tests
+    // =========================================================================
+
+    #[test]
+    fn test_redact_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "password": "secret123", "ssn": "123-45-6789"});
+        let expr = runtime
+            .compile(r#"redact(@, `["password", "ssn"]`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "alice");
+        assert_eq!(obj.get("password").unwrap().as_str().unwrap(), "[REDACTED]");
+        assert_eq!(obj.get("ssn").unwrap().as_str().unwrap(), "[REDACTED]");
+    }
+
+    #[test]
+    fn test_redact_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"user": {"name": "bob", "password": "secret"}});
+        let expr = runtime.compile(r#"redact(@, `["password"]`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let user = obj.get("user").unwrap().as_object().unwrap();
+        assert_eq!(user.get("name").unwrap().as_str().unwrap(), "bob");
+        assert_eq!(
+            user.get("password").unwrap().as_str().unwrap(),
+            "[REDACTED]"
+        );
+    }
+
+    #[test]
+    fn test_redact_array_of_objects() {
+        let runtime = setup_runtime();
+        let data = json!([
+            {"name": "alice", "token": "abc"},
+            {"name": "bob", "token": "xyz"}
+        ]);
+        let expr = runtime.compile(r#"redact(@, `["token"]`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        let first = arr[0].as_object().unwrap();
+        assert_eq!(first.get("token").unwrap().as_str().unwrap(), "[REDACTED]");
+    }
+
+    // =========================================================================
+    // mask tests
+    // =========================================================================
+
+    #[test]
+    fn test_mask_default() {
+        let runtime = setup_runtime();
+        let data = json!("4111111111111111");
+        let expr = runtime.compile("mask(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "************1111");
+    }
+
+    #[test]
+    fn test_mask_custom_length() {
+        let runtime = setup_runtime();
+        let data = json!("555-123-4567");
+        let expr = runtime.compile("mask(@, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "*********567");
+    }
+
+    #[test]
+    fn test_mask_short_string() {
+        let runtime = setup_runtime();
+        let data = json!("abc");
+        let expr = runtime.compile("mask(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // If string is shorter than show_last, mask everything
+        assert_eq!(result.as_str().unwrap(), "***");
+    }
+
+    // =========================================================================
+    // redact_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_redact_keys_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"password": "secret", "api_key": "abc123", "name": "test"});
+        let expr = runtime
+            .compile(r#"redact_keys(@, `"password|api_key"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("password").unwrap().as_str().unwrap(), "[REDACTED]");
+        assert_eq!(obj.get("api_key").unwrap().as_str().unwrap(), "[REDACTED]");
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_redact_keys_pattern() {
+        let runtime = setup_runtime();
+        let data = json!({"secret_key": "a", "secret_token": "b", "name": "test"});
+        let expr = runtime.compile(r#"redact_keys(@, `"secret.*"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("secret_key").unwrap().as_str().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(
+            obj.get("secret_token").unwrap().as_str().unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "test");
+    }
+
+    // =========================================================================
+    // pluck_deep tests
+    // =========================================================================
+
+    #[test]
+    fn test_pluck_deep_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"users": [{"id": 1}, {"id": 2}], "meta": {"id": 99}});
+        let expr = runtime.compile(r#"pluck_deep(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_pluck_deep_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"b": {"c": 1}}, "d": {"c": 2}});
+        let expr = runtime.compile(r#"pluck_deep(@, `"c"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_pluck_deep_not_found() {
+        let runtime = setup_runtime();
+        let data = json!({"a": 1});
+        let expr = runtime.compile(r#"pluck_deep(@, `"x"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // paths_to tests
+    // =========================================================================
+
+    #[test]
+    fn test_paths_to_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"id": 1}, "b": {"id": 2}});
+        let expr = runtime.compile(r#"paths_to(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let paths: Vec<String> = arr
+            .iter()
+            .map(|p| p.as_str().unwrap().to_string())
+            .collect();
+        assert!(paths.contains(&"a.id".to_string()));
+        assert!(paths.contains(&"b.id".to_string()));
+    }
+
+    #[test]
+    fn test_paths_to_array() {
+        let runtime = setup_runtime();
+        let data = json!({"users": [{"id": 1}]});
+        let expr = runtime.compile(r#"paths_to(@, `"id"`)"#).unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_str().unwrap(), "users.0.id");
+    }
+
+    // =========================================================================
+    // snake_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_snake_keys_camel() {
+        let runtime = setup_runtime();
+        let data = json!({"userName": "alice"});
+        let expr = runtime.compile("snake_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("user_name"));
+        assert_eq!(obj.get("user_name").unwrap().as_str().unwrap(), "alice");
+    }
+
+    #[test]
+    fn test_snake_keys_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"userInfo": {"firstName": "bob"}});
+        let expr = runtime.compile("snake_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("user_info"));
+        let nested = obj.get("user_info").unwrap().as_object().unwrap();
+        assert!(nested.contains_key("first_name"));
+    }
+
+    // =========================================================================
+    // camel_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_camel_keys_snake() {
+        let runtime = setup_runtime();
+        let data = json!({"user_name": "alice"});
+        let expr = runtime.compile("camel_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("userName"));
+        assert_eq!(obj.get("userName").unwrap().as_str().unwrap(), "alice");
+    }
+
+    #[test]
+    fn test_camel_keys_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"user_info": {"first_name": "bob"}});
+        let expr = runtime.compile("camel_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("userInfo"));
+        let nested = obj.get("userInfo").unwrap().as_object().unwrap();
+        assert!(nested.contains_key("firstName"));
+    }
+
+    // =========================================================================
+    // kebab_keys tests
+    // =========================================================================
+
+    #[test]
+    fn test_kebab_keys_camel() {
+        let runtime = setup_runtime();
+        let data = json!({"userName": "alice"});
+        let expr = runtime.compile("kebab_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("user-name"));
+        assert_eq!(obj.get("user-name").unwrap().as_str().unwrap(), "alice");
+    }
+
+    #[test]
+    fn test_kebab_keys_snake() {
+        let runtime = setup_runtime();
+        let data = json!({"user_name": "bob"});
+        let expr = runtime.compile("kebab_keys(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("user-name"));
+        assert_eq!(obj.get("user-name").unwrap().as_str().unwrap(), "bob");
+    }
+
+    // =========================================================================
+    // structural_diff tests
+    // =========================================================================
+
+    #[test]
+    fn test_structural_diff_added() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 1, "y": 2}});
+        let expr = runtime.compile("structural_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let added = obj.get("added").unwrap().as_array().unwrap();
+        assert_eq!(added.len(), 1);
+        assert_eq!(added[0].as_str().unwrap(), "y");
+    }
+
+    #[test]
+    fn test_structural_diff_removed() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1, "y": 2}, "b": {"x": 1}});
+        let expr = runtime.compile("structural_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let removed = obj.get("removed").unwrap().as_array().unwrap();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].as_str().unwrap(), "y");
+    }
+
+    #[test]
+    fn test_structural_diff_type_changed() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": "string"}});
+        let expr = runtime.compile("structural_diff(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        let type_changed = obj.get("type_changed").unwrap().as_array().unwrap();
+        assert_eq!(type_changed.len(), 1);
+    }
+
+    #[test]
+    fn test_has_same_shape_true() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"x": 2}});
+        let expr = runtime.compile("has_same_shape(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_has_same_shape_false() {
+        let runtime = setup_runtime();
+        let data = json!({"a": {"x": 1}, "b": {"y": 2}});
+        let expr = runtime.compile("has_same_shape(a, b)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // infer_schema tests
+    // =========================================================================
+
+    #[test]
+    fn test_infer_schema_object() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "age": 30});
+        let expr = runtime.compile("infer_schema(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let schema = result.as_object().unwrap();
+        assert_eq!(schema.get("type").unwrap().as_str().unwrap(), "object");
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("name"));
+        assert!(props.contains_key("age"));
+    }
+
+    #[test]
+    fn test_infer_schema_array() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("infer_schema(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let schema = result.as_object().unwrap();
+        assert_eq!(schema.get("type").unwrap().as_str().unwrap(), "array");
+        let items = schema.get("items").unwrap().as_object().unwrap();
+        assert_eq!(items.get("type").unwrap().as_str().unwrap(), "number");
+    }
+
+    // =========================================================================
+    // chunk_by_size tests
+    // =========================================================================
+
+    #[test]
+    fn test_chunk_by_size() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("chunk_by_size(@, `10`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let chunks = result.as_array().unwrap();
+        assert!(chunks.len() > 1); // Should be split into multiple chunks
+    }
+
+    // =========================================================================
+    // paginate tests
+    // =========================================================================
+
+    #[test]
+    fn test_paginate() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let expr = runtime.compile("paginate(@, `2`, `3`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+
+        let page_data = obj.get("data").unwrap().as_array().unwrap();
+        assert_eq!(page_data.len(), 3);
+        assert_eq!(page_data[0].as_f64().unwrap() as i64, 4); // Page 2 starts at index 3
+
+        assert_eq!(obj.get("page").unwrap().as_f64().unwrap() as i64, 2);
+        assert_eq!(obj.get("total").unwrap().as_f64().unwrap() as i64, 10);
+        assert_eq!(obj.get("total_pages").unwrap().as_f64().unwrap() as i64, 4);
+        assert!(obj.get("has_next").unwrap().as_bool().unwrap());
+        assert!(obj.get("has_prev").unwrap().as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // estimate_size tests
+    // =========================================================================
+
+    #[test]
+    fn test_estimate_size() {
+        let runtime = setup_runtime();
+        let data = json!({"hello": "world"});
+        let expr = runtime.compile("estimate_size(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let size = result.as_f64().unwrap() as i64;
+        assert!(size > 0);
+    }
+
+    // =========================================================================
+    // truncate_to_size tests
+    // =========================================================================
+
+    #[test]
+    fn test_truncate_to_size_array() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3, 4, 5]);
+        let expr = runtime.compile("truncate_to_size(@, `5`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert!(arr.len() < 5); // Should be truncated
+    }
+
+    // =========================================================================
+    // template tests
+    // =========================================================================
+
+    #[test]
+    fn test_template_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice", "age": 30});
+        let expr = runtime
+            .compile(r#"template(@, `"Hello {{name}}, you are {{age}} years old"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result.as_str().unwrap(),
+            "Hello alice, you are 30 years old"
+        );
+    }
+
+    #[test]
+    fn test_template_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"user": {"name": "bob"}});
+        let expr = runtime
+            .compile(r#"template(@, `"Welcome {{user.name}}!"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Welcome bob!");
+    }
+
+    #[test]
+    fn test_template_missing_default() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice"});
+        let expr = runtime
+            .compile(r#"template(@, `"{{name}} - {{title}}"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "alice - ");
+    }
+
+    #[test]
+    fn test_template_fallback() {
+        let runtime = setup_runtime();
+        let data = json!({});
+        let expr = runtime
+            .compile(r#"template(@, `"Hello {{name|Guest}}"`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Hello Guest");
+    }
+
+    #[test]
+    fn test_template_null_template_error() {
+        let runtime = setup_runtime();
+        let data = json!({"name": "alice"});
+        // Simulate what happens when user forgets backticks - the template string
+        // evaluates as a field reference which returns null
+        let expr = runtime.compile(r#"template(@, missing_field)"#).unwrap();
+        let result = expr.search(&data);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("second argument is null"),
+            "Error should mention null argument: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("backticks"),
+            "Error should mention backticks: {}",
+            err_msg
+        );
+    }
+}

--- a/crates/jpx-core/src/extensions/path.rs
+++ b/crates/jpx-core/src/extensions/path.rs
@@ -102,3 +102,43 @@ impl Function for PathJoinFn {
         Ok(Value::String(result))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_path_basename() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_basename(@)").unwrap();
+        let data = json!("/path/to/file.txt");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "file.txt");
+    }
+
+    #[test]
+    fn test_path_dirname() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_dirname(@)").unwrap();
+        let data = json!("/path/to/file.txt");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "/path/to");
+    }
+
+    #[test]
+    fn test_path_ext() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_ext(@)").unwrap();
+        let data = json!("/path/to/file.txt");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), ".txt");
+    }
+}

--- a/crates/jpx-core/src/extensions/phonetic.rs
+++ b/crates/jpx-core/src/extensions/phonetic.rs
@@ -263,3 +263,142 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(PhoneticMatchFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_soundex() {
+        let runtime = setup_runtime();
+        let data = json!("Robert");
+        let expr = runtime.compile("soundex(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "R163");
+    }
+
+    #[test]
+    fn test_soundex_similar_names() {
+        let runtime = setup_runtime();
+        // Robert and Rupert should have the same Soundex code
+        let data = json!("Rupert");
+        let expr = runtime.compile("soundex(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "R163");
+    }
+
+    #[test]
+    fn test_metaphone() {
+        let runtime = setup_runtime();
+        let data = json!("Smith");
+        let expr = runtime.compile("metaphone(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "SM0");
+    }
+
+    #[test]
+    fn test_double_metaphone() {
+        let runtime = setup_runtime();
+        let data = json!("Schmidt");
+        let expr = runtime.compile("double_metaphone(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Primary encoding
+        assert!(!arr[0].as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_nysiis() {
+        let runtime = setup_runtime();
+        let data = json!("Johnson");
+        let expr = runtime.compile("nysiis(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_match_rating_codex() {
+        let runtime = setup_runtime();
+        let data = json!("Smith");
+        let expr = runtime.compile("match_rating_codex(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_caverphone() {
+        let runtime = setup_runtime();
+        let data = json!("Thompson");
+        let expr = runtime.compile("caverphone(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_caverphone2() {
+        let runtime = setup_runtime();
+        let data = json!("Thompson");
+        let expr = runtime.compile("caverphone2(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_str().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_sounds_like_true() {
+        let runtime = setup_runtime();
+        let data = json!(["Robert", "Rupert"]);
+        let expr = runtime.compile("sounds_like(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_sounds_like_false() {
+        let runtime = setup_runtime();
+        let data = json!(["Robert", "Smith"]);
+        let expr = runtime.compile("sounds_like(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_phonetic_match_default() {
+        let runtime = setup_runtime();
+        let data = json!(["Robert", "Rupert"]);
+        let expr = runtime.compile("phonetic_match(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_phonetic_match_metaphone() {
+        let runtime = setup_runtime();
+        let data = json!(["Smith", "Smyth"]);
+        let expr = runtime
+            .compile("phonetic_match(@[0], @[1], 'metaphone')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        // Both should encode to SM0
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_phonetic_match_nysiis() {
+        let runtime = setup_runtime();
+        let data = json!(["Johnson", "Jonson"]);
+        let expr = runtime
+            .compile("phonetic_match(@[0], @[1], 'nysiis')")
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+}

--- a/crates/jpx-core/src/extensions/random.rs
+++ b/crates/jpx-core/src/extensions/random.rs
@@ -189,3 +189,45 @@ impl Function for UuidFn {
         Ok(Value::String(id.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_random() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("random()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let value = result.as_f64().unwrap();
+        assert!((0.0..1.0).contains(&value));
+    }
+
+    #[test]
+    fn test_shuffle() {
+        let runtime = setup_runtime();
+        let data = json!([1, 2, 3]);
+        let expr = runtime.compile("shuffle(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn test_uuid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("uuid()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let uuid_str = result.as_str().unwrap();
+        // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        assert_eq!(uuid_str.len(), 36);
+    }
+}

--- a/crates/jpx-core/src/extensions/regex_fns.rs
+++ b/crates/jpx-core/src/extensions/regex_fns.rs
@@ -112,3 +112,51 @@ impl Function for RegexReplaceFn {
         Ok(Value::String(result.into_owned()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_regex_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_match(@, '^hello')").unwrap();
+
+        let data = json!("hello world");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("world hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_regex_extract() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_extract(@, '[0-9]+')").unwrap();
+        let data = json!("abc123def456");
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "123");
+        assert_eq!(arr[1].as_str().unwrap(), "456");
+    }
+
+    #[test]
+    fn test_regex_replace() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_replace(@, '[0-9]+', 'X')").unwrap();
+        let data = json!("abc123def456");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "abcXdefX");
+    }
+}

--- a/crates/jpx-core/src/extensions/semver_fns.rs
+++ b/crates/jpx-core/src/extensions/semver_fns.rs
@@ -219,3 +219,138 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(SemverIsValidFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_semver_parse() {
+        let runtime = setup_runtime();
+        let data = json!("1.2.3");
+        let expr = runtime.compile("semver_parse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("major").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(obj.get("minor").unwrap().as_f64().unwrap(), 2.0);
+        assert_eq!(obj.get("patch").unwrap().as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_semver_parse_with_pre() {
+        let runtime = setup_runtime();
+        let data = json!("1.0.0-alpha.1");
+        let expr = runtime.compile("semver_parse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("major").unwrap().as_f64().unwrap(), 1.0);
+        assert_eq!(obj.get("pre").unwrap().as_str().unwrap(), "alpha.1");
+    }
+
+    #[test]
+    fn test_semver_major() {
+        let runtime = setup_runtime();
+        let data = json!("2.3.4");
+        let expr = runtime.compile("semver_major(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_semver_minor() {
+        let runtime = setup_runtime();
+        let data = json!("2.3.4");
+        let expr = runtime.compile("semver_minor(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_semver_patch_fn() {
+        let runtime = setup_runtime();
+        let data = json!("2.3.4");
+        let expr = runtime.compile("semver_patch(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 4.0);
+    }
+
+    #[test]
+    fn test_semver_compare_less() {
+        let runtime = setup_runtime();
+        let data = json!(["1.0.0", "2.0.0"]);
+        let expr = runtime.compile("semver_compare(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), -1.0);
+    }
+
+    #[test]
+    fn test_semver_compare_equal() {
+        let runtime = setup_runtime();
+        let data = json!(["1.0.0", "1.0.0"]);
+        let expr = runtime.compile("semver_compare(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_semver_compare_greater() {
+        let runtime = setup_runtime();
+        let data = json!(["2.0.0", "1.0.0"]);
+        let expr = runtime.compile("semver_compare(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_semver_satisfies_true() {
+        let runtime = setup_runtime();
+        let data = json!(["1.2.3", "^1.0.0"]);
+        let expr = runtime.compile("semver_satisfies(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_semver_satisfies_false() {
+        let runtime = setup_runtime();
+        let data = json!(["2.0.0", "^1.0.0"]);
+        let expr = runtime.compile("semver_satisfies(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_semver_satisfies_tilde() {
+        let runtime = setup_runtime();
+        let data = json!(["1.2.5", "~1.2.0"]);
+        let expr = runtime.compile("semver_satisfies(@[0], @[1])").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_semver_is_valid_true() {
+        let runtime = setup_runtime();
+        let data = json!("1.2.3");
+        let expr = runtime.compile("semver_is_valid(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_semver_is_valid_false() {
+        let runtime = setup_runtime();
+        let data = json!("not-a-version");
+        let expr = runtime.compile("semver_is_valid(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+}

--- a/crates/jpx-core/src/extensions/string.rs
+++ b/crates/jpx-core/src/extensions/string.rs
@@ -1875,3 +1875,613 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(ShellEscapeFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_lower() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("lower(@)").unwrap();
+        let result = expr.search(&json!("HELLO")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_upper() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("upper(@)").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "HELLO");
+    }
+
+    #[test]
+    fn test_trim() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("trim(@)").unwrap();
+        let result = expr.search(&json!("  hello  ")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_split() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("split(@, ',')").unwrap();
+        let result = expr.search(&json!("a,b,c")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "a");
+    }
+
+    #[test]
+    fn test_camel_case() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("camel_case(@)").unwrap();
+        let result = expr.search(&json!("hello_world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "helloWorld");
+    }
+
+    #[test]
+    fn test_snake_case() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("snake_case(@)").unwrap();
+        let result = expr.search(&json!("helloWorld")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello_world");
+    }
+
+    #[test]
+    fn test_wrap_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("wrap(@, `5`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello\nworld");
+    }
+
+    #[test]
+    fn test_wrap_preserves_newlines() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("wrap(@, `100`)").unwrap();
+        let result = expr.search(&json!("hello\nworld")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello\nworld");
+    }
+
+    #[test]
+    fn test_wrap_wide_width() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("wrap(@, `100`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_ltrimstr() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("ltrimstr(@, 'hello ')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "world");
+    }
+
+    #[test]
+    fn test_ltrimstr_no_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("ltrimstr(@, 'foo')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_rtrimstr() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("rtrimstr(@, ' world')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_rtrimstr_no_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("rtrimstr(@, 'foo')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_indices() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("indices(@, 'l')").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 2);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 3);
+    }
+
+    #[test]
+    fn test_indices_no_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("indices(@, 'x')").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_indices_overlapping() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("indices(@, 'aa')").unwrap();
+        let result = expr.search(&json!("aaa")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 0);
+        assert_eq!(arr[1].as_f64().unwrap() as i64, 1);
+    }
+
+    #[test]
+    fn test_inside() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("inside('world', @)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_inside_not_found() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("inside('foo', @)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_sprintf_string() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('Hello, %s!', @)").unwrap();
+        let result = expr.search(&json!("World")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Hello, World!");
+    }
+
+    #[test]
+    fn test_sprintf_integer() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('%d + %d = %d', @)").unwrap();
+        let data = json!([1, 2, 3]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1 + 2 = 3");
+    }
+
+    #[test]
+    #[allow(clippy::approx_constant)]
+    fn test_sprintf_float_precision() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('Pi is %.2f', @)").unwrap();
+        let data = json!(3.14159);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Pi is 3.14");
+    }
+
+    #[test]
+    fn test_sprintf_hex() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('Hex: %x', @)").unwrap();
+        let data = json!(255);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Hex: ff");
+    }
+
+    #[test]
+    fn test_sprintf_width() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('%10s', @)").unwrap();
+        let result = expr.search(&json!("hi")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "        hi");
+    }
+
+    #[test]
+    fn test_sprintf_escaped_percent() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("sprintf('100%% done', @)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "100% done");
+    }
+
+    // JEP-014 find_first tests
+    #[test]
+    fn test_find_first_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_first(@, 'world')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 6);
+    }
+
+    #[test]
+    fn test_find_first_not_found() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_first(@, 'xyz')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_find_first_with_start() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_first(@, 'o', `5`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 7);
+    }
+
+    #[test]
+    fn test_find_first_with_start_and_end() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_first(@, 'o', `0`, `5`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 4);
+    }
+
+    #[test]
+    fn test_find_first_with_negative_start() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_first(@, 'o', `-5`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 7);
+    }
+
+    // JEP-014 find_last tests
+    #[test]
+    fn test_find_last_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_last(@, 'o')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 7);
+    }
+
+    #[test]
+    fn test_find_last_not_found() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_last(@, 'xyz')").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_find_last_with_start_and_end() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_last(@, 'o', `0`, `6`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 4);
+    }
+
+    #[test]
+    fn test_find_last_with_negative_end() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_last(@, 'l', `0`, `-1`)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_f64().unwrap() as i64, 9);
+    }
+
+    // =========================================================================
+    // mask tests
+    // Note: In jpx-core the object module's mask (with default show_last=4)
+    // takes precedence over the string module's mask.
+    // =========================================================================
+
+    #[test]
+    fn test_mask_default() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("mask(@)").unwrap();
+        // Default shows last 4; "secret" (6 chars) -> mask 2, show 4
+        let result = expr.search(&json!("secret")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "**cret");
+    }
+
+    #[test]
+    fn test_mask_keep_last_4() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("mask(@, `4`)").unwrap();
+        let result = expr.search(&json!("4111111111111111")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "************1111");
+    }
+
+    #[test]
+    fn test_mask_visible_exceeds_length() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("mask(@, `10`)").unwrap();
+        // When show_last >= length, object mask returns all stars
+        let result = expr.search(&json!("short")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "*****");
+    }
+
+    // =========================================================================
+    // normalize_whitespace tests
+    // =========================================================================
+
+    #[test]
+    fn test_normalize_whitespace_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("normalize_whitespace(@)").unwrap();
+        let result = expr.search(&json!("hello    world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_normalize_whitespace_mixed() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("normalize_whitespace(@)").unwrap();
+        let result = expr.search(&json!("hello\t\n  world\n\nfoo")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world foo");
+    }
+
+    #[test]
+    fn test_normalize_whitespace_leading_trailing() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("normalize_whitespace(@)").unwrap();
+        let result = expr.search(&json!("  hello world  ")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    // =========================================================================
+    // is_blank tests
+    // =========================================================================
+
+    #[test]
+    fn test_is_blank_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_blank(@)").unwrap();
+        let result = expr.search(&json!("")).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_blank_whitespace() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_blank(@)").unwrap();
+        let result = expr.search(&json!("   \t\n  ")).unwrap();
+        assert!(result.as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_is_blank_not_blank() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_blank(@)").unwrap();
+        let result = expr.search(&json!("  a  ")).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // abbreviate tests
+    // =========================================================================
+
+    #[test]
+    fn test_abbreviate_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("abbreviate(@, `10`)").unwrap();
+        let result = expr.search(&json!("This is a very long string")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "This is...");
+    }
+
+    #[test]
+    fn test_abbreviate_no_truncation() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("abbreviate(@, `20`)").unwrap();
+        let result = expr.search(&json!("short")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "short");
+    }
+
+    #[test]
+    fn test_abbreviate_custom_suffix() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("abbreviate(@, `8`, `\"~\"`)").unwrap();
+        let result = expr.search(&json!("Hello World")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Hello W~");
+    }
+
+    // =========================================================================
+    // center tests
+    // =========================================================================
+
+    #[test]
+    fn test_center_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("center(@, `10`)").unwrap();
+        let result = expr.search(&json!("hi")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "    hi    ");
+    }
+
+    #[test]
+    fn test_center_custom_char() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("center(@, `10`, `\"-\"`)").unwrap();
+        let result = expr.search(&json!("hi")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "----hi----");
+    }
+
+    #[test]
+    fn test_center_already_wide() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("center(@, `3`)").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_center_odd_padding() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("center(@, `7`)").unwrap();
+        let result = expr.search(&json!("hi")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "  hi   ");
+    }
+
+    // =========================================================================
+    // reverse_string tests
+    // =========================================================================
+
+    #[test]
+    fn test_reverse_string_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("reverse_string(@)").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "olleh");
+    }
+
+    #[test]
+    fn test_reverse_string_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("reverse_string(@)").unwrap();
+        let result = expr.search(&json!("")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_reverse_string_palindrome() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("reverse_string(@)").unwrap();
+        let result = expr.search(&json!("racecar")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "racecar");
+    }
+
+    // =========================================================================
+    // explode tests
+    // =========================================================================
+
+    #[test]
+    fn test_explode_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("explode(@)").unwrap();
+        let result = expr.search(&json!("abc")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_f64().unwrap() as u32, 97); // 'a'
+        assert_eq!(arr[1].as_f64().unwrap() as u32, 98); // 'b'
+        assert_eq!(arr[2].as_f64().unwrap() as u32, 99); // 'c'
+    }
+
+    #[test]
+    fn test_explode_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("explode(@)").unwrap();
+        let result = expr.search(&json!("")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_explode_unicode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("explode(@)").unwrap();
+        let result = expr.search(&json!("A\u{263a}")).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_f64().unwrap() as u32, 65); // 'A'
+        assert_eq!(arr[1].as_f64().unwrap() as u32, 9786); // smiley
+    }
+
+    // =========================================================================
+    // implode tests
+    // =========================================================================
+
+    #[test]
+    fn test_implode_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("implode(@)").unwrap();
+        let data = json!([97, 98, 99]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "abc");
+    }
+
+    #[test]
+    fn test_implode_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("implode(@)").unwrap();
+        let data: serde_json::Value = serde_json::from_str("[]").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_implode_unicode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("implode(@)").unwrap();
+        let data = json!([65, 9786]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "A\u{263a}");
+    }
+
+    #[test]
+    fn test_explode_implode_roundtrip() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("implode(explode(@))").unwrap();
+        let result = expr.search(&json!("Hello, \u{4e16}\u{754c}!")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "Hello, \u{4e16}\u{754c}!");
+    }
+
+    // =========================================================================
+    // shell_escape tests
+    // =========================================================================
+
+    #[test]
+    fn test_shell_escape_simple() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("hello")).unwrap();
+        // Simple alphanumeric doesn't need quoting
+        assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_shell_escape_with_spaces() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("hello world")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "'hello world'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("$PATH; rm -rf /")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "'$PATH; rm -rf /'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_single_quote() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("it's")).unwrap();
+        // Single quotes are escaped as '\''
+        assert_eq!(result.as_str().unwrap(), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_shell_escape_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "''");
+    }
+
+    #[test]
+    fn test_shell_escape_path() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("/usr/local/bin")).unwrap();
+        // Paths with only safe chars don't need quoting
+        assert_eq!(result.as_str().unwrap(), "/usr/local/bin");
+    }
+
+    #[test]
+    fn test_shell_escape_backticks() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("shell_escape(@)").unwrap();
+        let result = expr.search(&json!("`whoami`")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "'`whoami`'");
+    }
+}

--- a/crates/jpx-core/src/extensions/text.rs
+++ b/crates/jpx-core/src/extensions/text.rs
@@ -860,3 +860,487 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(CollapseWhitespaceFn::new()),
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_word_count() {
+        let runtime = setup_runtime();
+        let data = json!("Hello world, this is a test.");
+        let expr = runtime.compile("word_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 6.0);
+    }
+
+    #[test]
+    fn test_word_count_empty() {
+        let runtime = setup_runtime();
+        let data = json!("");
+        let expr = runtime.compile("word_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn test_char_count() {
+        let runtime = setup_runtime();
+        let data = json!("Hello world");
+        let expr = runtime.compile("char_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // "Hello world" without space = 10 characters
+        assert_eq!(result.as_f64().unwrap(), 10.0);
+    }
+
+    #[test]
+    fn test_sentence_count() {
+        let runtime = setup_runtime();
+        let data = json!("Hello world. How are you? I am fine!");
+        let expr = runtime.compile("sentence_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_sentence_count_no_punctuation() {
+        let runtime = setup_runtime();
+        let data = json!("Hello world");
+        let expr = runtime.compile("sentence_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_paragraph_count() {
+        let runtime = setup_runtime();
+        let data = json!("First paragraph.\n\nSecond paragraph.\n\nThird.");
+        let expr = runtime.compile("paragraph_count(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_reading_time() {
+        let runtime = setup_runtime();
+        // 200 words = 1 minute at 200 wpm
+        let words: Vec<&str> = vec!["word"; 200];
+        let text = words.join(" ");
+        let data = json!(text);
+        let expr = runtime.compile("reading_time(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_reading_time_short() {
+        let runtime = setup_runtime();
+        let data = json!("Quick read");
+        let expr = runtime.compile("reading_time(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0); // Rounds up to 1 minute
+    }
+
+    #[test]
+    fn test_reading_time_seconds() {
+        let runtime = setup_runtime();
+        // 100 words = 30 seconds at 200 wpm
+        let words: Vec<&str> = vec!["word"; 100];
+        let text = words.join(" ");
+        let data = json!(text);
+        let expr = runtime.compile("reading_time_seconds(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 30.0);
+    }
+
+    #[test]
+    fn test_char_frequencies() {
+        let runtime = setup_runtime();
+        let data = json!("aab");
+        let expr = runtime.compile("char_frequencies(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("a").unwrap().as_f64().unwrap(), 2.0);
+        assert_eq!(obj.get("b").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_word_frequencies() {
+        let runtime = setup_runtime();
+        let data = json!("hello world hello");
+        let expr = runtime.compile("word_frequencies(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("hello").unwrap().as_f64().unwrap(), 2.0);
+        assert_eq!(obj.get("world").unwrap().as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_word_frequencies_normalized() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, HELLO hello!");
+        let expr = runtime.compile("word_frequencies(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        // All normalized to "hello"
+        assert_eq!(obj.get("hello").unwrap().as_f64().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_ngrams_char() {
+        let runtime = setup_runtime();
+        let data = json!("hello");
+        let expr = runtime.compile("ngrams(@, `3`, 'char')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "hel");
+        assert_eq!(arr[1].as_str().unwrap(), "ell");
+        assert_eq!(arr[2].as_str().unwrap(), "llo");
+    }
+
+    #[test]
+    fn test_ngrams_word() {
+        let runtime = setup_runtime();
+        let data = json!("the quick brown fox");
+        let expr = runtime.compile("ngrams(@, `2`)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // Each element is an array of words
+        let first = arr[0].as_array().unwrap();
+        assert_eq!(first[0].as_str().unwrap(), "the");
+        assert_eq!(first[1].as_str().unwrap(), "quick");
+    }
+
+    #[test]
+    fn test_ngrams_empty() {
+        let runtime = setup_runtime();
+        let data = json!("hi");
+        // Asking for 3-grams from a 2-char string
+        let expr = runtime.compile("ngrams(@, `3`, 'char')").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_bigrams() {
+        let runtime = setup_runtime();
+        let data = json!("a b c d");
+        let expr = runtime.compile("bigrams(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // [["a", "b"], ["b", "c"], ["c", "d"]]
+        let first = arr[0].as_array().unwrap();
+        assert_eq!(first[0].as_str().unwrap(), "a");
+        assert_eq!(first[1].as_str().unwrap(), "b");
+        let last = arr[2].as_array().unwrap();
+        assert_eq!(last[0].as_str().unwrap(), "c");
+        assert_eq!(last[1].as_str().unwrap(), "d");
+    }
+
+    #[test]
+    fn test_bigrams_single_word() {
+        let runtime = setup_runtime();
+        let data = json!("hello");
+        let expr = runtime.compile("bigrams(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_trigrams() {
+        let runtime = setup_runtime();
+        let data = json!("a b c d e");
+        let expr = runtime.compile("trigrams(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        // [["a", "b", "c"], ["b", "c", "d"], ["c", "d", "e"]]
+        let first = arr[0].as_array().unwrap();
+        assert_eq!(first[0].as_str().unwrap(), "a");
+        assert_eq!(first[1].as_str().unwrap(), "b");
+        assert_eq!(first[2].as_str().unwrap(), "c");
+    }
+
+    #[test]
+    fn test_trigrams_too_short() {
+        let runtime = setup_runtime();
+        let data = json!("a b");
+        let expr = runtime.compile("trigrams(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // tokens tests
+    // =========================================================================
+
+    #[test]
+    fn test_tokens_basic() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime.compile("tokens(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "hello");
+        assert_eq!(arr[1].as_str().unwrap(), "world");
+    }
+
+    #[test]
+    fn test_tokens_punctuation_only() {
+        let runtime = setup_runtime();
+        let data = json!("... --- !!!");
+        let expr = runtime.compile("tokens(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_tokens_mixed() {
+        let runtime = setup_runtime();
+        let data = json!("The quick, brown fox!");
+        let expr = runtime.compile("tokens(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_str().unwrap(), "the");
+        assert_eq!(arr[1].as_str().unwrap(), "quick");
+        assert_eq!(arr[2].as_str().unwrap(), "brown");
+        assert_eq!(arr[3].as_str().unwrap(), "fox");
+    }
+
+    #[test]
+    fn test_tokens_empty() {
+        let runtime = setup_runtime();
+        let data = json!("");
+        let expr = runtime.compile("tokens(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 0);
+    }
+
+    // =========================================================================
+    // tokenize tests
+    // =========================================================================
+
+    // NOTE: tokenize tests are ignored because the multimatch category in
+    // functions.toml also has a "tokenize" entry which overwrites the text
+    // category's entry in the registry HashMap, preventing text::tokenize
+    // from being registered. Same issue as mm_tokenize in multi_match.rs.
+
+    #[test]
+    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
+    fn test_tokenize_default() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime.compile("tokenize(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "hello");
+        assert_eq!(arr[1].as_str().unwrap(), "world");
+    }
+
+    #[test]
+    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
+    fn test_tokenize_preserve_case() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime
+            .compile(r#"tokenize(@, `{"case": "preserve"}`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "Hello");
+        assert_eq!(arr[1].as_str().unwrap(), "World");
+    }
+
+    #[test]
+    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
+    fn test_tokenize_upper_case() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime
+            .compile(r#"tokenize(@, `{"case": "upper"}`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "HELLO");
+        assert_eq!(arr[1].as_str().unwrap(), "WORLD");
+    }
+
+    #[test]
+    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
+    fn test_tokenize_keep_punctuation() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime
+            .compile(r#"tokenize(@, `{"punctuation": "keep"}`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "hello,");
+        assert_eq!(arr[1].as_str().unwrap(), "world!");
+    }
+
+    #[test]
+    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
+    fn test_tokenize_preserve_case_keep_punctuation() {
+        let runtime = setup_runtime();
+        let data = json!("Hello, World!");
+        let expr = runtime
+            .compile(r#"tokenize(@, `{"case": "preserve", "punctuation": "keep"}`)"#)
+            .unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str().unwrap(), "Hello,");
+        assert_eq!(arr[1].as_str().unwrap(), "World!");
+    }
+
+    // =========================================================================
+    // stem tests
+    // =========================================================================
+
+    #[test]
+    fn test_stem_basic() {
+        let runtime = setup_runtime();
+        let data = json!("running");
+        let expr = runtime.compile("stem(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "run");
+    }
+
+    #[test]
+    fn test_stem_plural() {
+        let runtime = setup_runtime();
+        let data = json!("cats");
+        let expr = runtime.compile("stem(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "cat");
+    }
+
+    #[test]
+    fn test_stems_array() {
+        let runtime = setup_runtime();
+        let data = json!(["running", "cats", "quickly"]);
+        let expr = runtime.compile("stems(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str().unwrap(), "run");
+        assert_eq!(arr[1].as_str().unwrap(), "cat");
+        assert_eq!(arr[2].as_str().unwrap(), "quick");
+    }
+
+    // =========================================================================
+    // stopwords tests
+    // =========================================================================
+
+    #[test]
+    fn test_stopwords_english() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("stopwords()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let arr = result.as_array().unwrap();
+        // English stopwords should include common words
+        let words: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        assert!(words.contains(&"the".to_string()));
+        assert!(words.contains(&"is".to_string()));
+        assert!(words.contains(&"a".to_string()));
+    }
+
+    #[test]
+    fn test_remove_stopwords() {
+        let runtime = setup_runtime();
+        let data = json!(["the", "quick", "brown", "fox"]);
+        let expr = runtime.compile("remove_stopwords(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        // "the" should be removed
+        let words: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        assert!(!words.contains(&"the".to_string()));
+        assert!(words.contains(&"quick".to_string()));
+        assert!(words.contains(&"brown".to_string()));
+        assert!(words.contains(&"fox".to_string()));
+    }
+
+    #[test]
+    fn test_is_stopword() {
+        let runtime = setup_runtime();
+        let data = json!("the");
+        let expr = runtime.compile("is_stopword(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.as_bool().unwrap());
+
+        let data = json!("elephant");
+        let result = expr.search(&data).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // text normalization tests
+    // =========================================================================
+
+    #[test]
+    fn test_normalize_unicode_default() {
+        let runtime = setup_runtime();
+        // cafe with combining acute accent (e + combining accent)
+        let data = json!("cafe\u{0301}");
+        let expr = runtime.compile("normalize_unicode(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // NFC should compose to e-acute
+        assert_eq!(result.as_str().unwrap(), "caf\u{00e9}");
+    }
+
+    #[test]
+    fn test_remove_accents() {
+        let runtime = setup_runtime();
+        let data = json!("caf\u{00e9} na\u{00ef}ve r\u{00e9}sum\u{00e9}");
+        let expr = runtime.compile("remove_accents(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "cafe naive resume");
+    }
+
+    #[test]
+    fn test_collapse_whitespace() {
+        let runtime = setup_runtime();
+        let data = json!("  hello   world  ");
+        let expr = runtime.compile("collapse_whitespace(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_collapse_whitespace_tabs_newlines() {
+        let runtime = setup_runtime();
+        let data = json!("hello\t\n\nworld");
+        let expr = runtime.compile("collapse_whitespace(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+}

--- a/crates/jpx-core/src/extensions/type_conv.rs
+++ b/crates/jpx-core/src/extensions/type_conv.rs
@@ -446,3 +446,149 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     );
     register_if_enabled(runtime, "auto_parse", enabled, Box::new(AutoParseFn::new()));
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_type_of() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("type_of(@)").unwrap();
+
+        let result = expr.search(&json!("hello")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "string");
+
+        let result = expr.search(&json!(42)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "number");
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_empty(@)").unwrap();
+
+        let result = expr.search(&json!("")).unwrap();
+        assert!(result.as_bool().unwrap());
+
+        let result = expr.search(&json!("hello")).unwrap();
+        assert!(!result.as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // parse_numbers tests
+    // =========================================================================
+
+    #[test]
+    fn test_parse_numbers_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"count": "42", "price": "19.99", "name": "test"});
+        let expr = runtime.compile("parse_numbers(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result["count"].as_f64().unwrap() as i64, 42);
+        assert!((result["price"].as_f64().unwrap() - 19.99).abs() < 0.01);
+        assert_eq!(result["name"].as_str().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_parse_numbers_nested() {
+        let runtime = setup_runtime();
+        let data = json!({"outer": {"inner": "123"}});
+        let expr = runtime.compile("parse_numbers(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result["outer"]["inner"].as_f64().unwrap() as i64, 123);
+    }
+
+    #[test]
+    fn test_parse_numbers_non_numeric() {
+        let runtime = setup_runtime();
+        let data = json!({"val": "42abc"});
+        let expr = runtime.compile("parse_numbers(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        // Should remain as string since it's not a pure number
+        assert_eq!(result["val"].as_str().unwrap(), "42abc");
+    }
+
+    // =========================================================================
+    // parse_booleans tests
+    // =========================================================================
+
+    #[test]
+    fn test_parse_booleans_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"active": "true", "verified": "false", "name": "test"});
+        let expr = runtime.compile("parse_booleans(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result["active"].as_bool().unwrap());
+        assert!(!result["verified"].as_bool().unwrap());
+        assert_eq!(result["name"].as_str().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_parse_booleans_variants() {
+        let runtime = setup_runtime();
+        let data = json!({"a": "YES", "b": "no", "c": "ON", "d": "off", "e": "1", "f": "0"});
+        let expr = runtime.compile("parse_booleans(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result["a"].as_bool().unwrap());
+        assert!(!result["b"].as_bool().unwrap());
+        assert!(result["c"].as_bool().unwrap());
+        assert!(!result["d"].as_bool().unwrap());
+        assert!(result["e"].as_bool().unwrap());
+        assert!(!result["f"].as_bool().unwrap());
+    }
+
+    // =========================================================================
+    // parse_nulls tests
+    // =========================================================================
+
+    #[test]
+    fn test_parse_nulls_basic() {
+        let runtime = setup_runtime();
+        let data = json!({"a": "null", "b": "NULL", "c": "None", "d": "nil", "e": "hello"});
+        let expr = runtime.compile("parse_nulls(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result["a"].is_null());
+        assert!(result["b"].is_null());
+        assert!(result["c"].is_null());
+        assert!(result["d"].is_null());
+        assert_eq!(result["e"].as_str().unwrap(), "hello");
+    }
+
+    // =========================================================================
+    // auto_parse tests
+    // =========================================================================
+
+    #[test]
+    fn test_auto_parse_mixed() {
+        let runtime = setup_runtime();
+        let data = json!({"num": "42", "bool": "true", "nil": "null", "str": "hello"});
+        let expr = runtime.compile("auto_parse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result["num"].as_f64().unwrap() as i64, 42);
+        assert!(result["bool"].as_bool().unwrap());
+        assert!(result["nil"].is_null());
+        assert_eq!(result["str"].as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_auto_parse_array() {
+        let runtime = setup_runtime();
+        let data = json!(["42", "true", "null", "hello"]);
+        let expr = runtime.compile("auto_parse(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_f64().unwrap() as i64, 42);
+        assert!(arr[1].as_bool().unwrap());
+        assert!(arr[2].is_null());
+        assert_eq!(arr[3].as_str().unwrap(), "hello");
+    }
+}

--- a/crates/jpx-core/src/extensions/url_fns.rs
+++ b/crates/jpx-core/src/extensions/url_fns.rs
@@ -142,3 +142,68 @@ impl Function for UrlParseFn {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_url_encode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_encode(@)").unwrap();
+        let data = json!("hello world");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello%20world");
+    }
+
+    #[test]
+    fn test_url_decode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_decode(@)").unwrap();
+        let data = json!("hello%20world");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_url_parse() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_parse(@)").unwrap();
+        let data = json!("https://example.com:8080/path?query=1#frag");
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("scheme").unwrap().as_str().unwrap(), "https");
+        assert_eq!(obj.get("host").unwrap().as_str().unwrap(), "example.com");
+        assert_eq!(obj.get("port").unwrap().as_f64().unwrap() as u16, 8080);
+    }
+
+    #[test]
+    fn test_url_parse_origin() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_parse(@)").unwrap();
+        let data = json!("https://example.com:8080/path");
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("origin").unwrap().as_str().unwrap(),
+            "https://example.com:8080"
+        );
+    }
+
+    #[test]
+    fn test_url_parse_invalid_returns_null() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_parse(@)").unwrap();
+        let data = json!("not a valid url");
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+}

--- a/crates/jpx-core/src/extensions/utility.rs
+++ b/crates/jpx-core/src/extensions/utility.rs
@@ -361,3 +361,175 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "env", enabled, Box::new(EnvFn::new()));
     register_if_enabled(runtime, "get_env", enabled, Box::new(GetEnvFn::new()));
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_default() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("default(@, 'fallback')").unwrap();
+
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "fallback");
+
+        let result = expr.search(&json!("value")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "value");
+    }
+
+    #[test]
+    fn test_if() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("if(`true`, 'yes', 'no')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "yes");
+
+        let expr = runtime.compile("if(`false`, 'yes', 'no')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "no");
+    }
+
+    #[test]
+    fn test_json_decode_object() {
+        let runtime = setup_runtime();
+        // Test parsing a JSON object string
+        let expr = runtime.compile("json_decode(@)").unwrap();
+        let data = json!(r#"{"a":1,"b":2}"#);
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_object());
+        let obj = result.as_object().unwrap();
+        assert!(obj.contains_key("a"));
+    }
+
+    #[test]
+    fn test_json_decode_from_field() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_decode(s)").unwrap();
+        let data = json!({"s": r#"{"a":1,"b":2}"#});
+
+        let result = expr.search(&data);
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val.is_object());
+    }
+
+    #[test]
+    fn test_json_decode_invalid_returns_null() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_decode(@)").unwrap();
+        let data = json!("not valid json");
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_json_encode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_encode(@)").unwrap();
+        let data = json!({"a": 1});
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_json_pointer_nested() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_pointer(@, '/foo/bar/1')").unwrap();
+        let data = json!({"foo": {"bar": [1, 2, 3]}});
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn test_json_pointer_root() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_pointer(@, '')").unwrap();
+        let data = json!({"a": 1});
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_object());
+    }
+
+    #[test]
+    fn test_json_pointer_missing() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_pointer(@, '/missing')").unwrap();
+        let data = json!({"a": 1});
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_json_pointer_array() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("json_pointer(@, '/0')").unwrap();
+        let data = json!([1, 2, 3]);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_f64().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn test_pretty_default_indent() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("pretty(@)").unwrap();
+        let data = json!({"a": 1, "b": [2, 3]});
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains('\n'));
+        assert!(s.contains("  ")); // 2-space indent
+    }
+
+    #[test]
+    fn test_pretty_custom_indent() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("pretty(@, `4`)").unwrap();
+        let data = json!({"a": 1});
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(s.contains("    ")); // 4-space indent
+    }
+
+    #[test]
+    fn test_pretty_simple_value() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("pretty(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "\"hello\"");
+    }
+
+    #[test]
+    fn test_env_returns_object() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("env()").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.is_object());
+    }
+
+    #[test]
+    fn test_get_env_existing() {
+        // PATH should exist on all systems
+        let runtime = setup_runtime();
+        let expr = runtime.compile("get_env('PATH')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.is_string());
+    }
+
+    #[test]
+    fn test_get_env_missing() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("get_env('THIS_ENV_VAR_SHOULD_NOT_EXIST_12345')")
+            .unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert!(result.is_null());
+    }
+}

--- a/crates/jpx-core/src/extensions/validation.rs
+++ b/crates/jpx-core/src/extensions/validation.rs
@@ -334,3 +334,255 @@ impl Function for IsHexFn {
         Ok(Value::Bool(is_valid))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Runtime;
+    use serde_json::json;
+
+    fn setup_runtime() -> Runtime {
+        Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build()
+    }
+
+    #[test]
+    fn test_is_ipv4() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_ipv4(@)").unwrap();
+
+        let data = json!("192.168.1.1");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("not an ip");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_ipv6() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_ipv6(@)").unwrap();
+
+        let data = json!("::1");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("2001:db8::1");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_email() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_email(@)").unwrap();
+
+        let data = json!("test@example.com");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("not-an-email");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_luhn_check_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("luhn_check(@)").unwrap();
+
+        // Valid Luhn number
+        let data = json!("79927398713");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_luhn_check_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("luhn_check(@)").unwrap();
+
+        let data = json!("79927398710");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_credit_card_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_credit_card(@)").unwrap();
+
+        // Test Visa number (passes Luhn)
+        let data = json!("4111111111111111");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_credit_card_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_credit_card(@)").unwrap();
+
+        // Invalid number
+        let data = json!("1234567890123456");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_credit_card_too_short() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_credit_card(@)").unwrap();
+
+        let data = json!("123456");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_phone_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_phone(@)").unwrap();
+
+        let data = json!("+1-555-123-4567");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("(555) 123-4567");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_phone_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_phone(@)").unwrap();
+
+        let data = json!("123");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_jwt_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_jwt(@)").unwrap();
+
+        let data = json!(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        );
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_jwt_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_jwt(@)").unwrap();
+
+        // Only two parts - invalid
+        let data = json!("only.twoparts");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+
+        // Contains invalid characters for base64url
+        let data = json!("abc.def!ghi.jkl");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_iso_date_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_iso_date(@)").unwrap();
+
+        let data = json!("2023-12-13T15:30:00Z");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("2023-12-13");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_iso_date_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_iso_date(@)").unwrap();
+
+        let data = json!("12/13/2023");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_json_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_json(@)").unwrap();
+
+        let data = json!(r#"{"a": 1, "b": [2, 3]}"#);
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_json_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_json(@)").unwrap();
+
+        let data = json!("not json");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_base64_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_base64(@)").unwrap();
+
+        let data = json!("SGVsbG8gV29ybGQ=");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_base64_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_base64(@)").unwrap();
+
+        let data = json!("not valid base64!!!");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_is_hex_valid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_hex(@)").unwrap();
+
+        let data = json!("deadbeef");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+
+        let data = json!("ABCDEF0123456789");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_is_hex_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("is_hex(@)").unwrap();
+
+        let data = json!("not hex!");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(false));
+    }
+}

--- a/crates/jpx-core/src/interpreter.rs
+++ b/crates/jpx-core/src/interpreter.rs
@@ -195,3 +195,204 @@ pub fn interpret(data: &Value, node: &Ast, ctx: &mut Context<'_>) -> SearchResul
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::Runtime;
+
+    fn search(expr: &str, data: &serde_json::Value) -> serde_json::Value {
+        let rt = Runtime::strict();
+        let compiled = rt.compile(expr).unwrap();
+        compiled.search(data).unwrap()
+    }
+
+    fn search_err(expr: &str, data: &serde_json::Value) -> crate::JmespathError {
+        let rt = Runtime::strict();
+        let compiled = rt.compile(expr).unwrap();
+        compiled.search(data).unwrap_err()
+    }
+
+    #[test]
+    fn null_propagation_field() {
+        assert_eq!(search("foo", &json!(null)), json!(null));
+        assert_eq!(search("foo.bar", &json!({"foo": null})), json!(null));
+    }
+
+    #[test]
+    fn null_propagation_index() {
+        assert_eq!(search("[0]", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn null_propagation_projection() {
+        assert_eq!(search("[*].foo", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn projection_filters_null() {
+        let data = json!([{"foo": "a"}, {"bar": "b"}, {"foo": "c"}]);
+        assert_eq!(search("[*].foo", &data), json!(["a", "c"]));
+    }
+
+    #[test]
+    fn wildcard_on_non_object() {
+        assert_eq!(search("*", &json!("string")), json!(null));
+        assert_eq!(search("*", &json!(42)), json!(null));
+    }
+
+    #[test]
+    fn wildcard_on_object() {
+        let result = search("*", &json!({"a": 1, "b": 2}));
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert!(arr.contains(&json!(1)));
+        assert!(arr.contains(&json!(2)));
+    }
+
+    #[test]
+    fn cross_type_equality_returns_false() {
+        // jpx-core returns false for cross-type comparisons (not null)
+        assert_eq!(search("`1` == `\"1\"`", &json!(null)), json!(false));
+        assert_eq!(search("`1` == `true`", &json!(null)), json!(false));
+    }
+
+    #[test]
+    fn same_type_equality() {
+        assert_eq!(search("`1` == `1`", &json!(null)), json!(true));
+        assert_eq!(search("`1` == `2`", &json!(null)), json!(false));
+        assert_eq!(
+            search("`\"hello\"` == `\"hello\"`", &json!(null)),
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn flatten_semantics() {
+        let data = json!([[1, 2], [3, 4], [5]]);
+        assert_eq!(search("[]", &data), json!([1, 2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn flatten_mixed() {
+        let data = json!([[1, 2], 3, [4]]);
+        assert_eq!(search("[]", &data), json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn flatten_on_non_array() {
+        assert_eq!(search("[]", &json!("string")), json!(null));
+    }
+
+    #[test]
+    fn pipe_stops_projection() {
+        let data = json!({
+            "people": [
+                {"name": "a", "age": 20},
+                {"name": "b", "age": 25},
+                {"name": "c", "age": 30}
+            ]
+        });
+        assert_eq!(search("people[*].name | [0]", &data), json!("a"));
+    }
+
+    #[test]
+    fn or_semantics() {
+        assert_eq!(search("a || b", &json!({"a": 1, "b": 2})), json!(1));
+        assert_eq!(search("a || b", &json!({"b": 2})), json!(2));
+        assert_eq!(search("a || b", &json!({})), json!(null));
+    }
+
+    #[test]
+    fn and_semantics() {
+        assert_eq!(search("a && b", &json!({"a": 1, "b": 2})), json!(2));
+        assert_eq!(search("a && b", &json!({"b": 2})), json!(null));
+    }
+
+    #[test]
+    fn not_semantics() {
+        assert_eq!(search("!`true`", &json!(null)), json!(false));
+        assert_eq!(search("!`false`", &json!(null)), json!(true));
+        assert_eq!(search("!`null`", &json!(null)), json!(true));
+        assert_eq!(search("!`\"\"`", &json!(null)), json!(true));
+        assert_eq!(search("!`\"hello\"`", &json!(null)), json!(false));
+    }
+
+    #[test]
+    fn slice_step_zero_error() {
+        let err = search_err("[::0]", &json!([1, 2, 3]));
+        let display = format!("{err}");
+        assert!(display.contains("Invalid slice"));
+    }
+
+    #[test]
+    fn unknown_function_error() {
+        let err = search_err("nonexistent(@)", &json!(null));
+        let display = format!("{err}");
+        assert!(display.contains("Unknown function"));
+    }
+
+    #[test]
+    fn multilist_on_null() {
+        assert_eq!(search("[a, b]", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn multihash_on_null() {
+        assert_eq!(search("{x: a, y: b}", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn multilist_on_data() {
+        assert_eq!(search("[a, b]", &json!({"a": 1, "b": 2})), json!([1, 2]));
+    }
+
+    #[test]
+    fn multihash_on_data() {
+        assert_eq!(
+            search("{x: a, y: b}", &json!({"a": 1, "b": 2})),
+            json!({"x": 1, "y": 2})
+        );
+    }
+
+    #[test]
+    fn comparison_operators() {
+        assert_eq!(search("`5` > `3`", &json!(null)), json!(true));
+        assert_eq!(search("`5` < `3`", &json!(null)), json!(false));
+        assert_eq!(search("`5` >= `5`", &json!(null)), json!(true));
+        assert_eq!(search("`5` <= `5`", &json!(null)), json!(true));
+        assert_eq!(search("`5` != `3`", &json!(null)), json!(true));
+    }
+
+    #[test]
+    fn literal_passthrough() {
+        assert_eq!(search("`42`", &json!(null)), json!(42));
+        assert_eq!(search("`\"hello\"`", &json!(null)), json!("hello"));
+        assert_eq!(search("`true`", &json!(null)), json!(true));
+        assert_eq!(search("`null`", &json!(null)), json!(null));
+    }
+
+    #[test]
+    fn identity() {
+        assert_eq!(search("@", &json!(42)), json!(42));
+        assert_eq!(search("@", &json!("hello")), json!("hello"));
+    }
+
+    #[test]
+    fn filter_expression() {
+        let data = json!([1, 2, 3, 4, 5]);
+        assert_eq!(search("[? @ > `3`]", &data), json!([4, 5]));
+    }
+
+    #[test]
+    fn builtin_function_length() {
+        assert_eq!(search("length(@)", &json!([1, 2, 3])), json!(3));
+        assert_eq!(search("length(@)", &json!("hello")), json!(5));
+    }
+
+    #[test]
+    fn builtin_function_sort() {
+        assert_eq!(search("sort(@)", &json!([3, 1, 2])), json!([1, 2, 3]));
+    }
+}

--- a/crates/jpx-core/src/parser.rs
+++ b/crates/jpx-core/src/parser.rs
@@ -526,3 +526,301 @@ impl<'a> Parser<'a> {
         Ok(nodes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Comparator;
+
+    #[test]
+    fn parse_field() {
+        let ast = parse("foo").unwrap();
+        assert!(matches!(ast, Ast::Field { name, .. } if name == "foo"));
+    }
+
+    #[test]
+    fn parse_identity() {
+        let ast = parse("@").unwrap();
+        assert!(matches!(ast, Ast::Identity { .. }));
+    }
+
+    #[test]
+    fn parse_subexpr() {
+        let ast = parse("foo.bar").unwrap();
+        assert!(matches!(ast, Ast::Subexpr { .. }));
+    }
+
+    #[test]
+    fn parse_deeply_nested_subexpr() {
+        let ast = parse("a.b.c.d.e").unwrap();
+        assert!(matches!(ast, Ast::Subexpr { .. }));
+    }
+
+    #[test]
+    fn parse_index_positive() {
+        let ast = parse("[0]").unwrap();
+        assert!(matches!(ast, Ast::Index { idx: 0, .. }));
+    }
+
+    #[test]
+    fn parse_index_negative() {
+        let ast = parse("[-1]").unwrap();
+        assert!(matches!(ast, Ast::Index { idx: -1, .. }));
+    }
+
+    #[test]
+    fn parse_slice_basic() {
+        let ast = parse("[0:5]").unwrap();
+        match ast {
+            Ast::Projection { lhs, .. } => {
+                assert!(matches!(
+                    *lhs,
+                    Ast::Slice {
+                        start: Some(0),
+                        stop: Some(5),
+                        step: 1,
+                        ..
+                    }
+                ));
+            }
+            _ => panic!("expected Projection with Slice lhs"),
+        }
+    }
+
+    #[test]
+    fn parse_slice_with_step() {
+        let ast = parse("[::2]").unwrap();
+        match ast {
+            Ast::Projection { lhs, .. } => {
+                assert!(matches!(
+                    *lhs,
+                    Ast::Slice {
+                        start: None,
+                        stop: None,
+                        step: 2,
+                        ..
+                    }
+                ));
+            }
+            _ => panic!("expected Projection with Slice lhs"),
+        }
+    }
+
+    #[test]
+    fn parse_slice_negative_step() {
+        let ast = parse("[::-1]").unwrap();
+        match ast {
+            Ast::Projection { lhs, .. } => {
+                assert!(matches!(*lhs, Ast::Slice { step: -1, .. }));
+            }
+            _ => panic!("expected Projection with Slice lhs"),
+        }
+    }
+
+    #[test]
+    fn parse_wildcard_values() {
+        let ast = parse("*").unwrap();
+        assert!(matches!(ast, Ast::Projection { .. }));
+    }
+
+    #[test]
+    fn parse_wildcard_index() {
+        let ast = parse("[*]").unwrap();
+        assert!(matches!(ast, Ast::Projection { .. }));
+    }
+
+    #[test]
+    fn parse_flatten() {
+        let ast = parse("[]").unwrap();
+        match ast {
+            Ast::Projection { lhs, .. } => {
+                assert!(matches!(*lhs, Ast::Flatten { .. }));
+            }
+            _ => panic!("expected Projection with Flatten"),
+        }
+    }
+
+    #[test]
+    fn parse_filter() {
+        let ast = parse("[?a > `1`]").unwrap();
+        assert!(matches!(ast, Ast::Projection { .. }));
+    }
+
+    #[test]
+    fn parse_or() {
+        let ast = parse("a || b").unwrap();
+        assert!(matches!(ast, Ast::Or { .. }));
+    }
+
+    #[test]
+    fn parse_and() {
+        let ast = parse("a && b").unwrap();
+        assert!(matches!(ast, Ast::And { .. }));
+    }
+
+    #[test]
+    fn parse_not() {
+        let ast = parse("!a").unwrap();
+        assert!(matches!(ast, Ast::Not { .. }));
+    }
+
+    #[test]
+    fn parse_pipe() {
+        let ast = parse("a | b").unwrap();
+        assert!(matches!(ast, Ast::Subexpr { .. }));
+    }
+
+    #[test]
+    fn parse_function_call() {
+        let ast = parse("length(@)").unwrap();
+        match ast {
+            Ast::Function { name, args, .. } => {
+                assert_eq!(name, "length");
+                assert_eq!(args.len(), 1);
+            }
+            _ => panic!("expected Function"),
+        }
+    }
+
+    #[test]
+    fn parse_multi_list() {
+        let ast = parse("[a, b, c]").unwrap();
+        match ast {
+            Ast::MultiList { elements, .. } => {
+                assert_eq!(elements.len(), 3);
+            }
+            _ => panic!("expected MultiList"),
+        }
+    }
+
+    #[test]
+    fn parse_multi_hash() {
+        let ast = parse("{a: b, c: d}").unwrap();
+        match ast {
+            Ast::MultiHash { elements, .. } => {
+                assert_eq!(elements.len(), 2);
+            }
+            _ => panic!("expected MultiHash"),
+        }
+    }
+
+    #[test]
+    fn parse_literal_string() {
+        let ast = parse("`\"hello\"`").unwrap();
+        assert!(matches!(ast, Ast::Literal { .. }));
+    }
+
+    #[test]
+    fn parse_literal_number() {
+        let ast = parse("`42`").unwrap();
+        assert!(matches!(ast, Ast::Literal { .. }));
+    }
+
+    #[test]
+    fn parse_literal_null() {
+        let ast = parse("`null`").unwrap();
+        assert!(matches!(ast, Ast::Literal { .. }));
+    }
+
+    #[test]
+    fn parse_raw_string() {
+        let ast = parse("'hello'").unwrap();
+        match ast {
+            Ast::Literal { value, .. } => {
+                assert_eq!(value, serde_json::json!("hello"));
+            }
+            _ => panic!("expected Literal from raw string"),
+        }
+    }
+
+    #[test]
+    fn parse_expref() {
+        let ast = parse("&foo").unwrap();
+        assert!(matches!(ast, Ast::Expref { .. }));
+    }
+
+    #[test]
+    fn parse_all_comparators() {
+        for (expr, cmp) in [
+            ("a == b", Comparator::Equal),
+            ("a != b", Comparator::NotEqual),
+            ("a > b", Comparator::GreaterThan),
+            ("a >= b", Comparator::GreaterThanEqual),
+            ("a < b", Comparator::LessThan),
+            ("a <= b", Comparator::LessThanEqual),
+        ] {
+            let ast = parse(expr).unwrap();
+            match ast {
+                Ast::Comparison { comparator, .. } => assert_eq!(comparator, cmp, "for {expr}"),
+                _ => panic!("expected Comparison for {expr}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_quoted_identifier() {
+        let ast = parse("\"foo bar\"").unwrap();
+        match ast {
+            Ast::Field { name, .. } => assert_eq!(name, "foo bar"),
+            _ => panic!("expected Field from quoted identifier"),
+        }
+    }
+
+    #[test]
+    fn parse_parenthesized_expression() {
+        let ast = parse("(a)").unwrap();
+        assert!(matches!(ast, Ast::Field { .. }));
+    }
+
+    #[test]
+    fn error_empty_expression() {
+        let result = parse("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_unclosed_bracket() {
+        let result = parse("[0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_trailing_garbage() {
+        let result = parse("foo bar");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_quoted_string_as_function() {
+        let result = parse("\"foo\"()");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_trailing_comma_in_list() {
+        let result = parse("[a, b,]");
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn parse_let_expression() {
+        let ast = parse("let $x = `1` in $x").unwrap();
+        assert!(matches!(ast, Ast::Let { .. }));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn parse_variable_ref() {
+        // This will parse fine, but searching will fail (no scope)
+        let ast = parse("$x").unwrap();
+        assert!(matches!(ast, Ast::VariableRef { .. }));
+    }
+
+    #[cfg(feature = "let-expr")]
+    #[test]
+    fn error_let_missing_in() {
+        let result = parse("let $x = `1` $x");
+        assert!(result.is_err());
+    }
+}

--- a/crates/jpx-core/src/runtime.rs
+++ b/crates/jpx-core/src/runtime.rs
@@ -159,3 +159,113 @@ impl RuntimeBuilder {
         rt
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_runtime_has_no_functions() {
+        let rt = Runtime::new();
+        assert!(rt.get_function("abs").is_none());
+        assert_eq!(rt.function_names().count(), 0);
+    }
+
+    #[test]
+    fn strict_runtime_has_26_builtins() {
+        let rt = Runtime::strict();
+        assert_eq!(rt.function_names().count(), 26);
+        assert!(rt.get_function("abs").is_some());
+        assert!(rt.get_function("length").is_some());
+        assert!(rt.get_function("sort").is_some());
+    }
+
+    #[test]
+    fn register_and_get_function() {
+        let mut rt = Runtime::new();
+        rt.register_function("abs", Box::new(AbsFn::new()));
+        assert!(rt.get_function("abs").is_some());
+        assert!(rt.get_function("nonexistent").is_none());
+    }
+
+    #[test]
+    fn deregister_function() {
+        let mut rt = Runtime::strict();
+        assert!(rt.get_function("abs").is_some());
+        let removed = rt.deregister_function("abs");
+        assert!(removed.is_some());
+        assert!(rt.get_function("abs").is_none());
+        assert_eq!(rt.function_names().count(), 25);
+    }
+
+    #[test]
+    fn deregister_nonexistent_returns_none() {
+        let mut rt = Runtime::new();
+        assert!(rt.deregister_function("nope").is_none());
+    }
+
+    #[test]
+    fn builder_with_standard() {
+        let rt = Runtime::builder().with_standard().build();
+        assert_eq!(rt.function_names().count(), 26);
+    }
+
+    #[test]
+    #[cfg(feature = "extensions")]
+    fn builder_with_category() {
+        let rt = Runtime::builder()
+            .with_standard()
+            .with_category(Category::String)
+            .build();
+        assert!(rt.function_names().count() > 26);
+        assert!(rt.get_function("lower").is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "extensions")]
+    fn builder_with_all_extensions() {
+        let rt = Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build();
+        assert!(rt.function_names().count() > 26);
+    }
+
+    #[test]
+    #[cfg(feature = "extensions")]
+    fn builder_without_function() {
+        let rt = Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .without_function("lower")
+            .build();
+        assert!(rt.get_function("lower").is_none());
+        assert!(rt.get_function("upper").is_some());
+    }
+
+    #[test]
+    fn compile_with_runtime() {
+        let rt = Runtime::strict();
+        let expr = rt.compile("length(@)").unwrap();
+        let result = expr.search(&json!([1, 2, 3])).unwrap();
+        assert_eq!(result, json!(3));
+    }
+
+    #[test]
+    fn unknown_function_compile_succeeds_search_fails() {
+        let rt = Runtime::new();
+        let expr = rt.compile("nonexistent(@)").unwrap();
+        let result = expr.search(&json!(null));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn function_names_iterator() {
+        let rt = Runtime::strict();
+        let names: Vec<&str> = rt.function_names().collect();
+        assert!(names.contains(&"abs"));
+        assert!(names.contains(&"length"));
+        assert!(names.contains(&"values"));
+    }
+}

--- a/crates/jpx-core/tests/property_tests.rs
+++ b/crates/jpx-core/tests/property_tests.rs
@@ -1,0 +1,152 @@
+//! Property-based tests for jpx-core using proptest.
+//!
+//! These tests verify safety invariants: no panics on arbitrary input,
+//! reflexivity/symmetry of equality, and bounded output for slices.
+
+use proptest::prelude::*;
+use serde_json::{Value, json};
+
+use jpx_core::{Runtime, ValueExt};
+
+/// Generates an arbitrary JSON value with bounded recursion depth.
+fn arb_json_value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(|n| json!(n)),
+        any::<f64>()
+            .prop_filter("finite", |f| f.is_finite())
+            .prop_map(|n| json!(n)),
+        "[a-zA-Z0-9_ ]{0,20}".prop_map(|s| json!(s)),
+    ];
+    leaf.prop_recursive(4, 64, 8, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..8).prop_map(Value::Array),
+            prop::collection::hash_map("[a-z]{1,5}", inner, 0..5)
+                .prop_map(|m| Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+/// Generates syntactically plausible JMESPath expressions.
+fn arb_jmespath_expr() -> impl Strategy<Value = String> {
+    let simple = prop_oneof![
+        Just("@".to_string()),
+        "[a-zA-Z_][a-zA-Z0-9_]{0,5}",
+        (0..10i32).prop_map(|n| format!("[{n}]")),
+        Just("*".to_string()),
+        Just("`null`".to_string()),
+    ];
+    prop_oneof![
+        simple.clone(),
+        (simple.clone(), simple.clone()).prop_map(|(a, b)| format!("{a}.{b}")),
+        (simple.clone(), simple.clone()).prop_map(|(a, b)| format!("{a} | {b}")),
+        simple.clone().prop_map(|s| format!("length({s})")),
+    ]
+}
+
+proptest! {
+    /// The parser must never panic on arbitrary input strings.
+    #[test]
+    fn parser_never_panics(s in ".*") {
+        let _ = jpx_core::parse(&s);
+    }
+
+    /// The interpreter must never panic when given a valid expression and arbitrary data.
+    #[test]
+    fn interpreter_never_panics(
+        expr_str in arb_jmespath_expr(),
+        data in arb_json_value(),
+    ) {
+        let rt = Runtime::strict();
+        if let Ok(expr) = rt.compile(&expr_str) {
+            let _ = expr.search(&data);
+        }
+    }
+
+    /// ValueExt field access must never panic on arbitrary values and field names.
+    #[test]
+    fn value_ext_field_never_panics(
+        data in arb_json_value(),
+        field in "[a-z]{1,10}",
+    ) {
+        let _ = data.get_field(&field);
+    }
+
+    /// ValueExt index access must never panic.
+    #[test]
+    fn value_ext_index_never_panics(
+        data in arb_json_value(),
+        idx in 0..100usize,
+    ) {
+        let _ = data.get_index(idx);
+        let _ = data.get_negative_index(idx);
+    }
+
+    /// Equality must be reflexive: every value equals itself.
+    #[test]
+    fn equality_reflexive(v in arb_json_value()) {
+        let result = v.compare(&jpx_core::ast::Comparator::Equal, &v);
+        prop_assert_eq!(result, Some(true));
+    }
+
+    /// Equality must be symmetric: if v == w then w == v.
+    #[test]
+    fn equality_symmetric(
+        v in arb_json_value(),
+        w in arb_json_value(),
+    ) {
+        let vw = v.compare(&jpx_core::ast::Comparator::Equal, &w);
+        let wv = w.compare(&jpx_core::ast::Comparator::Equal, &v);
+        prop_assert_eq!(vw, wv);
+    }
+
+    /// Slice output length must be bounded by input length.
+    #[test]
+    fn slice_result_bounded(
+        arr in prop::collection::vec(arb_json_value(), 0..20),
+        start in prop::option::of(-20i32..20),
+        stop in prop::option::of(-20i32..20),
+        step in prop_oneof![(-5i32..-1), (1i32..5)],
+    ) {
+        let val = Value::Array(arr.clone());
+        if let Some(result) = val.slice(start, stop, step) {
+            prop_assert!(result.len() <= arr.len());
+        }
+    }
+}
+
+#[cfg(feature = "extensions")]
+proptest! {
+    /// Extension functions must never panic when given safe expressions and arbitrary JSON.
+    #[test]
+    fn extension_functions_never_panic(
+        data in arb_json_value(),
+    ) {
+        let rt = Runtime::builder()
+            .with_standard()
+            .with_all_extensions()
+            .build();
+
+        let safe_exprs = [
+            "lower(to_string(@))",
+            "upper(to_string(@))",
+            "length(to_string(@))",
+            "type(@)",
+            "to_string(@)",
+            "to_number(to_string(@))",
+            "is_string(@)",
+            "is_number(@)",
+            "is_array(@)",
+            "is_object(@)",
+            "is_null(@)",
+            "is_boolean(@)",
+        ];
+
+        for expr_str in &safe_exprs {
+            if let Ok(expr) = rt.compile(expr_str) {
+                let _ = expr.search(&data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add 922 new tests to jpx-core, bringing total from 63 to 985 unit/property tests
- Migrate ~830 extension function tests from jmespath-extensions, translated to jpx-core's native serde_json::Value API with expref syntax
- Add property-based tests with proptest for parser/interpreter/ValueExt safety
- Add unit tests for core modules: parser (30), interpreter (25), runtime (11), error (17)

### Test breakdown by area

| Area | Tests Added |
|------|-------------|
| Core modules (parser, interpreter, runtime, error) | 83 |
| Property tests (proptest) | 8 |
| Extension: expression | 112 |
| Extension: array | 115 |
| Extension: object | 113 |
| Extension: datetime | 87 |
| Extension: string | 66 |
| Extension: text | 38 |
| Extension: math | 34 |
| Extension: format | 26 |
| Extension: multi_match | 26 |
| Extension: encoding | 24 |
| Extension: validation | 20 |
| Extension: fuzzy | 18 |
| Extension: utility | 16 |
| Extension: hash | 14 |
| Extension: phonetic | 13 |
| Extension: semver_fns | 13 |
| Extension: language | 13 |
| Extension: jsonpatch | 12 |
| Extension: discovery | 12 |
| Extension: network | 11 |
| Extension: type_conv | 10 |
| Extension: duration | 8 |
| Extension: ids | 8 |
| Extension: geo | 5 |
| Extension: url_fns | 5 |
| Extension: color | 4 |
| Extension: path | 3 |
| Extension: random | 3 |
| Extension: regex_fns | 3 |
| Extension: computing | 3 |

13 tests are `#[ignore]` for functions implemented but not yet registered in functions.toml (histogram, normalize, z_score, correlation, mm_tokenize, tokenize, fold).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p jpx-core --lib --all-features` (977 passed, 13 ignored)
- [x] `cargo test -p jpx-core --test property_tests --all-features` (8 passed)
- [x] `cargo test -p jpx-core --test compliance --all-features` (861 passed)
- [x] `cargo test --doc --all-features -p jpx-core` (9 passed)
- [x] `cargo test --lib --all-features --workspace` (all pass)
- [x] `cargo test --test '*' --all-features` (201 passed)