### PR TITLE
chore: bump MSRV to 1.90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.88"
+          toolchain: "1.90"
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV
-        # Some deps require 1.88+
+        # tower-mcp 0.5 requires 1.90+
         run: cargo check --no-default-features --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ default-members = ["crates/jpx"]
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/jpx"

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jpx-core"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jpx-engine"
 version = "0.2.0"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/jpx-mcp/Cargo.toml
+++ b/crates/jpx-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jpx-mcp"
 version = "0.1.4"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jpx"
 version = "0.3.0"
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Bump CI MSRV toolchain from 1.88 to 1.90 (`tower-mcp@0.5.0` requires 1.90)
- Add `rust-version = "1.90"` to workspace root Cargo.toml
- Add `rust-version.workspace = true` to all published crates (jpx, jpx-core, jpx-engine, jpx-mcp)

Unblocks #59 (tower-mcp 0.5 upgrade).

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI MSRV job passes with 1.90 toolchain