### PR TITLE
chore: add missing metadata to workspace Cargo.toml files

### DIFF
--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -6,7 +6,9 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "Complete JMESPath implementation with 400+ extension functions"
+documentation = "https://docs.rs/jpx-core"
 keywords = ["jmespath", "json", "query", "parser"]
 categories = ["data-structures", "parsing"]
 

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -6,7 +6,9 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "JMESPath query engine with introspection, discovery, and advanced features"
+documentation = "https://docs.rs/jpx-engine"
 keywords = ["jmespath", "json", "query", "engine"]
 categories = ["data-structures", "parsing"]
 

--- a/crates/jpx-mcp/Cargo.toml
+++ b/crates/jpx-mcp/Cargo.toml
@@ -6,7 +6,9 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 description = "JMESPath MCP server for AI assistants"
+documentation = "https://docs.rs/jpx-mcp"
 keywords = ["jmespath", "json", "mcp", "server", "ai"]
 categories = ["network-programming", "development-tools"]
 


### PR DESCRIPTION
## Summary

- Add `homepage.workspace = true` to jpx-core, jpx-engine, jpx-mcp (was only on jpx CLI)
- Add `documentation` field pointing to docs.rs for jpx-core, jpx-engine, jpx-mcp

No sub-crate READMEs exist, so `readme` field not added. jpx-python (`publish = false`) left as-is.

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] No functional changes, metadata only

Closes #69