### PR TITLE
fix: polish Docker setup with .dockerignore, build cache, and tag normalization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Build artifacts
+target/
+**/target/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# CI/CD
+.github/
+
+# Documentation
+/site/
+/docs/
+*.md
+!README.md
+
+# Python bindings and build artifacts
+python/.venv/
+python/**/__pycache__/
+python/**/*.so
+python/**/*.pyd
+.pytest_cache/
+
+# Examples and test fixtures
+examples/
+
+# Misc
+.DS_Store
+*.log
+CLAUDE.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Determine version
+        id: meta
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          VERSION="${TAG#jpx-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Download release binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -359,11 +366,11 @@ jobs:
           file: ./docker/cli/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.tag }}-amd64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-amd64
           labels: |
             org.opencontainers.image.title=jpx
             org.opencontainers.image.description=JMESPath CLI with extended functions
-            org.opencontainers.image.version=${{ needs.plan.outputs.tag }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
   # Build Docker image for linux/arm64 from source
@@ -381,6 +388,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.plan.outputs.tag }}
+
+      - name: Determine version
+        id: meta
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          VERSION="${TAG#jpx-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -402,12 +416,14 @@ jobs:
           file: ./docker/cli/Dockerfile.build
           platforms: linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.tag }}-arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}-arm64
           labels: |
             org.opencontainers.image.title=jpx
             org.opencontainers.image.description=JMESPath CLI with extended functions
-            org.opencontainers.image.version=${{ needs.plan.outputs.tag }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Create multi-arch manifest for Docker CLI
   docker-manifest:
@@ -438,25 +454,25 @@ jobs:
 
           # Create manifest for version tag
           docker buildx imagetools create -t ${IMAGE}:${VERSION} \
-            ${IMAGE}:${TAG}-amd64 \
-            ${IMAGE}:${TAG}-arm64
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
 
           # Create manifest for major.minor tag
           docker buildx imagetools create -t ${IMAGE}:${MAJOR_MINOR} \
-            ${IMAGE}:${TAG}-amd64 \
-            ${IMAGE}:${TAG}-arm64
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
 
           # Create manifest for major tag (only if major > 0)
           if [ "$MAJOR" != "0" ]; then
             docker buildx imagetools create -t ${IMAGE}:${MAJOR} \
-              ${IMAGE}:${TAG}-amd64 \
-              ${IMAGE}:${TAG}-arm64
+              ${IMAGE}:${VERSION}-amd64 \
+              ${IMAGE}:${VERSION}-arm64
           fi
 
           # Create manifest for latest tag
           docker buildx imagetools create -t ${IMAGE}:latest \
-            ${IMAGE}:${TAG}-amd64 \
-            ${IMAGE}:${TAG}-arm64
+            ${IMAGE}:${VERSION}-amd64 \
+            ${IMAGE}:${VERSION}-arm64
 
       - name: Verify multi-arch image
         run: |

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -30,3 +30,4 @@ USER jpx
 WORKDIR /home/jpx
 
 ENTRYPOINT ["jpx-mcp"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

- Add `.dockerignore` to exclude `target/`, `.git/`, `python/.venv/`, `docs/`, etc. from Docker build context (prevents uploading ~16 GB on every build)
- Add GHA build cache (`cache-from`/`cache-to`) to CLI arm64 Docker job, matching `docker-mcp.yml`
- Add `CMD ["--help"]` to MCP server Dockerfile so bare `docker run` shows help instead of silently blocking, matching CLI Dockerfile pattern
- Normalize CLI intermediate Docker tags from `jpx-v0.3.0-amd64` to `0.3.0-amd64`, matching `docker-mcp.yml` convention

Closes #61

## Test plan

- [x] `docker build -f docker/cli/Dockerfile.build .` succeeds (verifies `.dockerignore` keeps needed files)
- [x] `docker build -f docker/server/Dockerfile .` succeeds
- [x] `docker run` on MCP server image shows help output
- [ ] Verify intermediate tag names in `release.yml` match `docker-mcp.yml` pattern (review)