### PR TITLE
fix: replace comma-counting arity detection with bracket-aware parser

### DIFF
--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -1005,7 +1005,10 @@ mod tests {
             2
         );
         // nested brackets
-        assert_eq!(super::count_params("array[object[string, number]] -> array"), 1);
+        assert_eq!(
+            super::count_params("array[object[string, number]] -> array"),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace naive `signature.matches(',').count() + 1` with bracket-depth-aware parser
- Correctly handles signatures like `array, array[[string, string]] -> array` (2 params, not 4)
- Strips return type (`->`) before counting
- Handles optional (`?`), variadic (`...`), and empty signatures

## Test plan

- [x] 6 new tests covering: simple, brackets, optional/variadic, empty, and end-to-end arity matching
- [x] All existing similar_functions tests still pass
- [x] Clippy clean

Closes #28