### PR TITLE
chore: unify jpx and jpx-mcp versioning at 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/jpx-mcp/Cargo.toml
+++ b/crates/jpx-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-mcp"
-version = "0.1.4"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

- Add `version = "0.4.0"` to `[workspace.package]` in root Cargo.toml
- Change jpx and jpx-mcp to `version.workspace = true` so both apps release in lockstep
- Libraries keep independent semver: jpx-core (0.1.0), jpx-engine (0.2.0)

| Crate | Before | After | Inheritance |
|-------|--------|-------|-------------|
| jpx | 0.3.0 | 0.4.0 | workspace |
| jpx-mcp | 0.1.4 | 0.4.0 | workspace |
| jpx-core | 0.1.0 | 0.1.0 | independent |
| jpx-engine | 0.2.0 | 0.2.0 | independent |
| jpx-python | 0.1.0 | 0.1.0 | independent |

## Test plan

- [x] `cargo check --workspace --all-features` passes
- [x] `cargo metadata` confirms correct versions for all crates
- [ ] Verify release-plz handles the workspace version correctly on next release cycle

Closes #63