### PR TITLE
fix: exclude jpx-python from cargo-dist builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ on:
 env:
   # Use input tag for manual dispatch, otherwise use the pushed tag
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+  # Prevent pyo3 build failures if Python > 3.13 is on the runner
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
 jobs:
   # Run 'dist plan' to determine what tasks we need to do

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 description = "Python bindings for jpx JMESPath engine"
 publish = false
 
+[package.metadata.dist]
+dist = false
+
 [lib]
 name = "_core"
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary

The release workflow failed on `aarch64-apple-darwin` because the macOS runner has Python 3.14, but pyo3 0.23.5 only supports up to 3.13. pyo3 is only needed by `jpx-python` (the Python bindings), not the `jpx` CLI binary that cargo-dist is building.

Fixes:
- Add `[package.metadata.dist] dist = false` to `python/Cargo.toml` so cargo-dist excludes it
- Set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` in `release.yml` as a fallback

## Test plan

- [ ] Merge, then re-trigger the release workflow with `workflow_dispatch` for tag `jpx-v0.4.0`
- [ ] Verify `aarch64-apple-darwin` build succeeds without pyo3 compilation