### PR TITLE
test: add assert_cmd CLI integration test suite (109 tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +430,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -781,6 +807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +955,15 @@ checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1432,6 +1473,7 @@ name = "jpx"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "atty",
  "clap",
  "clap_complete",
@@ -1442,6 +1484,7 @@ dependencies = [
  "jpx-engine",
  "json-patch",
  "parquet",
+ "predicates",
  "rustyline",
  "serde",
  "serde_json",
@@ -1782,6 +1825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2094,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -2693,6 +2772,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -53,4 +53,6 @@ let-expr = ["jpx-engine/let-expr"]
 parquet = ["dep:parquet", "jpx-engine/arrow"]
 
 [dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
 tempfile = "3"

--- a/crates/jpx/tests/cli_args.rs
+++ b/crates/jpx/tests/cli_args.rs
@@ -1,0 +1,360 @@
+//! Integration tests for jpx CLI argument parsing, conflicts, and modes.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn jpx() -> Command {
+    assert_cmd::cargo_bin_cmd!("jpx")
+}
+
+// ============================================================================
+// Help and Version
+// ============================================================================
+
+mod help_and_version {
+    use super::*;
+
+    #[test]
+    fn version_shows_jpx_pattern() {
+        jpx()
+            .arg("--version")
+            .assert()
+            .success()
+            .stdout(predicate::str::is_match(r"jpx \d+\.\d+\.\d+").unwrap());
+    }
+
+    #[test]
+    fn short_help_exits_success() {
+        jpx()
+            .arg("-h")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Usage:"));
+    }
+
+    #[test]
+    fn long_help_shows_examples() {
+        jpx()
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("EXAMPLES:"));
+    }
+}
+
+// ============================================================================
+// Expression Input
+// ============================================================================
+
+mod expression_input {
+    use super::*;
+
+    #[test]
+    fn positional_expression_from_stdin() {
+        jpx()
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"alice\""));
+    }
+
+    #[test]
+    fn flag_expression_from_stdin() {
+        jpx()
+            .args(["-e", "name"])
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"alice\""));
+    }
+
+    #[test]
+    fn multiple_flag_expressions_chain() {
+        jpx()
+            .args(["-e", "[*].name", "-e", "sort(@)"])
+            .write_stdin(r#"[{"name":"b"},{"name":"a"}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"a\"").and(predicate::str::contains("\"b\"")));
+    }
+
+    #[test]
+    fn multiple_positional_expressions_chain() {
+        jpx()
+            .args(["[*].name", "sort(@)"])
+            .write_stdin(r#"[{"name":"b"},{"name":"a"}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\"a\"").and(predicate::str::contains("\"b\"")));
+    }
+
+    #[test]
+    fn missing_expression_errors() {
+        jpx()
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("Expression required"));
+    }
+
+    #[test]
+    fn flag_and_positional_conflict() {
+        jpx()
+            .args(["-e", "x", "y"])
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
+
+// ============================================================================
+// Mode Flags
+// ============================================================================
+
+mod mode_flags {
+    use super::*;
+
+    #[test]
+    fn strict_blocks_extension_functions() {
+        jpx()
+            .args(["--strict", "-n", "upper('hello')"])
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(
+                predicate::str::contains("Unknown function")
+                    .or(predicate::str::contains("undefined function")),
+            );
+    }
+
+    #[test]
+    fn strict_allows_standard_functions() {
+        jpx()
+            .args(["--strict", "length(@)"])
+            .write_stdin("[1,2,3]")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("3"));
+    }
+
+    #[test]
+    fn quiet_suppresses_stream_parse_errors() {
+        // In streaming mode, -q suppresses per-line parse errors.
+        // "bad" is not valid JSON, but {"a":1} is. Quiet mode should
+        // suppress the error for "bad" and still output the valid result.
+        jpx()
+            .args(["-q", "--stream", "a"])
+            .write_stdin("bad\n{\"a\":1}")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1"))
+            .stderr(predicate::str::is_empty());
+    }
+
+    #[test]
+    fn verbose_shows_timing() {
+        jpx()
+            .args(["-v", "--color", "never", "@"])
+            .write_stdin("{}")
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Total time:"));
+    }
+
+    #[test]
+    fn verbose_shows_input_info() {
+        jpx()
+            .args(["-v", "--color", "never", "@"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Input:"));
+    }
+
+    #[test]
+    fn verbose_strict_shows_mode() {
+        jpx()
+            .args(["-v", "--strict", "--color", "never", "@"])
+            .write_stdin("{}")
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Mode: strict"));
+    }
+
+    #[test]
+    fn debug_shows_diagnostic_info() {
+        jpx()
+            .args(["--debug", "--color", "never", "-n", "@"])
+            .assert()
+            .success()
+            .stderr(
+                predicate::str::contains("jpx debug info")
+                    .and(predicate::str::contains("Version"))
+                    .and(predicate::str::contains("Environment"))
+                    .and(predicate::str::contains("Effective settings")),
+            );
+    }
+}
+
+// ============================================================================
+// Flag Conflicts
+// ============================================================================
+
+mod flag_conflicts {
+    use super::*;
+
+    #[test]
+    fn yaml_csv_conflict() {
+        jpx()
+            .args(["--yaml", "--csv", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn yaml_toml_conflict() {
+        jpx()
+            .args(["--yaml", "--toml", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn csv_tsv_conflict() {
+        jpx()
+            .args(["--csv", "--tsv", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn lines_table_conflict() {
+        jpx()
+            .args(["--lines", "--table", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn stream_slurp_conflict() {
+        jpx()
+            .args(["--stream", "--slurp", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn stream_null_input_conflict() {
+        jpx()
+            .args(["--stream", "--null-input", "@"])
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+
+    #[test]
+    fn table_style_requires_table() {
+        jpx()
+            .args(["--table-style", "ascii", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("required"));
+    }
+
+    #[test]
+    fn types_requires_paths() {
+        jpx()
+            .args(["--types", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("required"));
+    }
+
+    #[test]
+    fn values_requires_paths() {
+        jpx()
+            .args(["--values", "@"])
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("required"));
+    }
+
+    #[test]
+    fn expression_flag_and_query_file_conflict() {
+        jpx()
+            .args(["-e", "x", "-Q", "nonexistent.txt"])
+            .assert()
+            .failure()
+            .code(2)
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
+
+// ============================================================================
+// Shell Completions
+// ============================================================================
+
+mod shell_completions {
+    use super::*;
+
+    #[test]
+    fn bash_completions() {
+        jpx()
+            .args(["--completions", "bash"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+
+    #[test]
+    fn zsh_completions() {
+        jpx()
+            .args(["--completions", "zsh"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+
+    #[test]
+    fn fish_completions() {
+        jpx()
+            .args(["--completions", "fish"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+
+    #[test]
+    fn powershell_completions() {
+        jpx()
+            .args(["--completions", "powershell"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+}

--- a/crates/jpx/tests/cli_env_config.rs
+++ b/crates/jpx/tests/cli_env_config.rs
@@ -1,0 +1,258 @@
+//! Integration tests for jpx CLI environment variables and configuration file support.
+//!
+//! Tests cover JPX_RAW, JPX_COMPACT, JPX_STRICT, JPX_VERBOSE, JPX_QUIET env vars,
+//! truthy/falsy value parsing, config file loading via JPX_CONFIG, invalid TOML
+//! handling, missing config files, and exit codes.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn jpx() -> Command {
+    assert_cmd::cargo_bin_cmd!("jpx")
+}
+
+// ============================================================================
+// Environment Variables
+// ============================================================================
+
+mod env_vars {
+    use super::*;
+
+    #[test]
+    fn jpx_raw_env() {
+        jpx()
+            .env("JPX_RAW", "1")
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+    }
+
+    #[test]
+    fn jpx_compact_env() {
+        jpx()
+            .env("JPX_COMPACT", "1")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::starts_with("{\"a\":1,\"b\":2}"));
+    }
+
+    #[test]
+    fn jpx_strict_env() {
+        jpx()
+            .env("JPX_STRICT", "1")
+            .args(["-n", "upper('hello')"])
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(
+                predicate::str::contains("Unknown function")
+                    .or(predicate::str::contains("undefined function")),
+            );
+    }
+
+    #[test]
+    fn jpx_verbose_env() {
+        jpx()
+            .env("JPX_VERBOSE", "1")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin("{}")
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Total time:"));
+    }
+
+    #[test]
+    fn jpx_quiet_env() {
+        jpx()
+            .env("JPX_QUIET", "1")
+            .args(["--stream", "a"])
+            .write_stdin("bad\n{\"a\":1}")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1"))
+            .stderr(predicate::str::is_empty());
+    }
+
+    #[test]
+    fn env_truthy_values() {
+        // "true" (case-insensitive) is truthy
+        jpx()
+            .env("JPX_RAW", "true")
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+
+        // "yes" is truthy
+        jpx()
+            .env("JPX_RAW", "yes")
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+    }
+
+    #[test]
+    fn cli_flag_overrides_env() {
+        // Both -r flag and JPX_RAW=1 set: raw output should work
+        jpx()
+            .env("JPX_RAW", "1")
+            .arg("-r")
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+    }
+
+    #[test]
+    fn env_falsy_ignored() {
+        // "0" is falsy -- raw mode should NOT activate, so output has quotes
+        jpx()
+            .env("JPX_RAW", "0")
+            .arg("name")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("\"alice\"\n");
+
+        // "false" is also falsy
+        jpx()
+            .env("JPX_RAW", "false")
+            .arg("name")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("\"alice\"\n");
+    }
+}
+
+// ============================================================================
+// Configuration File
+// ============================================================================
+
+mod config_file {
+    use super::*;
+
+    #[test]
+    fn config_via_env() {
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "raw = true").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+    }
+
+    #[test]
+    fn config_applies_defaults() {
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "verbose = true").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin("{}")
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Total time:"));
+    }
+
+    #[test]
+    fn config_compact_works() {
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "compact = true").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::starts_with("{\"a\":1,\"b\":2}"));
+    }
+
+    #[test]
+    fn config_invalid_toml() {
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "invalid toml {{{{").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stderr(
+                predicate::str::contains("warning")
+                    .and(predicate::str::contains("Failed to parse")),
+            );
+    }
+
+    #[test]
+    fn config_missing_file() {
+        jpx()
+            .env("JPX_CONFIG", "/tmp/jpx_nonexistent_config_12345.toml")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("warning").not());
+    }
+}
+
+// ============================================================================
+// Exit Codes
+// ============================================================================
+
+mod exit_codes {
+    use super::*;
+
+    #[test]
+    fn success_exit_zero() {
+        jpx()
+            .arg("a")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .code(0);
+    }
+
+    #[test]
+    fn error_exit_one() {
+        jpx()
+            .arg("@")
+            .write_stdin("not json")
+            .assert()
+            .failure()
+            .code(1);
+    }
+}

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -1,0 +1,467 @@
+//! Integration tests for jpx CLI input/output behavior.
+//!
+//! Tests cover input modes (stdin, file, null-input, slurp, stream),
+//! output formats (JSON, compact, raw, YAML, TOML, CSV, TSV, lines, table),
+//! file output, and color modes.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+
+fn jpx() -> Command {
+    assert_cmd::cargo_bin_cmd!("jpx")
+}
+
+mod input_modes {
+    use super::*;
+
+    #[test]
+    fn stdin_json_object() {
+        jpx()
+            .arg("a")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("1\n");
+    }
+
+    #[test]
+    fn stdin_json_array() {
+        jpx()
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin("[1,2]")
+            .assert()
+            .success()
+            .stdout("[\n  1,\n  2\n]\n");
+    }
+
+    #[test]
+    fn file_input() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, r#"{{"name":"test"}}"#).unwrap();
+
+        jpx()
+            .arg("-f")
+            .arg(tmp.path())
+            .arg("name")
+            .arg("--color")
+            .arg("never")
+            .assert()
+            .success()
+            .stdout("\"test\"\n");
+    }
+
+    #[test]
+    fn file_not_found() {
+        jpx()
+            .arg("-f")
+            .arg("/tmp/nonexistent_jpx_test_8f3a2c.json")
+            .arg("@")
+            .assert()
+            .failure()
+            .stderr(
+                predicate::str::contains("not found")
+                    .or(predicate::str::contains("File not found")),
+            );
+    }
+
+    #[test]
+    fn null_input() {
+        jpx()
+            .arg("-n")
+            .arg("`42`")
+            .assert()
+            .success()
+            .stdout("42\n");
+    }
+
+    #[test]
+    fn null_input_ignores_stdin() {
+        // With -n, @ evaluates to null. Null results produce no output.
+        jpx()
+            .arg("-n")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("");
+    }
+
+    #[test]
+    fn slurp_combines() {
+        jpx()
+            .arg("-s")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin("1\n2\n3")
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("[")
+                    .and(predicate::str::contains("1"))
+                    .and(predicate::str::contains("2"))
+                    .and(predicate::str::contains("3")),
+            );
+    }
+
+    #[test]
+    fn slurp_with_expression() {
+        jpx()
+            .arg("-s")
+            .arg("length(@)")
+            .write_stdin("1\n2\n3")
+            .assert()
+            .success()
+            .stdout("3\n");
+    }
+
+    #[test]
+    fn stream_ndjson() {
+        jpx()
+            .arg("--stream")
+            .arg("id")
+            .write_stdin("{\"id\":1}\n{\"id\":2}")
+            .assert()
+            .success()
+            .stdout("1\n2\n");
+    }
+
+    #[test]
+    fn stream_skips_null() {
+        // Second line has no "a" field, so result is null and gets skipped.
+        jpx()
+            .arg("--stream")
+            .arg("a")
+            .write_stdin("{\"a\":1}\n{\"b\":2}")
+            .assert()
+            .success()
+            .stdout("1\n");
+    }
+
+    #[test]
+    fn null_input_short() {
+        // -n with now() returns a numeric timestamp
+        jpx()
+            .args(["-n", "now()"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_match(r"\d+").unwrap());
+    }
+
+    #[test]
+    fn empty_stdin_no_data() {
+        // Empty stdin with an expression fails to parse
+        jpx().arg("@").write_stdin("").assert().failure().code(1);
+    }
+
+    #[test]
+    fn invalid_json_stdin() {
+        jpx().arg("@").write_stdin("not json").assert().failure();
+    }
+}
+
+mod output_formats {
+    use super::*;
+
+    #[test]
+    fn default_pretty_json() {
+        jpx()
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\n").and(predicate::str::contains("  ")));
+    }
+
+    #[test]
+    fn compact_json() {
+        jpx()
+            .arg("-c")
+            .arg("@")
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::starts_with("{\"a\":1,\"b\":2}"));
+    }
+
+    #[test]
+    fn raw_string_output() {
+        jpx()
+            .arg("-r")
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice\n");
+    }
+
+    #[test]
+    fn raw_non_string() {
+        // Non-string values still print normally (as JSON) with -r.
+        jpx()
+            .arg("-r")
+            .arg("n")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"n":42}"#)
+            .assert()
+            .success()
+            .stdout("42\n");
+    }
+
+    #[test]
+    fn yaml_output() {
+        jpx()
+            .arg("--yaml")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a: 1"));
+    }
+
+    #[test]
+    fn yaml_short() {
+        jpx()
+            .arg("-y")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a: 1"));
+    }
+
+    #[test]
+    fn toml_output() {
+        jpx()
+            .arg("--toml")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a = 1"));
+    }
+
+    #[test]
+    fn csv_output() {
+        let assert = jpx()
+            .arg("--csv")
+            .arg("@")
+            .write_stdin(r#"[{"a":1,"b":2}]"#)
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        // Should have a header line containing column names and a data line.
+        let lines: Vec<&str> = stdout.trim().lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "CSV should have header + data rows, got: {:?}",
+            lines
+        );
+        assert!(lines[0].contains("a") && lines[0].contains("b"));
+    }
+
+    #[test]
+    fn tsv_output() {
+        let assert = jpx()
+            .arg("--tsv")
+            .arg("@")
+            .write_stdin(r#"[{"a":1,"b":2}]"#)
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(stdout.contains('\t'), "TSV output should contain tabs");
+        let lines: Vec<&str> = stdout.trim().lines().collect();
+        assert!(lines.len() >= 2, "TSV should have header + data rows");
+    }
+
+    #[test]
+    fn lines_output() {
+        jpx()
+            .arg("-l")
+            .arg("@")
+            .write_stdin("[1,2,3]")
+            .assert()
+            .success()
+            .stdout("1\n2\n3\n");
+    }
+
+    #[test]
+    fn table_output() {
+        jpx()
+            .arg("-t")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"[{"n":"a","v":1}]"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+
+    #[test]
+    fn table_ascii_style() {
+        jpx()
+            .arg("-t")
+            .arg("--table-style")
+            .arg("ascii")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"[{"n":"a"}]"#)
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("+")
+                    .and(predicate::str::contains("-"))
+                    .and(predicate::str::contains("|")),
+            );
+    }
+
+    #[test]
+    fn table_markdown_style() {
+        let assert = jpx()
+            .arg("-t")
+            .arg("--table-style")
+            .arg("markdown")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"[{"n":"a"}]"#)
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let lines: Vec<&str> = stdout.trim().lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "Markdown table should have at least 2 lines"
+        );
+        assert!(lines[0].contains('|'), "Header row should contain |");
+        assert!(lines[1].contains('-'), "Separator row should contain -");
+    }
+
+    #[test]
+    fn null_result_no_output() {
+        // Accessing a missing key returns null, which produces no output.
+        jpx()
+            .arg("b")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("");
+    }
+}
+
+mod file_output {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn output_to_file() {
+        let out = NamedTempFile::new().unwrap();
+        let out_path = out.path().to_str().unwrap().to_string();
+
+        jpx()
+            .arg("@")
+            .arg("-o")
+            .arg(&out_path)
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+
+        let contents = std::fs::read_to_string(&out_path).unwrap();
+        assert!(
+            contents.contains("\"a\"") && contents.contains("1"),
+            "Output file should contain JSON data"
+        );
+        // Pretty-printed output contains newlines and indentation.
+        assert!(contents.contains('\n') && contents.contains("  "));
+    }
+
+    #[test]
+    fn output_compact_to_file() {
+        let out = NamedTempFile::new().unwrap();
+        let out_path = out.path().to_str().unwrap().to_string();
+
+        jpx()
+            .arg("-c")
+            .arg("@")
+            .arg("-o")
+            .arg(&out_path)
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+
+        let contents = std::fs::read_to_string(&out_path).unwrap();
+        assert!(
+            contents.trim().starts_with("{\"a\":1}"),
+            "Compact output should be single-line JSON, got: {}",
+            contents.trim()
+        );
+    }
+
+    #[test]
+    fn output_yaml_to_file() {
+        let out = NamedTempFile::new().unwrap();
+        let out_path = out.path().to_str().unwrap().to_string();
+
+        jpx()
+            .arg("--yaml")
+            .arg("@")
+            .arg("-o")
+            .arg(&out_path)
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+
+        let contents = std::fs::read_to_string(&out_path).unwrap();
+        assert!(
+            contents.contains("a: 1"),
+            "YAML file should contain 'a: 1', got: {}",
+            contents
+        );
+    }
+}
+
+mod color_mode {
+    use super::*;
+
+    #[test]
+    fn color_never_no_ansi() {
+        let assert = jpx()
+            .arg("--color")
+            .arg("never")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+        let stdout = assert.get_output().stdout.clone();
+        assert!(
+            !stdout.contains(&b'\x1b'),
+            "Output with --color never should not contain ANSI escape codes"
+        );
+    }
+
+    #[test]
+    fn color_always_has_ansi() {
+        let assert = jpx()
+            .arg("--color")
+            .arg("always")
+            .arg("@")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+        let stdout = assert.get_output().stdout.clone();
+        assert!(
+            stdout.contains(&b'\x1b'),
+            "Output with --color always should contain ANSI escape codes"
+        );
+    }
+}

--- a/crates/jpx/tests/cli_operations.rs
+++ b/crates/jpx/tests/cli_operations.rs
@@ -1,0 +1,487 @@
+//! Integration tests for jpx CLI operations: discovery, explain, bench,
+//! stats/paths, diff/patch/merge, and query library features.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn jpx() -> Command {
+    assert_cmd::cargo_bin_cmd!("jpx")
+}
+
+// ============================================================================
+// Discovery
+// ============================================================================
+
+mod discovery {
+    use super::*;
+
+    #[test]
+    fn list_functions_shows_categories() {
+        jpx().arg("--list-functions").assert().success().stdout(
+            predicate::str::contains("STANDARD")
+                .and(predicate::str::contains("ARRAY"))
+                .and(predicate::str::contains("STRING"))
+                .and(predicate::str::contains("MATH")),
+        );
+    }
+
+    #[test]
+    fn list_category_filters() {
+        jpx()
+            .args(["--list-category", "array"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("ARRAY")
+                    .and(predicate::str::contains("unique"))
+                    .and(predicate::str::contains("Signature")),
+            );
+    }
+
+    #[test]
+    fn list_category_invalid() {
+        jpx()
+            .args(["--list-category", "bogus"])
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("Unknown category"));
+    }
+
+    #[test]
+    fn describe_function_detail() {
+        jpx()
+            .args(["--describe", "upper"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("upper")
+                    .and(predicate::str::contains("Signature"))
+                    .and(predicate::str::contains("Category")),
+            );
+    }
+
+    #[test]
+    fn describe_unknown() {
+        jpx()
+            .args(["--describe", "xyznonexistent"])
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("Unknown function"));
+    }
+
+    #[test]
+    fn search_finds_matches() {
+        jpx()
+            .args(["--search", "hash"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Found").and(predicate::str::is_empty().not()));
+    }
+
+    #[test]
+    fn search_no_results() {
+        jpx()
+            .args(["--search", "xyzxyznonexistent"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No functions found"));
+    }
+
+    #[test]
+    fn similar_finds_related() {
+        jpx()
+            .args(["--similar", "upper"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("Functions similar to")
+                    .and(predicate::str::contains("Same category"))
+                    .and(predicate::str::contains("string")),
+            );
+    }
+}
+
+// ============================================================================
+// Explain
+// ============================================================================
+
+mod explain {
+    use super::*;
+
+    #[test]
+    fn explain_simple() {
+        jpx()
+            .args(["--explain", "name"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Expression:").and(predicate::str::contains("Field")));
+    }
+
+    #[test]
+    fn explain_function() {
+        jpx()
+            .args(["--explain", "length(@)"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Function"));
+    }
+
+    #[test]
+    fn explain_pipeline() {
+        jpx()
+            .args(["--explain", "a", "sort(@)"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("Expression 1:")
+                    .and(predicate::str::contains("Expression 2:")),
+            );
+    }
+
+    #[test]
+    fn explain_no_input_needed() {
+        // --explain should not hang waiting for stdin; it only parses the expression.
+        jpx()
+            .args(["--explain", "items[*].name"])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+}
+
+// ============================================================================
+// Bench
+// ============================================================================
+
+mod bench {
+    use super::*;
+
+    #[test]
+    fn bench_basic() {
+        jpx()
+            .args(["--bench=10", "@", "-n"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("BENCHMARK"));
+    }
+
+    #[test]
+    fn bench_default_iterations() {
+        // --bench without =N uses default of 100 iterations. Because --bench
+        // uses num_args=0..=1, the expression must be provided via -e to avoid
+        // clap consuming it as the iteration count.
+        jpx()
+            .args(["-n", "-e", "@", "--bench"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("100"));
+    }
+
+    #[test]
+    fn bench_shows_stats() {
+        jpx()
+            .args(["--bench=10", "@", "-n"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("Mean")
+                    .and(predicate::str::contains("Median"))
+                    .and(predicate::str::contains("Throughput")),
+            );
+    }
+}
+
+// ============================================================================
+// Stats and Paths
+// ============================================================================
+
+mod stats_and_paths {
+    use super::*;
+
+    #[test]
+    fn stats_array() {
+        jpx()
+            .args(["--stats", "--color", "never"])
+            .write_stdin("[1,2,3]")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("array"));
+    }
+
+    #[test]
+    fn stats_object() {
+        jpx()
+            .args(["--stats", "--color", "never"])
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("object"));
+    }
+
+    #[test]
+    fn paths_basic() {
+        jpx()
+            .args(["--paths", "--color", "never"])
+            .write_stdin(r#"{"a":{"b":1}}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a").and(predicate::str::contains("b")));
+    }
+
+    #[test]
+    fn paths_with_types() {
+        jpx()
+            .args(["--paths", "--types", "--color", "never"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("number"));
+    }
+
+    #[test]
+    fn paths_with_values() {
+        jpx()
+            .args(["--paths", "--values", "--color", "never"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1"));
+    }
+}
+
+// ============================================================================
+// Diff / Patch / Merge
+// ============================================================================
+
+mod diff_patch_merge {
+    use super::*;
+
+    #[test]
+    fn diff_generates_patch() {
+        let mut source = NamedTempFile::new().unwrap();
+        let mut target = NamedTempFile::new().unwrap();
+        write!(source, r#"{{"name":"alice","age":30}}"#).unwrap();
+        write!(target, r#"{{"name":"alice","age":31}}"#).unwrap();
+
+        jpx()
+            .arg("--diff")
+            .arg(source.path())
+            .arg(target.path())
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("op")
+                    .and(predicate::str::contains("replace").or(
+                        predicate::str::contains("add").or(predicate::str::contains("remove")),
+                    )),
+            );
+    }
+
+    #[test]
+    fn diff_identical() {
+        let mut source = NamedTempFile::new().unwrap();
+        let mut target = NamedTempFile::new().unwrap();
+        write!(source, r#"{{"name":"alice"}}"#).unwrap();
+        write!(target, r#"{{"name":"alice"}}"#).unwrap();
+
+        jpx()
+            .arg("--diff")
+            .arg(source.path())
+            .arg(target.path())
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("[]"))
+            .stderr(predicate::str::contains("No differences"));
+    }
+
+    #[test]
+    fn patch_applies() {
+        let mut doc = NamedTempFile::new().unwrap();
+        let mut patch = NamedTempFile::new().unwrap();
+        write!(doc, r#"{{"name":"alice","age":30}}"#).unwrap();
+        write!(patch, r#"[{{"op":"replace","path":"/age","value":31}}]"#).unwrap();
+
+        jpx()
+            .arg("--patch")
+            .arg(patch.path())
+            .arg("-f")
+            .arg(doc.path())
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("alice").and(predicate::str::contains("31")));
+    }
+
+    #[test]
+    fn merge_applies() {
+        let mut doc = NamedTempFile::new().unwrap();
+        let mut merge = NamedTempFile::new().unwrap();
+        write!(doc, r#"{{"name":"alice","age":30}}"#).unwrap();
+        write!(merge, r#"{{"age":31,"city":"NYC"}}"#).unwrap();
+
+        jpx()
+            .arg("--merge")
+            .arg(merge.path())
+            .arg("-f")
+            .arg(doc.path())
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("alice")
+                    .and(predicate::str::contains("31"))
+                    .and(predicate::str::contains("NYC")),
+            );
+    }
+}
+
+// ============================================================================
+// Query Library
+// ============================================================================
+
+mod query_library {
+    use super::*;
+
+    #[test]
+    fn query_file_plain_text() {
+        let mut file = NamedTempFile::with_suffix(".txt").unwrap();
+        writeln!(file, "length(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .write_stdin("[1,2,3]")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("3"));
+    }
+
+    #[test]
+    fn query_file_jpx_single() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name my-query").unwrap();
+        writeln!(file, "-- :desc Get length").unwrap();
+        writeln!(file, "length(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .write_stdin("[1,2,3]")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("3"));
+    }
+
+    #[test]
+    fn query_file_jpx_colon() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name get-len").unwrap();
+        writeln!(file, "-- :desc Get length").unwrap();
+        writeln!(file, "length(@)").unwrap();
+        writeln!(file, "-- :name get-keys").unwrap();
+        writeln!(file, "-- :desc Get keys").unwrap();
+        writeln!(file, "keys(@)").unwrap();
+
+        let path_with_query = format!("{}:get-len", file.path().display());
+        jpx()
+            .arg("-Q")
+            .arg(&path_with_query)
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("2"));
+    }
+
+    #[test]
+    fn query_file_jpx_query_flag() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name get-len").unwrap();
+        writeln!(file, "length(@)").unwrap();
+        writeln!(file, "-- :name get-keys").unwrap();
+        writeln!(file, "keys(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .args(["--query", "get-keys"])
+            .write_stdin(r#"{"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("a").and(predicate::str::contains("b")));
+    }
+
+    #[test]
+    fn query_file_multiple_no_name() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name alpha").unwrap();
+        writeln!(file, "length(@)").unwrap();
+        writeln!(file, "-- :name beta").unwrap();
+        writeln!(file, "keys(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .write_stdin("{}")
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("alpha").and(predicate::str::contains("beta")));
+    }
+
+    #[test]
+    fn list_queries() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name first-query").unwrap();
+        writeln!(file, "-- :desc The first query").unwrap();
+        writeln!(file, "length(@)").unwrap();
+        writeln!(file, "-- :name second-query").unwrap();
+        writeln!(file, "-- :desc The second query").unwrap();
+        writeln!(file, "keys(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .arg("--list-queries")
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("first-query")
+                    .and(predicate::str::contains("second-query")),
+            );
+    }
+
+    #[test]
+    fn check_valid() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name valid-one").unwrap();
+        writeln!(file, "length(@)").unwrap();
+        writeln!(file, "-- :name valid-two").unwrap();
+        writeln!(file, "keys(@)").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .args(["--check", "--color", "never"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("All queries valid"));
+    }
+
+    #[test]
+    fn check_invalid() {
+        let mut file = NamedTempFile::with_suffix(".jpx").unwrap();
+        writeln!(file, "-- :name bad-query").unwrap();
+        writeln!(file, "invalid[[[").unwrap();
+
+        jpx()
+            .arg("-Q")
+            .arg(file.path())
+            .args(["--check", "--color", "never"])
+            .assert()
+            .failure()
+            .code(1)
+            .stdout(predicate::str::contains("Validation failed"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `assert_cmd` + `predicates` as dev-dependencies for the jpx CLI crate
- Create 4 focused test files with 109 integration tests covering CLI args, I/O behavior, operations, env vars, and config file support
- Existing `integration.rs` (201 extension function tests) is untouched

## Coverage

Previously untested areas now covered:

| Area | Before | After |
|------|--------|-------|
| Config file support (JPX_CONFIG, TOML parsing) | 0 tests | 5 |
| `--strict` mode | 0 | 4 |
| `--quiet` mode | 0 | 3 |
| Shell completions | 0 | 4 |
| Expression pipelines (`-e` chaining) | 0 | 2 |
| File output (`-o`) | 0 | 3 |
| Query library advanced features | 0 | 8 |
| Flag conflict validation | 1 | 10 |
| Env var behavior (truthy/falsy/override) | 0 | 8 |
| Discovery/explain/bench/stats/paths/diff/patch/merge | 0 | 25 |
| Exit codes | 0 | 2 (+ most tests verify codes) |

## Test files

- `cli_args.rs` (30): help/version, expression input, mode flags, flag conflicts, completions
- `cli_io.rs` (32): stdin/file/null-input/slurp/stream, all output formats, file output, color
- `cli_operations.rs` (32): discovery, explain, bench, stats/paths, diff/patch/merge, query library
- `cli_env_config.rs` (15): JPX_* env vars, truthy/falsy parsing, config.toml, exit codes

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p jpx --test cli_args --test cli_io --test cli_operations --test cli_env_config` (109/109 pass)
- [x] `cargo test --all-features --workspace` (all pass)