### PR TITLE
docs: drop jq comparison, show JMESPath in action

### DIFF
--- a/docs/src/presentations/jpx-in-5-minutes.html
+++ b/docs/src/presentations/jpx-in-5-minutes.html
@@ -9,18 +9,16 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.1.0/plugin/highlight/monokai.css">
   <style>
     .reveal h1, .reveal h2, .reveal h3 { text-transform: none; }
-    .reveal pre { font-size: 0.55em; width: 95%; }
+    .reveal pre { font-size: 0.5em; width: 95%; box-sizing: border-box; }
     .reveal code { font-family: "JetBrains Mono", "Fira Code", monospace; }
     .reveal .small { font-size: 0.7em; }
     .reveal .dim { color: #888; }
     .reveal ul { text-align: left; }
-    .reveal .two-col { display: flex; gap: 2em; }
-    .reveal .two-col > div { flex: 1; }
     .accent { color: #bb86fc; }
     .green { color: #03dac6; }
     .reveal .chip-grid {
-      display: flex; flex-wrap: wrap; gap: 0.4em; justify-content: center;
-      margin: 0.6em 0;
+      display: flex; flex-wrap: wrap; gap: 0.4em;
+      justify-content: center; margin: 0.6em 0;
     }
     .reveal .chip {
       background: rgba(187, 134, 252, 0.12);
@@ -31,12 +29,15 @@
       font-family: "JetBrains Mono", monospace;
     }
     .reveal .oneliners {
-      text-align: left; font-size: 0.6em; margin-top: 0.6em;
+      text-align: left; font-size: 0.55em; margin-top: 0.6em;
       font-family: "JetBrains Mono", monospace;
     }
-    .reveal .oneliners .expr { color: #bb86fc; }
+    .reveal .oneliners .fn { color: #bb86fc; }
     .reveal .oneliners .result { color: #03dac6; }
-    .reveal table td { vertical-align: top; border-bottom: 1px solid #333; }
+    .reveal table td {
+      vertical-align: top;
+      border-bottom: 1px solid #333;
+    }
   </style>
 </head>
 <body>
@@ -50,48 +51,44 @@
   <span class="dim">A jq alternative you can actually remember.</span></h3>
   <p class="dim">Josh Rotenberg</p>
   <aside class="notes">
-    Quick show of hands: who uses jq? Who has to Google the syntax every single time?
-    jpx is a JMESPath-based alternative. JMESPath is an RFC-spec query language for JSON —
-    it's already in the AWS CLI, Ansible, Boto3. Same idea as jq, but the syntax reads like English.
+    Quick show of hands: who uses jq? Who has to Google the syntax every time?
+    jpx is built on JMESPath — an RFC-spec query language for JSON.
+    It's already in the AWS CLI, Ansible, Boto3.
+    Same idea as jq, but the syntax reads like English.
     And jpx adds 400+ functions on top.
   </aside>
 </section>
 
-<!-- Slide 2: jq vs jpx -->
+<!-- Slide 2: JMESPath in action -->
 <section>
-  <h2>JSON querying<br><span class="dim">shouldn't feel like this</span></h2>
-  <div class="two-col">
-    <div>
-      <h3 class="dim">jq</h3>
-      <pre><code class="language-bash"># Active users, sorted by name
-[.users[] | select(.active)]
-  | sort_by(.name)
-  | [.[].name]</code></pre>
-    </div>
-    <div>
-      <h3 class="accent">jpx</h3>
-      <pre><code class="language-bash"># Active users, sorted by name
-users[?active]
-  | sort_by(@, &name)[*].name</code></pre>
-    </div>
-  </div>
-  <p class="fragment small" style="margin-top: 1em;">
-    jq has ~50 builtins.
-    <span class="dim">No date formatting. No hashing. No geo. No regex replace.</span><br>
-    jpx has <span class="accent">400+ functions</span> across <span class="accent">32 categories</span>, built in.
+  <h2>Query language for JSON<br>
+  <span class="dim">that reads like what you want</span></h2>
+  <pre><code class="language-bash">curl -s https://api.github.com/users/octocat \
+  | jpx '{
+      login: upper(login),
+      joined: format_date(parse_date(created_at), `"%B %Y"`),
+      repos: public_repos
+    }'</code></pre>
+  <pre class="fragment"><code class="language-json">{"login": "OCTOCAT", "joined": "January 2011", "repos": 8}</code></pre>
+  <p class="fragment small" style="margin-top: 0.8em;">
+    <span class="dim">JMESPath is an</span> RFC spec<span class="dim">.</span>
+    <span class="accent">jpx</span> adds
+    <span class="accent">400+ functions</span> on top &mdash;
+    <span class="dim">dates, hashing, geo, fuzzy matching, and more.</span>
   </p>
   <aside class="notes">
-    JMESPath's filter syntax — "users where active" — vs jq's select() pipeline.
-    jq is powerful, but it's a custom functional language you have to learn from scratch.
-    JMESPath is spec-based and reads like what you want.
-    And the function gap is real: jq has no date formatting, no hashing, no geo functions.
-    jpx has all of that out of the box.
+    One example, three things happening: field selection, string function, date parsing.
+    No special syntax to learn — it reads like "give me login uppercased, created_at
+    formatted as month-year, and the repo count."
+    JMESPath is a spec — it's not a custom language someone invented for a CLI tool.
+    jpx takes that spec and adds 400+ functions across 32 categories.
   </aside>
 </section>
 
 <!-- Slide 3: The function arsenal -->
 <section>
-  <h2><span class="accent">32</span> categories. <span class="accent">400+</span> functions.</h2>
+  <h2><span class="accent">32</span> categories.
+  <span class="accent">400+</span> functions.</h2>
   <div class="chip-grid">
     <span class="chip">string</span>
     <span class="chip">array</span>
@@ -115,15 +112,20 @@ users[?active]
     <span class="chip">ids</span>
   </div>
   <div class="oneliners">
-    <p><span class="expr">sha256</span>(<span class="dim">'my-secret'</span>) <span class="result">&rarr; "b94d27b9..."</span></p>
-    <p><span class="expr">geo_distance_km</span>(<span class="dim">40.42, -3.70, 37.77, -122.42</span>) <span class="result">&rarr; 9318</span>&nbsp; <span class="dim small">Madrid &rarr; SF</span></p>
-    <p><span class="expr">jaro_winkler</span>(<span class="dim">'Josh', 'Joshua'</span>) <span class="result">&rarr; 0.93</span></p>
-    <p><span class="expr">format_date</span>(<span class="expr">now</span>(), <span class="dim">'%B %d, %Y'</span>) <span class="result">&rarr; "February 10, 2026"</span></p>
+    <p><span class="fn">sha256</span>(<span class="dim">'secret'</span>)
+       <span class="result">&rarr; "2bb80d5..."</span></p>
+    <p><span class="fn">geo_distance_km</span>(<span class="dim">40.42, -3.70, 37.77, -122.42</span>)
+       <span class="result">&rarr; 9318</span>
+       <span class="dim" style="font-size:0.85em">&nbsp;Madrid &rarr; SF</span></p>
+    <p><span class="fn">jaro_winkler</span>(<span class="dim">'Josh', 'Joshua'</span>)
+       <span class="result">&rarr; 0.93</span></p>
+    <p><span class="fn">format_date</span>(<span class="fn">now</span>(),
+       <span class="dim">'%B %d, %Y'</span>)
+       <span class="result">&rarr; "February 10, 2026"</span></p>
   </div>
   <aside class="notes">
-    These aren't plugins. They're all built in. Every function is documented and discoverable
-    from the CLI with --search and --describe.
-    That geo function? Madrid to San Francisco, 9318 km — computed right here.
+    These aren't plugins — they're all built in and discoverable with --search.
+    That geo function? Madrid to San Francisco, 9318 km.
     Let me show you for real...
     [FLIP TO TERMINAL FOR DEMO]
   </aside>
@@ -133,24 +135,38 @@ users[?active]
 <section>
   <h2>The <span class="accent">jpx</span> ecosystem</h2>
   <table style="font-size: 0.7em;">
-    <tr><td class="accent" style="white-space:nowrap;">jpx</td><td>CLI with REPL, streaming, table/CSV/JSON output</td></tr>
-    <tr><td class="accent" style="white-space:nowrap;">jpx-mcp</td><td>MCP server &mdash; 29 tools for AI assistants</td></tr>
-    <tr><td class="accent" style="white-space:nowrap;">jpx-core</td><td>From-scratch JMESPath engine in Rust</td></tr>
-    <tr><td class="accent" style="white-space:nowrap;">jpx-engine</td><td>Introspection, BM25 search, query store</td></tr>
-    <tr><td class="accent" style="white-space:nowrap;">jpx <span class="dim small">(PyPI)</span></td><td>Python bindings via PyO3</td></tr>
+    <tr>
+      <td class="accent" style="white-space:nowrap">jpx</td>
+      <td>CLI with REPL, streaming, table/CSV output</td>
+    </tr>
+    <tr>
+      <td class="accent" style="white-space:nowrap">jpx-mcp</td>
+      <td>MCP server &mdash; 29 tools for AI assistants</td>
+    </tr>
+    <tr>
+      <td class="accent" style="white-space:nowrap">jpx-core</td>
+      <td>From-scratch JMESPath engine in Rust</td>
+    </tr>
+    <tr>
+      <td class="accent" style="white-space:nowrap">jpx-engine</td>
+      <td>Introspection, BM25 search, query store</td>
+    </tr>
+    <tr>
+      <td class="accent" style="white-space:nowrap">jpx <span class="dim small">(PyPI)</span></td>
+      <td>Python bindings via PyO3</td>
+    </tr>
   </table>
   <br>
   <p class="fragment small">
-    <span class="green">MCP server</span>: give Claude (or any MCP client) the ability to
-    query JSON, search 400+ functions, diff documents, and build query libraries &mdash;
-    all through tool calls.
+    <span class="green">MCP</span>: Claude can evaluate queries,
+    search functions, diff JSON, and build query libraries
+    &mdash; all through tool calls.
   </p>
   <aside class="notes">
     Everything is Rust, from the parser to the MCP server.
-    jpx-core is a ground-up JMESPath implementation — not a wrapper around an existing library.
-    The MCP server exposes 29 tools. Claude can evaluate queries, search functions,
-    explain expressions, diff JSON, manage named queries.
-    It also has a BM25 discovery index for searching tools across multiple MCP servers.
+    jpx-core is a ground-up JMESPath implementation — not a wrapper.
+    The MCP server exposes 29 tools to AI assistants.
+    It also has a BM25 discovery index for cross-server tool search.
     Python bindings let you use the same engine from scripts.
     MIT/Apache-2.0 dual licensed.
   </aside>
@@ -170,19 +186,19 @@ jpx --describe sha256
 # Interactive REPL
 jpx --repl
 
-# Query files — reusable expression libraries
-jpx -Q examples/earthquakes.jpx:mag-stats -f quakes.json</code></pre>
+# Reusable query libraries
+jpx -Q earthquakes.jpx:mag-stats -f data.json</code></pre>
   <br>
   <p>
     <span class="accent">github.com/joshrotenberg/jpx</span><br>
-    <span class="dim small">Docs: joshrotenberg.github.io/jpx</span>
+    <span class="dim small">joshrotenberg.github.io/jpx</span>
   </p>
   <aside class="notes">
-    Homebrew on Mac, cargo install, Docker, or a shell installer for Linux.
+    Homebrew on Mac, cargo install, Docker, or shell installer.
     --search does BM25 full-text search across all 400+ functions.
-    The REPL has tab completion and history — great for exploring.
-    Query files (.jpx) let you build reusable expression libraries with named queries.
-    Check it out, star the repo, file issues. PRs welcome.
+    The REPL has tab completion and history.
+    Query files (.jpx) let you build reusable expression libraries.
+    Check it out, star the repo, PRs welcome.
   </aside>
 </section>
 


### PR DESCRIPTION
## Summary

Follow-up to #100. Replaces the jq-vs-jpx side-by-side comparison (not
different enough to be compelling) with a "JMESPath in action" slide
showing a real GitHub API call with field selection, `upper()`, and
`format_date(parse_date(...))` in one shot.

Also fixes code overflow in text boxes by reducing `pre` font-size and
breaking long one-liner expressions across lines.

## Test plan

- [ ] Review presentation at `docs/src/presentations/jpx-in-5-minutes.html`