### PR TITLE
docs: document trailing file argument syntax

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -280,7 +280,11 @@ pub(crate) struct Args {
         short,
         long,
         help = "Input JSON file",
-        long_help = "Input file to read JSON from. If not provided, reads from stdin.\nSupports any valid JSON file."
+        long_help = "Input file to read JSON from. If not provided, reads from stdin.\nSupports any valid JSON file.\n\n\
+            The file can also be passed as a trailing positional argument:\n  \
+            jpx 'users[*].name' data.json\n\n\
+            When the last positional argument is an existing file, it is used as input\n\
+            instead of being treated as an expression."
     )]
     pub(crate) file: Option<String>,
 

--- a/docs/src/cli/basic-usage.md
+++ b/docs/src/cli/basic-usage.md
@@ -17,9 +17,16 @@ curl -s https://api.example.com/data | jpx 'results[0]'
 ### File Input
 
 ```bash
+# Trailing argument (jq-style)
+jpx 'users[*].name' data.json
+
+# Explicit flag
 jpx 'users[*].name' -f data.json
 jpx --file users.json 'length(@)'
 ```
+
+When the last positional argument is an existing file, jpx automatically uses it as input.
+The `-f` flag is still supported for explicitness or when the file doesn't exist yet.
 
 ### Null Input
 
@@ -106,9 +113,10 @@ Output:
 
 ## Expression as Positional Argument
 
-The expression can be the first positional argument:
+The expression can be the first positional argument, with an optional trailing file:
 
 ```bash
+jpx 'users[*].name' data.json
 jpx 'users[*].name' -f data.json
 ```
 

--- a/docs/src/cli/working-with-files.md
+++ b/docs/src/cli/working-with-files.md
@@ -19,7 +19,15 @@ curl -s https://api.example.com/data | jpx 'items[0]'
 
 ### From a File
 
-Use `-f` or `--file` to read from a file:
+Pass the file as a trailing argument (jq-style):
+
+```bash
+jpx 'users[*].name' data.json
+
+jpx 'settings.theme' config.json
+```
+
+Or use `-f` / `--file` explicitly:
 
 ```bash
 jpx -f data.json 'users[*].name'


### PR DESCRIPTION
## Summary

- Update CLI `--file` help text to mention the trailing positional argument pattern
- Update basic-usage.md to show `jpx 'expr' data.json` as the primary file input syntax
- Update working-with-files.md to lead with the jq-style trailing file pattern

Companion to #64, which implements the feature.

## Files changed

- `crates/jpx/src/args.rs` - `--file` long help mentions trailing arg
- `docs/src/cli/basic-usage.md` - File input and expression sections updated
- `docs/src/cli/working-with-files.md` - "From a File" section updated

## Test plan

- [x] `cargo clippy` passes
- [x] Docs render correctly (no broken markdown)