### PR TITLE
fix: resolve 13 ignored tests in jpx-core

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -1477,6 +1477,16 @@ aliases = ["fold"]
 features = ["core", "fp"]
 
 [[functions]]
+name = "fold"
+category = "expression"
+description = "Alias for reduce_expr - reduce array to single value using accumulator expression"
+signature = "string, array, any -> any"
+examples = [
+    { code = "fold(&add(accumulator, current), [1, 2, 3], `0`) -> 6", description = "Sum numbers" },
+]
+features = ["core", "fp"]
+
+[[functions]]
 name = "reject"
 category = "expression"
 description = "Keep elements where expression is falsy (inverse of filter_expr)"
@@ -2459,6 +2469,50 @@ examples = [
 ]
 features = ["core"]
 
+[[functions]]
+name = "histogram"
+category = "math"
+description = "Compute histogram bins for an array of numbers"
+signature = "array, number -> array[object]"
+examples = [
+    { code = "histogram([1, 2, 3, 4, 5], `3`) -> [{min: 1.0, max: 2.33, count: 2}, ...]", description = "3 bins" },
+    { code = "histogram([10, 20, 30], `2`) -> [{min: 10.0, max: 20.0, count: 2}, {min: 20.0, max: 30.0, count: 1}]", description = "2 bins" },
+]
+features = ["core"]
+
+[[functions]]
+name = "normalize"
+category = "math"
+description = "Min-max normalize an array of numbers to [0, 1] range"
+signature = "array -> array"
+examples = [
+    { code = "normalize([1, 3, 5]) -> [0.0, 0.5, 1.0]", description = "Basic normalization" },
+    { code = "normalize([10, 10, 10]) -> [0, 0, 0]", description = "All same values" },
+]
+features = ["core"]
+
+[[functions]]
+name = "z_score"
+category = "math"
+description = "Compute z-scores (standard scores) for an array of numbers"
+signature = "array -> array"
+examples = [
+    { code = "z_score([1, 3, 5]) -> [-1.22, 0.0, 1.22]", description = "Basic z-scores" },
+    { code = "z_score([10, 20, 30])[1] -> 0.0", description = "Middle value is 0" },
+]
+features = ["core"]
+
+[[functions]]
+name = "correlation"
+category = "math"
+description = "Compute Pearson correlation coefficient between two arrays"
+signature = "array, array -> number"
+examples = [
+    { code = "correlation([1, 2, 3], [1, 2, 3]) -> 1.0", description = "Perfect positive" },
+    { code = "correlation([1, 2, 3], [3, 2, 1]) -> -1.0", description = "Perfect negative" },
+]
+features = ["core"]
+
 # =============================================================================
 # MULTIMATCH FUNCTIONS
 # =============================================================================
@@ -2570,14 +2624,14 @@ examples = [
 features = ["core"]
 
 [[functions]]
-name = "tokenize"
+name = "mm_tokenize"
 category = "multimatch"
 description = "Smart word tokenization with optional lowercase and min_length"
 signature = "string, object? -> array[string]"
 examples = [
-    { code = '''tokenize('Hello, World!') -> [\"Hello\", \"World\"]''', description = "Basic tokenization" },
-    { code = '''tokenize('Hello, World!', {lowercase: `true`}) -> [\"hello\", \"world\"]''', description = "Lowercase option" },
-    { code = '''tokenize('a bb ccc', {min_length: `2`}) -> [\"bb\", \"ccc\"]''', description = "Minimum length" },
+    { code = '''mm_tokenize('Hello, World!') -> [\"Hello\", \"World\"]''', description = "Basic tokenization" },
+    { code = '''mm_tokenize('Hello, World!', {lowercase: `true`}) -> [\"hello\", \"world\"]''', description = "Lowercase option" },
+    { code = '''mm_tokenize('a bb ccc', {min_length: `2`}) -> [\"bb\", \"ccc\"]''', description = "Minimum length" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/expression.rs
+++ b/crates/jpx-core/src/extensions/expression.rs
@@ -2010,7 +2010,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // fold alias not registered: missing standalone entry in functions.toml
     fn test_fold_alias() {
         let runtime = setup_runtime();
         let data = json!([1, 2, 3]);

--- a/crates/jpx-core/src/extensions/math.rs
+++ b/crates/jpx-core/src/extensions/math.rs
@@ -1620,7 +1620,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // histogram not yet in functions.toml
     fn test_histogram() {
         let runtime = setup_runtime();
         let expr = runtime.compile("histogram(@, `3`)").unwrap();
@@ -1638,7 +1637,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // normalize not yet in functions.toml
     fn test_normalize() {
         let runtime = setup_runtime();
         let expr = runtime.compile("normalize(@)").unwrap();
@@ -1652,7 +1650,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // z_score not yet in functions.toml
     fn test_z_score() {
         let runtime = setup_runtime();
         let expr = runtime.compile("z_score(@)").unwrap();
@@ -1665,7 +1662,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // correlation not yet in functions.toml
     fn test_correlation_positive() {
         let runtime = setup_runtime();
         let expr = runtime
@@ -1676,7 +1672,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // correlation not yet in functions.toml
     fn test_correlation_negative() {
         let runtime = setup_runtime();
         let expr = runtime

--- a/crates/jpx-core/src/extensions/multi_match.rs
+++ b/crates/jpx-core/src/extensions/multi_match.rs
@@ -642,13 +642,7 @@ mod tests {
         assert_eq!(first.get("end").unwrap().as_f64().unwrap() as i64, 9);
     }
 
-    // mm_tokenize tests
-    // NOTE: mm_tokenize is registered under that name in code but functions.toml
-    // has it as "tokenize" (multimatch category), so register_if_enabled does not
-    // enable it. These tests are ignored until the naming mismatch is resolved.
-
     #[test]
-    #[ignore = "mm_tokenize not in functions.toml (listed as tokenize)"]
     fn test_mm_tokenize_basic() {
         let runtime = setup_runtime();
         let data = json!("Hello, world! This is a test.");
@@ -660,7 +654,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "mm_tokenize not in functions.toml (listed as tokenize)"]
     fn test_mm_tokenize_with_options() {
         let runtime = setup_runtime();
         let data = json!("Hello, world! A test.");

--- a/crates/jpx-core/src/extensions/text.rs
+++ b/crates/jpx-core/src/extensions/text.rs
@@ -1138,13 +1138,7 @@ mod tests {
     // tokenize tests
     // =========================================================================
 
-    // NOTE: tokenize tests are ignored because the multimatch category in
-    // functions.toml also has a "tokenize" entry which overwrites the text
-    // category's entry in the registry HashMap, preventing text::tokenize
-    // from being registered. Same issue as mm_tokenize in multi_match.rs.
-
     #[test]
-    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
     fn test_tokenize_default() {
         let runtime = setup_runtime();
         let data = json!("Hello, World!");
@@ -1157,7 +1151,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
     fn test_tokenize_preserve_case() {
         let runtime = setup_runtime();
         let data = json!("Hello, World!");
@@ -1172,7 +1165,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
     fn test_tokenize_upper_case() {
         let runtime = setup_runtime();
         let data = json!("Hello, World!");
@@ -1187,7 +1179,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
     fn test_tokenize_keep_punctuation() {
         let runtime = setup_runtime();
         let data = json!("Hello, World!");
@@ -1202,7 +1193,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "tokenize not registered: multimatch 'tokenize' overwrites text 'tokenize' in registry"]
     fn test_tokenize_preserve_case_keep_punctuation() {
         let runtime = setup_runtime();
         let data = json!("Hello, World!");


### PR DESCRIPTION
## Summary

- Rename multimatch `tokenize` to `mm_tokenize` in `functions.toml` to match code registration name, resolving name collision with `text::tokenize` (7 tests)
- Add `histogram`, `normalize`, `z_score`, `correlation` to `functions.toml` under math category (5 tests)
- Add standalone `fold` entry to `functions.toml` for the `reduce_expr` alias (1 test)
- Remove all `#[ignore]` markers -- all 13 tests now pass

## Test plan

- [x] All 13 previously-ignored tests pass
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt` clean

Closes #57