### PR TITLE
ci: skip Rust/Python CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "*.md"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "*.md"
+      - ".github/workflows/docs.yml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Closes #96.

Add `paths-ignore` to `ci.yml` so docs-only PRs skip the full Rust/Python CI matrix. Ignored paths:

- `docs/**` -- MkDocs source
- `mkdocs.yml` -- MkDocs config
- `*.md` -- root-level markdown (README, CHANGELOG, etc.)
- `.github/workflows/docs.yml` -- docs workflow changes

The `docs.yml` workflow already has its own path filtering and handles docs builds independently.

## Test plan

- [ ] A docs-only PR (like #95) should not trigger CI jobs
- [ ] A PR touching Rust code still triggers the full CI matrix