### PR TITLE
feat: add CI benchmark regression tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,66 @@
+name: Benchmarks
+
+on:
+  schedule:
+    # Weekly on Monday at 06:00 UTC -- builds baseline history on main
+    - cron: "0 6 * * 1"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/jpx-core/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: bench-v1
+
+      - name: Run benchmarks
+        run: cargo bench -p jpx-core --bench vs_jmespath -- --output-format bencher | tee bench-output.txt
+
+      - name: Store benchmark result (main)
+        if: github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: jpx-core benchmarks
+          tool: cargo
+          output-file-path: bench-output.txt
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmarks/jpx-core
+          auto-push: true
+          alert-threshold: "150%"
+          fail-threshold: "200%"
+          comment-on-alert: true
+          alert-comment-cc-users: "@joshrotenberg"
+
+      - name: Compare benchmark result (PR)
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: jpx-core benchmarks
+          tool: cargo
+          output-file-path: bench-output.txt
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmarks/jpx-core
+          save-data-file: false
+          alert-threshold: "150%"
+          fail-threshold: "200%"
+          comment-on-alert: true
+          alert-comment-cc-users: "@joshrotenberg"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/benchmarks.yml` using `benchmark-action/github-action-benchmark@v1` to track jpx-core Criterion benchmark performance over time
- Weekly cron on main builds baseline history; PR runs compare against baseline without saving data
- Benchmark data stored on gh-pages branch under `benchmarks/jpx-core/` (no conflict with docs deployment which uses artifact-based `actions/deploy-pages@v4`)
- Alert threshold at 150% (warns), fail threshold at 200% (blocks merge)
- Separate Rust cache (`bench-v1` prefix) to avoid polluting test caches

## Test plan

- [ ] Trigger a manual `workflow_dispatch` run after merging to seed the baseline
- [ ] Confirm gh-pages branch is created with `benchmarks/jpx-core/data.js`
- [ ] Open a test PR touching jpx-core and verify summary table appears in Actions UI
- [ ] Verify docs deployment still works (no gh-pages conflict)

Closes #50