### PR TITLE
fix: support trailing positional arg as input file

### DIFF
--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -126,6 +126,15 @@ fn run() -> Result<()> {
         return ops::check_queries(query_path, &args.color, &runtime);
     }
 
+    // jq-style: if the last positional arg is an existing file and no -f was given, use it as input
+    if args.file.is_none() && !args.null_input && args.positional_expressions.len() > 1 {
+        let last = args.positional_expressions.last().unwrap();
+        if std::path::Path::new(last).is_file() {
+            let file_arg = args.positional_expressions.pop().unwrap();
+            args.file = Some(file_arg);
+        }
+    }
+
     // Get expressions from positional args, -e flags, or file
     let expressions: Vec<String> = if let Some(query_path) = &args.query_file {
         match query_library::load_query_expression(query_path, args.query_name.as_deref(), false)? {


### PR DESCRIPTION
## Summary

- When multiple positional args are given and the last one is an existing file, treat it as the input file instead of an expression
- Matches jq-style syntax (`jpx 'expr' file.json`) that the docs already describe
- Previously all positional args were consumed as expressions, causing the CLI to hang on stdin

## Behavior

| Command | Before | After |
|---------|--------|-------|
| `jpx 'expr' file.json` | Hangs (stdin) | Reads file.json |
| `jpx 'expr'` | Reads stdin | No change |
| `jpx 'e1' 'e2'` | Pipeline, stdin | No change |
| `jpx 'e1' 'e2' file.json` | Pipeline of 3, stdin | Pipeline of 2, reads file.json |
| `jpx 'expr' nofile.json` | Expression fails | No change (not a file, stays as expression) |

The `len() > 1` guard ensures a single arg is always treated as an expression.

## Test plan

- [x] `jpx 'library.name' /tmp/test.json` reads the file
- [x] `echo '...' \| jpx 'library.name'` stdin still works
- [x] `echo '...' \| jpx 'keys(@)' 'length(@)'` pipeline still works
- [x] All 310 existing tests pass