### PR TITLE
docs: companion .jpx query files for all guides

### DIFF
--- a/docs/src/cli/examples.md
+++ b/docs/src/cli/examples.md
@@ -401,6 +401,17 @@ Available queries in queries.jpx:
     Count errors by service
 ```
 
+### Use query libraries
+
+Many of these cookbook patterns are available as a `.jpx` query library. See [examples/cookbook.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/cookbook.jpx):
+
+```bash
+jpx -Q examples/cookbook.jpx --list-queries
+jpx -Q examples/cookbook.jpx:filter-sort-transform data.json
+```
+
+See [Query Files](query-files.md) for more on creating and using query libraries.
+
 ### Debug complex expressions
 
 When a query isn't working, break it down:

--- a/docs/src/guides/earthquakes.md
+++ b/docs/src/guides/earthquakes.md
@@ -403,6 +403,29 @@ jpx 'features
 
 ---
 
+## Using Query Libraries
+
+Instead of typing these queries repeatedly, save them in a `.jpx` query library. See [examples/earthquakes.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/earthquakes.jpx) for a ready-to-use library:
+
+```bash
+# List available queries
+jpx -Q examples/earthquakes.jpx --list-queries
+
+# Run common analyses
+jpx -Q examples/earthquakes.jpx:mag-stats earthquakes.json
+jpx -Q examples/earthquakes.jpx:summary-report earthquakes.json
+
+# Sort by magnitude
+jpx -Q examples/earthquakes.jpx:sort-by-mag earthquakes.json
+
+# Output as table
+jpx -Q examples/earthquakes.jpx:coordinates -t earthquakes.json
+```
+
+See [Query Files](../cli/query-files.md) for more on creating and using query libraries.
+
+---
+
 ## Try It Yourself
 
 1. **Fetch live data**: The USGS API updates in real-time

--- a/docs/src/guides/nasa-neo.md
+++ b/docs/src/guides/nasa-neo.md
@@ -429,6 +429,27 @@ jpx 'near_earth_objects."2024-01-15"[*].name' neo_day.json
 
 ---
 
+## Using Query Libraries
+
+Instead of typing these queries repeatedly, save them in a `.jpx` query library. See [examples/nasa-neo.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/nasa-neo.jpx) for a ready-to-use library:
+
+```bash
+# List available queries
+jpx -Q examples/nasa-neo.jpx --list-queries
+
+# Run common analyses
+jpx -Q examples/nasa-neo.jpx:hazardous neo_browse.json
+jpx -Q examples/nasa-neo.jpx:risk-report neo_browse.json
+jpx -Q examples/nasa-neo.jpx:top-5-largest neo_browse.json
+
+# Output as table
+jpx -Q examples/nasa-neo.jpx:closest-approaches -t neo_browse.json
+```
+
+See [Query Files](../cli/query-files.md) for more on creating and using query libraries.
+
+---
+
 ## Try It Yourself
 
 1. **Get your free API key**: [api.nasa.gov](https://api.nasa.gov/)

--- a/docs/src/guides/nobel-prize.md
+++ b/docs/src/guides/nobel-prize.md
@@ -403,6 +403,27 @@ jpx '{
 
 ---
 
+## Using Query Libraries
+
+Instead of typing these queries repeatedly, save them in a `.jpx` query library. See [examples/nobel-prize.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/nobel-prize.jpx) for a ready-to-use library:
+
+```bash
+# List available queries
+jpx -Q examples/nobel-prize.jpx --list-queries
+
+# Run common analyses
+jpx -Q examples/nobel-prize.jpx:summary-by-category laureates.json
+jpx -Q examples/nobel-prize.jpx:female laureates.json
+jpx -Q examples/nobel-prize.jpx:age-at-award laureates.json
+
+# Export as CSV
+jpx --csv -Q examples/nobel-prize.jpx:flatten-export laureates.json
+```
+
+See [Query Files](../cli/query-files.md) for more on creating and using query libraries.
+
+---
+
 ## Try It Yourself
 
 1. **Explore the API**:

--- a/docs/src/guides/project-management.md
+++ b/docs/src/guides/project-management.md
@@ -694,6 +694,27 @@ This guide demonstrates functions from these categories:
 
 ---
 
+## Using Query Libraries
+
+Instead of typing these queries repeatedly, save them in a `.jpx` query library. See [examples/project-management.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/project-management.jpx) for a ready-to-use library:
+
+```bash
+# List available queries
+jpx -Q examples/project-management.jpx --list-queries
+
+# Run common analyses
+jpx -Q examples/project-management.jpx:dashboard projects.json
+jpx -Q examples/project-management.jpx:stale-projects projects.json
+jpx -Q examples/project-management.jpx:status-counts projects.json
+
+# Output as table
+jpx -Q examples/project-management.jpx:full-export -t projects.json
+```
+
+See [Query Files](../cli/query-files.md) for more on creating and using query libraries.
+
+---
+
 ## Try It Yourself
 
 Save the sample dataset to a file and experiment:

--- a/docs/src/guides/standard-jmespath.md
+++ b/docs/src/guides/standard-jmespath.md
@@ -513,6 +513,24 @@ Output:
 
 ---
 
+## Using Query Libraries
+
+All the queries in this guide are available as a `.jpx` query library. See [examples/standard-jmespath.jpx](https://github.com/joshrotenberg/jpx/blob/main/examples/standard-jmespath.jpx) for a ready-to-use library:
+
+```bash
+# List available queries
+jpx -Q examples/standard-jmespath.jpx --list-queries
+
+# Run standard-only queries
+jpx -Q examples/standard-jmespath.jpx:top-3-available books.json
+jpx -Q examples/standard-jmespath.jpx:library-report books.json
+jpx -Q examples/standard-jmespath.jpx:stats books.json
+```
+
+See [Query Files](../cli/query-files.md) for more on creating and using query libraries.
+
+---
+
 ## When to Use Extensions
 
 Standard JMESPath is powerful for basic transformations, but you'll want extensions for:

--- a/examples/cookbook.jpx
+++ b/examples/cookbook.jpx
@@ -1,0 +1,71 @@
+-- :name nested-field
+-- :desc Get a nested field
+user.profile.name
+
+-- :name pick-fields
+-- :desc Pick specific fields from an object
+{id: id, name: name}
+
+-- :name array-field
+-- :desc Get a field from every object in an array
+[*].name
+
+-- :name filter-status
+-- :desc Filter by a field condition
+[?status == `"active"`]
+
+-- :name filter-multi
+-- :desc Filter by multiple conditions
+[?age > `30` && active]
+
+-- :name filter-nested
+-- :desc Filter by nested field value
+[?user.role == `"admin"`]
+
+-- :name rename-fields
+-- :desc Rename fields in projection
+{first: firstName, last: lastName}
+
+-- :name computed-field
+-- :desc Add a computed field
+{price: price, qty: qty, total: multiply(price, qty)}
+
+-- :name snake-keys
+-- :desc Convert object keys to snake_case
+snake_keys(@)
+
+-- :name sort-objects
+-- :desc Sort objects by field
+sort_by(@, &name)
+
+-- :name unique
+-- :desc Remove duplicates from array
+unique(@)
+
+-- :name group-by
+-- :desc Group array elements by field
+group_by(@, `"dept"`)
+
+-- :name chunk
+-- :desc Split array into batches
+chunk(@, `3`)
+
+-- :name remove-nulls
+-- :desc Remove null values from object
+remove_nulls(@)
+
+-- :name remove-empty
+-- :desc Remove all empty values (null, empty string, empty array, empty object)
+remove_empty(@)
+
+-- :name pick-keys
+-- :desc Pick specific keys from object
+pick(@, [`"a"`, `"c"`])
+
+-- :name omit-keys
+-- :desc Omit specific keys from object
+omit(@, [`"b"`])
+
+-- :name filter-sort-transform
+-- :desc Extract, filter, transform, and sort pipeline
+[?dept == `"eng"`] | sort_by(@, &salary) | [*].{name: name, salary: salary}

--- a/examples/earthquakes.jpx
+++ b/examples/earthquakes.jpx
@@ -1,0 +1,127 @@
+-- :name titles
+-- :desc List all earthquake titles
+features[*].properties.title
+
+-- :name magnitudes
+-- :desc Get all magnitudes
+features[*].properties.mag
+
+-- :name count
+-- :desc Count total events
+length(features)
+
+-- :name major
+-- :desc Find earthquakes with magnitude 6+
+features[?properties.mag >= `6`].properties.title
+
+-- :name deep
+-- :desc Find deep earthquakes (> 100km depth)
+features[?geometry.coordinates[2] > `100`].{
+  title: properties.title,
+  depth_km: geometry.coordinates[2]
+}
+
+-- :name tsunami-alerts
+-- :desc Find earthquakes with tsunami alerts
+features[?properties.tsunami == `1`].properties.title
+
+-- :name by-location
+-- :desc Filter earthquakes near Russia
+features[?contains(properties.place, `Russia`)].properties.title
+
+-- :name mag-stats
+-- :desc Magnitude statistics summary
+{
+  count: length(features),
+  min: min(features[*].properties.mag),
+  max: max(features[*].properties.mag),
+  avg: avg(features[*].properties.mag),
+  median: median(features[*].properties.mag),
+  stddev: round(stddev(features[*].properties.mag), `3`)
+}
+
+-- :name depth-stats
+-- :desc Depth statistics summary
+{
+  shallowest: min(features[*].geometry.coordinates[2]),
+  deepest: max(features[*].geometry.coordinates[2]),
+  avg_depth: round(avg(features[*].geometry.coordinates[2]), `1`)
+}
+
+-- :name sort-by-mag
+-- :desc Sort by magnitude descending
+sort_by(features, &properties.mag) | reverse(@) | [*].{
+  mag: properties.mag,
+  place: properties.place
+}
+
+-- :name top-3-significance
+-- :desc Top 3 by significance score
+sort_by(features, &properties.sig) | reverse(@) | [:3] | [*].{
+  significance: properties.sig,
+  title: properties.title
+}
+
+-- :name coordinates
+-- :desc Extract place, latitude, longitude
+features[*].{
+  place: properties.place,
+  lat: geometry.coordinates[1],
+  lon: geometry.coordinates[0]
+}
+
+-- :name distance-from-sf
+-- :desc Distance from San Francisco sorted by proximity
+features[*].{
+  place: properties.place,
+  distance_km: round(geo_distance_km(
+    `37.7749`, `-122.4194`,
+    geometry.coordinates[1], geometry.coordinates[0]
+  ), `0`)
+} | sort_by(@, &distance_km)
+
+-- :name timestamps
+-- :desc Convert timestamps to readable dates
+features[*].{
+  title: properties.title,
+  date: from_unixtime(floor(divide(properties.time, `1000`)))
+}
+
+-- :name flatten
+-- :desc Flatten to flat structure for export
+features[*].{
+  id: id,
+  magnitude: properties.mag,
+  location: properties.place,
+  longitude: geometry.coordinates[0],
+  latitude: geometry.coordinates[1],
+  depth_km: geometry.coordinates[2],
+  timestamp: properties.time
+}
+
+-- :name summary-report
+-- :desc Comprehensive earthquake summary report
+{
+  report_title: `USGS Earthquake Summary`,
+  generated: metadata.title,
+  total_events: length(features),
+  magnitude_stats: {
+    min: min(features[*].properties.mag),
+    max: max(features[*].properties.mag),
+    average: round(avg(features[*].properties.mag), `2`),
+    median: median(features[*].properties.mag)
+  },
+  depth_stats: {
+    shallowest_km: min(features[*].geometry.coordinates[2]),
+    deepest_km: max(features[*].geometry.coordinates[2])
+  },
+  major_events: features[?properties.mag >= `5.5`] | [*].{
+    magnitude: properties.mag,
+    location: properties.place
+  },
+  by_region: {
+    russia: length(features[?contains(properties.place, `Russia`)]),
+    indonesia: length(features[?contains(properties.place, `Indonesia`)]),
+    chile: length(features[?contains(properties.place, `Chile`)])
+  }
+}

--- a/examples/nasa-neo.jpx
+++ b/examples/nasa-neo.jpx
@@ -1,0 +1,141 @@
+-- :name names
+-- :desc List all asteroid names
+near_earth_objects[*].name
+
+-- :name short-names
+-- :desc List short/common names
+near_earth_objects[*].name_limited
+
+-- :name total-count
+-- :desc Total known NEOs from page metadata
+page.total_elements
+
+-- :name hazardous
+-- :desc Find potentially hazardous asteroids
+near_earth_objects[?is_potentially_hazardous_asteroid == `true`].{
+  name: name_limited,
+  diameter_km: estimated_diameter.kilometers.estimated_diameter_max
+}
+
+-- :name large
+-- :desc Find asteroids larger than 1km
+near_earth_objects[?estimated_diameter.kilometers.estimated_diameter_max > `1`].{
+  name: name,
+  max_diameter_km: estimated_diameter.kilometers.estimated_diameter_max,
+  hazardous: is_potentially_hazardous_asteroid
+}
+
+-- :name diameter-estimates
+-- :desc Diameter range estimates in km
+near_earth_objects[*].{
+  name: name_limited,
+  min_km: estimated_diameter.kilometers.estimated_diameter_min,
+  max_km: estimated_diameter.kilometers.estimated_diameter_max
+}
+
+-- :name avg-diameter
+-- :desc Calculate average diameter for each asteroid
+near_earth_objects[*].{
+  name: name_limited,
+  avg_diameter_km: divide(
+    add(
+      estimated_diameter.kilometers.estimated_diameter_min,
+      estimated_diameter.kilometers.estimated_diameter_max
+    ),
+    `2`
+  )
+}
+
+-- :name next-approach
+-- :desc Get next close approach date and distance
+near_earth_objects[*].{
+  name: name_limited,
+  next_approach: close_approach_data[0].close_approach_date,
+  miss_distance_km: close_approach_data[0].miss_distance.kilometers
+}
+
+-- :name closest-approaches
+-- :desc Sort by closest miss distance
+near_earth_objects[*].{
+  name: name_limited,
+  miss_km: to_number(close_approach_data[0].miss_distance.kilometers)
+} | sort_by(@, &miss_km) | [:10]
+
+-- :name high-speed
+-- :desc Find high-speed approaches (> 50,000 kph)
+near_earth_objects[*].{
+  name: name_limited,
+  speed_kph: to_number(close_approach_data[0].relative_velocity.kilometers_per_hour),
+  date: close_approach_data[0].close_approach_date
+} | [?speed_kph > `50000`]
+
+-- :name size-stats
+-- :desc Size statistics across all NEOs
+{
+  count: length(near_earth_objects),
+  smallest_km: min(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_min),
+  largest_km: max(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_max),
+  avg_max_km: round(avg(near_earth_objects[*].estimated_diameter.kilometers.estimated_diameter_max), `2`)
+}
+
+-- :name hazard-stats
+-- :desc Hazard classification statistics
+{
+  total: length(near_earth_objects),
+  hazardous: length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+  safe: length(near_earth_objects[?is_potentially_hazardous_asteroid == `false`]),
+  hazard_percentage: multiply(
+    divide(
+      length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+      length(near_earth_objects)
+    ),
+    `100`
+  )
+}
+
+-- :name top-5-largest
+-- :desc Top 5 largest asteroids
+sort_by(near_earth_objects, &estimated_diameter.kilometers.estimated_diameter_max)
+  | reverse(@)
+  | [:5]
+  | [*].{
+      name: name,
+      max_diameter_km: round(estimated_diameter.kilometers.estimated_diameter_max, `2`),
+      hazardous: is_potentially_hazardous_asteroid
+    }
+
+-- :name flatten-export
+-- :desc Flatten for analysis/CSV export
+near_earth_objects[*].{
+  id: id,
+  name: name_limited,
+  magnitude: absolute_magnitude_h,
+  diameter_min_km: estimated_diameter.kilometers.estimated_diameter_min,
+  diameter_max_km: estimated_diameter.kilometers.estimated_diameter_max,
+  is_hazardous: is_potentially_hazardous_asteroid,
+  next_approach_date: close_approach_data[0].close_approach_date,
+  miss_distance_km: close_approach_data[0].miss_distance.kilometers,
+  velocity_kph: close_approach_data[0].relative_velocity.kilometers_per_hour,
+  jpl_url: nasa_jpl_url
+}
+
+-- :name risk-report
+-- :desc Comprehensive risk assessment report
+{
+  report_title: `Near Earth Object Risk Assessment`,
+  total_objects: page.total_elements,
+  sample_size: length(near_earth_objects),
+  potentially_hazardous: {
+    count: length(near_earth_objects[?is_potentially_hazardous_asteroid == `true`]),
+    objects: near_earth_objects[?is_potentially_hazardous_asteroid == `true`] | [*].{
+      name: name,
+      diameter_km: round(estimated_diameter.kilometers.estimated_diameter_max, `2`),
+      next_approach: close_approach_data[0].close_approach_date,
+      miss_lunar: close_approach_data[0].miss_distance.lunar
+    }
+  },
+  largest_objects: sort_by(near_earth_objects, &estimated_diameter.kilometers.estimated_diameter_max)
+    | reverse(@)
+    | [:3]
+    | [*].{name: name_limited, km: round(estimated_diameter.kilometers.estimated_diameter_max, `1`)}
+}

--- a/examples/nobel-prize.jpx
+++ b/examples/nobel-prize.jpx
@@ -1,0 +1,116 @@
+-- :name names
+-- :desc List all laureate names
+laureates[*].knownName.en
+
+-- :name name-year-category
+-- :desc Get name, prize year, and category
+laureates[*].{
+  name: knownName.en,
+  year: nobelPrizes[0].awardYear,
+  category: nobelPrizes[0].category.en
+}
+
+-- :name count
+-- :desc Count laureates
+length(laureates)
+
+-- :name physics
+-- :desc Find Physics laureates
+laureates[?nobelPrizes[0].category.en == `Physics`].knownName.en
+
+-- :name female
+-- :desc Find female laureates
+laureates[?gender == `female`].{
+  name: knownName.en,
+  category: nobelPrizes[0].category.en,
+  year: nobelPrizes[0].awardYear
+}
+
+-- :name living
+-- :desc Find living laureates
+laureates[?death == null].{
+  name: knownName.en,
+  born: birth.date
+}
+
+-- :name by-country
+-- :desc Find laureates born in a specific country (USA)
+laureates[?birth.place.country.en == `USA`].{
+  name: knownName.en,
+  city: birth.place.city.en
+}
+
+-- :name multiple-prizes
+-- :desc Find laureates with multiple Nobel Prizes
+laureates[?length(nobelPrizes) > `1`].{
+  name: knownName.en,
+  prizes: nobelPrizes[*].{
+    year: awardYear,
+    category: category.en
+  }
+}
+
+-- :name age-at-award
+-- :desc Calculate age at time of award
+laureates[?birth.date != null].{
+  name: knownName.en,
+  born: split(birth.date, `-`)[0],
+  awarded: nobelPrizes[0].awardYear,
+  age_at_award: subtract(
+    to_number(nobelPrizes[0].awardYear),
+    to_number(split(birth.date, `-`)[0])
+  )
+}
+
+-- :name country-frequency
+-- :desc Count laureates by birth country
+frequencies(laureates[*].birth.place.country.en)
+
+-- :name affiliations
+-- :desc Extract university affiliations
+laureates[*].{
+  name: knownName.en,
+  university: nobelPrizes[0].affiliations[0].name.en,
+  country: nobelPrizes[0].affiliations[0].country.en
+}
+
+-- :name quantum-research
+-- :desc Find laureates whose work involved quantum
+laureates[?contains(lower(to_string(nobelPrizes[*].motivation.en)), `quantum`)].{
+  name: knownName.en,
+  motivation: nobelPrizes[0].motivation.en
+}
+
+-- :name flatten-export
+-- :desc Flatten for CSV export
+laureates[*].{
+  id: id,
+  name: knownName.en,
+  gender: gender,
+  birth_date: birth.date,
+  birth_country: birth.place.country.en,
+  death_date: death.date,
+  prize_year: nobelPrizes[0].awardYear,
+  prize_category: nobelPrizes[0].category.en,
+  prize_portion: nobelPrizes[0].portion,
+  motivation: nobelPrizes[0].motivation.en
+}
+
+-- :name summary-by-category
+-- :desc Count laureates per prize category
+{
+  physics: length(laureates[?nobelPrizes[0].category.en == `Physics`]),
+  chemistry: length(laureates[?nobelPrizes[0].category.en == `Chemistry`]),
+  medicine: length(laureates[?contains(nobelPrizes[0].category.en, `Medicine`) || contains(nobelPrizes[0].category.en, `Physiology`)]),
+  literature: length(laureates[?nobelPrizes[0].category.en == `Literature`]),
+  peace: length(laureates[?nobelPrizes[0].category.en == `Peace`]),
+  economics: length(laureates[?contains(nobelPrizes[0].category.en, `Economic`)])
+}
+
+-- :name solo-winners
+-- :desc Find solo prize winners (no sharing)
+laureates[?nobelPrizes[0].portion == `1`].{
+  name: knownName.en,
+  category: nobelPrizes[0].category.en,
+  year: nobelPrizes[0].awardYear
+}

--- a/examples/project-management.jpx
+++ b/examples/project-management.jpx
@@ -1,0 +1,95 @@
+-- :name ids
+-- :desc Get all project IDs
+[*].projectId
+
+-- :name names
+-- :desc Get all project names
+[*].details.name
+
+-- :name active
+-- :desc Filter to active projects
+[?status == 'active'].details.name
+
+-- :name no-milestones
+-- :desc Projects with no milestones defined
+[?milestones == `[]`].{id: projectId, name: details.name, status: status}
+
+-- :name status-counts
+-- :desc Count projects by status
+frequencies([*].status)
+
+-- :name all-tags
+-- :desc All unique tags sorted
+unique([*].details.tags[]) | sort(@)
+
+-- :name tag-frequency
+-- :desc How often each tag appears
+frequencies([*].details.tags[])
+
+-- :name by-tag
+-- :desc Find projects with a specific tag (security)
+[?includes(details.tags, 'security')].{id: projectId, name: details.name}
+
+-- :name stale-projects
+-- :desc Projects not modified in 30+ days
+[?date_diff(now(), to_epoch(timestamps.last_modified), 'days') > `30`].details.name
+
+-- :name most-recent
+-- :desc Most recently modified project
+max_by(@, &timestamps.last_modified).details.name
+
+-- :name incomplete-milestones
+-- :desc Projects with pending milestones
+[?milestones[?completed == `false`]].{
+  project: details.name,
+  pending: milestones[?completed == `false`][].phase
+}
+
+-- :name fuzzy-search
+-- :desc Fuzzy match project names
+[?fuzzy_match(details.name, 'energy')].details.name
+
+-- :name keyword-search
+-- :desc Search descriptions for AI or machine learning
+[?contains(details.description, 'AI') || contains(details.description, 'machine learning')].details.name
+
+-- :name slugs
+-- :desc URL-friendly slugs from project names
+[*].{id: projectId, slug: kebab_case(details.name)}
+
+-- :name computed-fields
+-- :desc Add computed milestone count and incomplete flag
+[*].{
+  name: details.name,
+  status: status,
+  milestone_count: length(milestones),
+  has_incomplete: length(milestones[?completed == `false`]) > `0`
+}
+
+-- :name dashboard
+-- :desc Executive dashboard summary
+{
+  total_projects: length(@),
+  active: length([?status == 'active']),
+  pending: length([?status == 'pending']),
+  on_hold: length([?status == 'on-hold']),
+  archived: length([?status == 'archived']),
+  with_milestones: length([?milestones != `[]`]),
+  without_milestones: length([?milestones == `[]`]),
+  incomplete_milestones: length([*].milestones[?completed == `false`][]),
+  newest_project: max_by(@, &timestamps.created_at).details.name,
+  oldest_project: min_by(@, &timestamps.created_at).details.name,
+  unique_tags: length(unique([*].details.tags[]))
+}
+
+-- :name full-export
+-- :desc Rich export with computed fields
+[*].{
+  id: projectId,
+  title: details.name,
+  status: upper(status),
+  tags: join(', ', details.tags),
+  age_days: date_diff(now(), to_epoch(timestamps.created_at), 'days'),
+  last_touch: time_ago(timestamps.last_modified),
+  slug: kebab_case(details.name)
+}

--- a/examples/standard-jmespath.jpx
+++ b/examples/standard-jmespath.jpx
@@ -1,0 +1,82 @@
+-- :name all-titles
+-- :desc Get all book titles
+library.books[*].title
+
+-- :name title-author
+-- :desc Get title and author for each book
+library.books[*].{title: title, author: author}
+
+-- :name available
+-- :desc Find available books
+library.books[?available == `true`].title
+
+-- :name high-rated
+-- :desc Books rated 4.3 or higher
+library.books[?rating >= `4.3`].{title: title, rating: rating}
+
+-- :name year-range
+-- :desc Books from the 1940s
+library.books[?year >= `1940` && year < `1960`].title
+
+-- :name by-author-prefix
+-- :desc Books by authors starting with J
+library.books[?starts_with(author, `J`)].{title: title, author: author}
+
+-- :name dystopian
+-- :desc Books in the dystopian genre
+library.books[?contains(genres, `dystopian`)].title
+
+-- :name sort-by-year
+-- :desc Sort by year (oldest first)
+sort_by(library.books, &year)[*].{title: title, year: year}
+
+-- :name sort-by-rating-desc
+-- :desc Sort by rating (highest first)
+reverse(sort_by(library.books, &rating))[*].{title: title, rating: rating}
+
+-- :name stats
+-- :desc Min/max statistics for year and rating
+{
+  oldest_year: min(library.books[*].year),
+  newest_year: max(library.books[*].year),
+  lowest_rating: min(library.books[*].rating),
+  highest_rating: max(library.books[*].rating)
+}
+
+-- :name top-rated
+-- :desc Find the highest rated book
+max_by(library.books, &rating).{title: title, rating: rating}
+
+-- :name oldest
+-- :desc Find the oldest book
+min_by(library.books, &year).{title: title, year: year}
+
+-- :name top-3-available
+-- :desc Top 3 available books by rating
+library.books
+  | [?available == `true`]
+  | sort_by(@, &rating)
+  | reverse(@)
+  | [:3]
+  | [*].{title: title, rating: rating}
+
+-- :name library-report
+-- :desc Comprehensive library report using standard functions only
+{
+  library_name: library.name,
+  total_books: length(library.books),
+  available_count: length(library.books[?available == `true`]),
+  checked_out_count: length(library.books[?available == `false`]),
+  average_rating: avg(library.books[*].rating),
+  rating_range: {
+    min: min(library.books[*].rating),
+    max: max(library.books[*].rating)
+  },
+  year_range: {
+    oldest: min(library.books[*].year),
+    newest: max(library.books[*].year)
+  },
+  top_rated: max_by(library.books, &rating).title,
+  authors: sort(library.books[*].author),
+  available_titles: sort(library.books[?available == `true`][*].title)
+}


### PR DESCRIPTION
## Summary
- Creates 6 new `.jpx` query library files with expressions extracted from guide pages, totaling 97 named queries across all files
- Adds "Using Query Libraries" sections to each guide page linking to its companion `.jpx` file with usage examples
- Existing `examples/hacker-news.jpx` and `examples/nlp.jpx` already covered those guides; now all guide pages have companions

New files:
| File | Queries | Guide |
|------|---------|-------|
| `examples/earthquakes.jpx` | 16 | USGS Earthquakes |
| `examples/nobel-prize.jpx` | 15 | Nobel Prize API |
| `examples/nasa-neo.jpx` | 16 | NASA Near Earth Objects |
| `examples/project-management.jpx` | 18 | Project Management |
| `examples/standard-jmespath.jpx` | 14 | Standard JMESPath Only |
| `examples/cookbook.jpx` | 18 | Cookbook (examples.md) |

## Test plan
- [ ] Run `jpx -Q examples/<file>.jpx --list-queries` for each new file to verify parsing
- [ ] Run `jpx -Q examples/<file>.jpx --check` to validate all query syntax
- [ ] Verify guide pages render correctly with `mkdocs serve`

Closes #66