### PR TITLE
fix: strict mode reporting in engine_info and validate

### DIFF
--- a/crates/jpx-engine/src/eval.rs
+++ b/crates/jpx-engine/src/eval.rs
@@ -158,10 +158,51 @@ impl JpxEngine {
     /// ```
     pub fn validate(&self, expression: &str) -> ValidationResult {
         match jpx_core::compile(expression) {
-            Ok(_) => ValidationResult {
-                valid: true,
-                error: None,
-            },
+            Ok(expr) => {
+                if self.strict {
+                    // Reject let expressions in strict mode
+                    if crate::explain::has_let_nodes(expr.as_ast()) {
+                        return ValidationResult {
+                            valid: false,
+                            error: Some(
+                                "Let expressions are not available in strict mode \
+                                 (standard JMESPath only)."
+                                    .to_string(),
+                            ),
+                        };
+                    }
+
+                    // Reject extension functions in strict mode
+                    let func_names = crate::explain::collect_function_names(expr.as_ast());
+                    let extension_fns: Vec<&String> = func_names
+                        .iter()
+                        .filter(|name| {
+                            self.registry
+                                .get_function(name)
+                                .is_some_and(|f| !f.is_standard)
+                        })
+                        .collect();
+                    if !extension_fns.is_empty() {
+                        let names = extension_fns
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return ValidationResult {
+                            valid: false,
+                            error: Some(format!(
+                                "Extension function(s) not available in strict mode: {names}. \
+                                 Only standard JMESPath functions are allowed."
+                            )),
+                        };
+                    }
+                }
+
+                ValidationResult {
+                    valid: true,
+                    error: None,
+                }
+            }
             Err(e) => ValidationResult {
                 valid: false,
                 error: Some(e.to_string()),
@@ -355,5 +396,43 @@ mod tests {
         let result = engine.validate("items[*].{id: id, name: name} | [?id > `5`]");
         assert!(result.valid);
         assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn test_validate_strict_rejects_let_expression() {
+        let engine = JpxEngine::strict();
+        let result = engine.validate("let $x = name in $x");
+        assert!(!result.valid);
+        let err = result.error.unwrap();
+        assert!(err.contains("strict mode"), "error was: {err}");
+        assert!(err.contains("Let expression"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_validate_strict_rejects_extension_function() {
+        let engine = JpxEngine::strict();
+        let result = engine.validate("upper(name)");
+        assert!(!result.valid);
+        let err = result.error.unwrap();
+        assert!(err.contains("strict mode"), "error was: {err}");
+        assert!(err.contains("upper"), "error was: {err}");
+    }
+
+    #[test]
+    fn test_validate_strict_allows_standard_functions() {
+        let engine = JpxEngine::strict();
+        let result = engine.validate("length(sort(@))");
+        assert!(result.valid, "error: {:?}", result.error);
+    }
+
+    #[test]
+    fn test_validate_non_strict_allows_all() {
+        let engine = JpxEngine::new();
+
+        let result = engine.validate("upper(name)");
+        assert!(result.valid, "error: {:?}", result.error);
+
+        let result = engine.validate("let $x = name in $x");
+        assert!(result.valid, "error: {:?}", result.error);
     }
 }

--- a/crates/jpx-engine/src/explain.rs
+++ b/crates/jpx-engine/src/explain.rs
@@ -452,6 +452,70 @@ pub fn has_let_nodes(node: &Ast) -> bool {
     }
 }
 
+/// Collect all function names referenced in the AST.
+///
+/// Walks the entire AST and returns a deduplicated, sorted list of
+/// every function name that appears in a `Function` node. Useful for
+/// checking whether an expression uses extension functions.
+pub fn collect_function_names(node: &Ast) -> Vec<String> {
+    let mut names = Vec::new();
+    collect_functions_recursive(node, &mut names);
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn collect_functions_recursive(node: &Ast, names: &mut Vec<String>) {
+    match node {
+        Ast::Identity { .. }
+        | Ast::Field { .. }
+        | Ast::Index { .. }
+        | Ast::Slice { .. }
+        | Ast::Literal { .. }
+        | Ast::VariableRef { .. } => {}
+        Ast::Subexpr { lhs, rhs, .. }
+        | Ast::Projection { lhs, rhs, .. }
+        | Ast::And { lhs, rhs, .. }
+        | Ast::Or { lhs, rhs, .. }
+        | Ast::Comparison { lhs, rhs, .. } => {
+            collect_functions_recursive(lhs, names);
+            collect_functions_recursive(rhs, names);
+        }
+        Ast::Condition {
+            predicate, then, ..
+        } => {
+            collect_functions_recursive(predicate, names);
+            collect_functions_recursive(then, names);
+        }
+        Ast::Not { node, .. } | Ast::Flatten { node, .. } | Ast::ObjectValues { node, .. } => {
+            collect_functions_recursive(node, names);
+        }
+        Ast::Function { name, args, .. } => {
+            names.push(name.clone());
+            for arg in args {
+                collect_functions_recursive(arg, names);
+            }
+        }
+        Ast::MultiList { elements, .. } => {
+            for e in elements {
+                collect_functions_recursive(e, names);
+            }
+        }
+        Ast::MultiHash { elements, .. } => {
+            for kvp in elements {
+                collect_functions_recursive(&kvp.value, names);
+            }
+        }
+        Ast::Expref { ast, .. } => collect_functions_recursive(ast, names),
+        Ast::Let { bindings, expr, .. } => {
+            for (_, ast) in bindings {
+                collect_functions_recursive(ast, names);
+            }
+            collect_functions_recursive(expr, names);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -703,5 +767,27 @@ mod tests {
         let result = engine().explain("`42`").unwrap();
         assert_eq!(result.steps[0].node_type, "literal");
         assert!(result.steps[0].description.contains("42"));
+    }
+
+    // --- collect_function_names tests ---
+
+    #[test]
+    fn test_collect_function_names_empty() {
+        let ast = jpx_core::parse("foo.bar").unwrap();
+        assert!(collect_function_names(&ast).is_empty());
+    }
+
+    #[test]
+    fn test_collect_function_names_standard() {
+        let ast = jpx_core::parse("length(sort(@))").unwrap();
+        let names = collect_function_names(&ast);
+        assert_eq!(names, vec!["length", "sort"]);
+    }
+
+    #[test]
+    fn test_collect_function_names_nested() {
+        let ast = jpx_core::parse("users[?contains(name, 'a')] | sort_by(@, &age) | [0]").unwrap();
+        let names = collect_function_names(&ast);
+        assert_eq!(names, vec!["contains", "sort_by"]);
     }
 }

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -981,7 +981,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
                     "name": "jpx-mcp",
                     "version": env!("CARGO_PKG_VERSION"),
                     "strict_mode": engine.is_strict(),
-                    "let_expressions": cfg!(feature = "let-expr"),
+                    "let_expressions": cfg!(feature = "let-expr") && !engine.is_strict(),
                     "function_count": function_count,
                     "category_count": category_count,
                     "stored_queries": stored_queries,


### PR DESCRIPTION
## Summary

Closes #92, closes #93.

- `engine_info` now reports `let_expressions: false` when strict mode is enabled, instead of always reflecting the compile-time feature flag
- `validate` now rejects let expressions and extension functions in strict mode, closing the validate-passes-but-evaluate-fails gap
- Added `collect_function_names` AST helper for extracting all function names from an expression

## Test plan

- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo test --lib --all-features --workspace` -- 267 engine tests pass (7 new)
- [x] `cargo test --test '*' --all-features` -- 311 integration/CLI tests pass
- [ ] Rebuild MCP server and verify `engine_info` on jpx-strict shows `let_expressions: false`
- [ ] Verify `validate("upper(name)")` on jpx-strict returns `valid: false`
- [ ] Verify `validate("let $x = a in $x")` on jpx-strict returns `valid: false`
- [ ] Verify `validate("sort(@)")` on jpx-strict returns `valid: true`