### PR TITLE
feat: add suggest_function MCP tool

### DIFF
--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -123,6 +123,28 @@ pub struct SimilarParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SuggestFunctionParams {
+    /// Natural-language description of what you want to do (e.g., "remove duplicate values from an array")
+    pub task: String,
+    /// Maximum number of suggestions to return (default: 5)
+    #[serde(default = "default_suggest_limit")]
+    pub limit: usize,
+}
+
+fn default_suggest_limit() -> usize {
+    5
+}
+
+#[derive(Debug, Serialize)]
+struct Suggestion {
+    name: String,
+    signature: String,
+    description: String,
+    example: String,
+    relevance: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct StatsParams {
     /// JSON input to analyze
     pub input: String,
@@ -274,6 +296,46 @@ fn json_result(value: &impl Serialize) -> Result<CallToolResult, Error> {
 
 fn error_result(message: impl Into<String>) -> CallToolResult {
     CallToolResult::error(message)
+}
+
+/// Strip natural-language filler from a task description to extract search terms.
+fn clean_task_description(task: &str) -> String {
+    let prefixes: &[&str] = &[
+        "i want to ",
+        "i need to ",
+        "i'd like to ",
+        "how do i ",
+        "how to ",
+        "how can i ",
+        "is there a way to ",
+        "can i ",
+        "please ",
+        "help me ",
+        "i'm trying to ",
+    ];
+    let mut s = task.trim().to_lowercase();
+    for prefix in prefixes {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            s = rest.to_string();
+            break;
+        }
+    }
+    s.trim().to_string()
+}
+
+/// Convert a match_type from search_functions into a human-readable relevance note.
+fn relevance_note(match_type: &str) -> String {
+    match match_type {
+        "exact_name" => "direct match by name".into(),
+        "alias" => "matches a function alias".into(),
+        "name_prefix" => "name starts with your search term".into(),
+        "name_contains" => "name contains your search term".into(),
+        "category" => "in a matching category".into(),
+        "description" => "description matches your task".into(),
+        "fuzzy_name" => "similar function name".into(),
+        "synonym" => "matches via synonym expansion".into(),
+        other => format!("related ({})", other),
+    }
 }
 
 // =============================================================================
@@ -569,6 +631,44 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
                         params.function
                     ))),
                 }
+            }
+        })
+        .build();
+
+    // -- suggest_function
+    let e = engine.clone();
+    let suggest_function = ToolBuilder::new("suggest_function")
+        .description(
+            "Suggest JMESPath functions for a task described in natural language. \
+            Accepts a plain-English description of what you want to accomplish \
+            (e.g., 'remove duplicate values from an array', 'convert to uppercase', \
+            'find the maximum value') and returns ranked function suggestions with \
+            relevance explanations.",
+        )
+        .read_only()
+        .handler(move |params: SuggestFunctionParams| {
+            let engine = e.clone();
+            async move {
+                let query = clean_task_description(&params.task);
+                if query.is_empty() {
+                    return Ok(error_result(
+                        "Please describe what you want to do (e.g., 'remove duplicates from an array').",
+                    ));
+                }
+
+                let results = engine.search_functions(&query, params.limit);
+                let suggestions: Vec<Suggestion> = results
+                    .into_iter()
+                    .map(|r| Suggestion {
+                        name: r.function.name,
+                        signature: r.function.signature,
+                        description: r.function.description,
+                        example: r.function.example,
+                        relevance: relevance_note(&r.match_type),
+                    })
+                    .collect();
+
+                json_result(&suggestions)
             }
         })
         .build();
@@ -937,6 +1037,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .tool(evaluate_file)
         .tool(search)
         .tool(similar)
+        .tool(suggest_function)
         .tool(stats)
         .tool(paths)
         .tool(register_tools)

--- a/crates/jpx-mcp/tests/tools.rs
+++ b/crates/jpx-mcp/tests/tools.rs
@@ -48,8 +48,8 @@ async fn test_list_tools() {
 
     let tools = client.list_tools().await;
 
-    // Should have 29 tools (consolidated from 32)
-    assert_eq!(tools.len(), 29, "Expected 29 tools, got {}", tools.len());
+    // Should have 30 tools (29 + suggest_function)
+    assert_eq!(tools.len(), 30, "Expected 30 tools, got {}", tools.len());
 
     let tool_names: Vec<&str> = tools
         .iter()
@@ -1065,4 +1065,124 @@ async fn test_search_no_results() {
     assert!(!result.is_error);
     let text = result.first_text().unwrap();
     assert!(text.contains("[]"));
+}
+
+// =============================================================================
+// suggest_function tool
+// =============================================================================
+
+#[tokio::test]
+async fn test_suggest_deduplicate() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "suggest_function",
+            json!({"task": "remove duplicate values from an array"}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    assert!(text.contains("unique"), "should suggest unique: {text}");
+    assert!(text.contains("relevance"));
+}
+
+#[tokio::test]
+async fn test_suggest_sort() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "suggest_function",
+            json!({"task": "sort an array of objects by a field"}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    assert!(
+        text.contains("sort_by") || text.contains("sort"),
+        "should suggest sort: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_suggest_convert_to_uppercase() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "suggest_function",
+            json!({"task": "convert a string to uppercase"}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    assert!(text.contains("upper"), "should suggest upper: {text}");
+}
+
+#[tokio::test]
+async fn test_suggest_natural_language_prefix() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "suggest_function",
+            json!({"task": "I want to find the maximum value in an array"}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    assert!(
+        text.contains("max") || text.contains("max_by"),
+        "should suggest max: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_suggest_no_match() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool("suggest_function", json!({"task": "xyzzy_nonexistent_qqq"}))
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    assert!(text.contains("[]"), "should return empty list: {text}");
+}
+
+#[tokio::test]
+async fn test_suggest_empty_task() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool("suggest_function", json!({"task": ""}))
+        .await;
+
+    assert!(result.is_error);
+}
+
+#[tokio::test]
+async fn test_suggest_respects_limit() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "suggest_function",
+            json!({"task": "string manipulation", "limit": 2}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).unwrap();
+    assert!(
+        parsed.len() <= 2,
+        "should respect limit: got {}",
+        parsed.len()
+    );
 }


### PR DESCRIPTION
## Summary

- Add `suggest_function` tool that accepts natural-language task descriptions (e.g., "remove duplicate values from an array") and returns ranked function suggestions with relevance explanations
- Strips filler phrases ("I want to", "how do I", etc.) then delegates to existing `search_functions()` engine with synonym expansion and BM25 scoring
- Returns up to 5 suggestions (configurable via `limit`) with name, signature, description, example, and human-readable relevance note
- Tool count: 29 -> 30

## Test plan

- [x] 7 new integration tests via tower-mcp TestClient
- [x] Deduplication task suggests `unique`
- [x] Sort task suggests `sort`/`sort_by`
- [x] Uppercase task suggests `upper`
- [x] Natural language prefixes stripped ("I want to find the maximum..." -> suggests `max`)
- [x] No-match returns empty list (not error)
- [x] Empty task returns error
- [x] `limit` parameter respected
- [x] All 58 jpx-mcp tests pass, all 202 integration tests pass

Closes #37