### PR TITLE
fix: update stale jmespath-extensions references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 JMESPath CLI and tools with 400+ extended functions - a powerful jq alternative.
 
-This repository contains the tooling built on [jmespath-extensions](https://github.com/joshrotenberg/jmespath-extensions):
+This repository contains the jpx ecosystem:
 
 | Package | Description |
 |---------|-------------|
@@ -77,13 +77,13 @@ The library provides 400+ functions across these categories:
 | **Fuzzy** | `levenshtein`, `jaro_winkler`, `soundex`, `metaphone` |
 | **Expression** | `map_expr`, `filter_expr`, `sort_by_expr`, `group_by_expr` |
 
-See [jmespath-extensions](https://github.com/joshrotenberg/jmespath-extensions) for the full function reference.
+See the [documentation](https://joshrotenberg.github.io/jpx/) for the full function reference.
 
 ## Acknowledgments
 
 - **[JMESPath](https://jmespath.org/)** - The query language specification
 - **[jmespath.rs](https://crates.io/crates/jmespath)** - Rust implementation by [@mtdowling](https://github.com/mtdowling)
-- **[jmespath-extensions](https://github.com/joshrotenberg/jmespath-extensions)** - Extended function library
+- **[jpx-core](crates/jpx-core/)** - JMESPath implementation with 400+ extension functions
 
 ## License
 

--- a/crates/jpx/README.md
+++ b/crates/jpx/README.md
@@ -38,7 +38,7 @@ jq '.name | ascii_upcase'               jpx 'upper(name)'
 
 **Choose jq** for: streaming large files, custom function definitions, complex recursive transformations.
 
-**[Full comparison →](https://joshrotenberg.github.io/jmespath-extensions/examples/jq-comparison.html)**
+**[Full comparison →](https://joshrotenberg.github.io/jpx/cli/why-jpx/)**
 
 ## Quick Start (Docker)
 
@@ -104,7 +104,7 @@ cargo install jpx-mcp
 docker run -i --rm ghcr.io/joshrotenberg/jpx-mcp
 ```
 
-See the [MCP documentation](https://joshrotenberg.github.io/jmespath-extensions/server/mcp/overview.html) for setup instructions with Claude Desktop.
+See the [MCP documentation](https://joshrotenberg.github.io/jpx/mcp/overview/) for setup instructions with Claude Desktop.
 
 ## Usage
 
@@ -526,16 +526,16 @@ echo '{"ip": "192.168.1.1"}' | jpx 'is_ipv4(ip)'
 ### Expression Functions (Higher-Order)
 
 ```bash
-# Filter with expression (expression string first, then array)
-echo '[{"age": 25}, {"age": 17}, {"age": 30}]' | jpx 'filter_expr(`"age >= \`18\`"`, @)'
+# Filter with expression reference
+echo '[{"age": 25}, {"age": 17}, {"age": 30}]' | jpx 'filter_expr(&age >= `18`, @)'
 # [{"age": 25}, {"age": 30}]
 
-# Map with expression (extract field from each object)
-echo '[{"name": "Alice"}, {"name": "Bob"}]' | jpx 'map_expr(`"name"`, @)'
+# Map with expression reference
+echo '[{"name": "Alice"}, {"name": "Bob"}]' | jpx 'map_expr(&name, @)'
 # ["Alice", "Bob"]
 
-# Group by expression
-echo '[{"type": "a", "v": 1}, {"type": "b", "v": 2}, {"type": "a", "v": 3}]' | jpx 'group_by_expr(`"type"`, @)'
+# Group by expression reference
+echo '[{"type": "a", "v": 1}, {"type": "b", "v": 2}, {"type": "a", "v": 3}]' | jpx 'group_by_expr(&type, @)'
 # {"a": [{"type": "a", "v": 1}, {"type": "a", "v": 3}], "b": [{"type": "b", "v": 2}]}
 ```
 


### PR DESCRIPTION
## Summary

- **Root README**: Remove reference to jmespath-extensions as upstream library, point function reference link to jpx docs site, update acknowledgments to reference jpx-core
- **Crate README**: Fix jq comparison and MCP docs links to point to jpx docs site instead of old jmespath-extensions GitHub Pages, fix expression function examples to use native expref syntax (`&expr`) instead of deprecated string-based syntax

## Remaining valid references

The Python bindings (`jmespath-extensions` on PyPI) links in `mkdocs.yml`, `docs/src/libraries.md`, and `docs/src/index.md` are still correct and unchanged.

## Test plan

- [x] All links point to existing pages
- [x] Expression examples use correct native expref syntax