### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrow",
  "dirs",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.1.1" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.3.0" }
+jpx-core = { path = "crates/jpx-core", version = "0.1.2" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.3.1" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.1...jpx-core-v0.1.2) - 2026-02-11
+
+### Other
+
+- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
+
 ## [0.1.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.0...jpx-core-v0.1.1) - 2026-02-08
 
 ### Fixed

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.0...jpx-engine-v0.3.1) - 2026-02-11
+
+### Other
+
+- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
+
 ## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.2.0...jpx-engine-v0.3.0) - 2026-02-08
 
 ### Added

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.0...jpx-mcp-v0.4.1) - 2026-02-11
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.1.4...jpx-mcp-v0.4.0) - 2026-02-08
 
 ### Added

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.0...jpx-v0.4.1) - 2026-02-11
+
+### Other
+
+- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
+
 ## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.3.0...jpx-v0.4.0) - 2026-02-08
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `jpx-engine`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `jpx`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `jpx-mcp`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.1.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.1...jpx-core-v0.1.2) - 2026-02-11

### Other

- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.3.1](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.0...jpx-engine-v0.3.1) - 2026-02-11

### Other

- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
</blockquote>

## `jpx`

<blockquote>

## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.0...jpx-v0.4.1) - 2026-02-11

### Other

- Add AGENTS.md for AI coding agents ([#104](https://github.com/joshrotenberg/jpx/pull/104))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.0...jpx-mcp-v0.4.1) - 2026-02-11

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).