### PR TITLE
fix: functions category filter case-sensitive mismatch

### DIFF
--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -173,12 +173,15 @@ impl JpxEngine {
     /// assert!(string_funcs.iter().all(|f| f.category == "String"));
     /// ```
     pub fn functions(&self, category: Option<&str>) -> Vec<FunctionDetail> {
-        match category.and_then(parse_category) {
-            Some(cat) => self
-                .registry
-                .functions_in_category(cat)
-                .map(FunctionDetail::from)
-                .collect(),
+        match category {
+            Some(name) => match parse_category(name) {
+                Some(cat) => self
+                    .registry
+                    .functions_in_category(cat)
+                    .map(FunctionDetail::from)
+                    .collect(),
+                None => Vec::new(),
+            },
             None => self
                 .registry
                 .functions()
@@ -467,9 +470,10 @@ fn calculate_match_score(
 
 /// Parse category string to Category enum
 pub(crate) fn parse_category(name: &str) -> Option<Category> {
+    let input = name.to_lowercase();
     Category::all()
         .iter()
-        .find(|cat| format!("{:?}", cat).to_lowercase() == name.to_lowercase())
+        .find(|cat| cat.name() == input)
         .copied()
 }
 
@@ -720,14 +724,27 @@ mod tests {
     #[test]
     fn test_functions_invalid_category() {
         let engine = JpxEngine::new();
-        // When a category string does not match any known category, parse_category
-        // returns None, and functions() falls through to returning all functions.
         let invalid = engine.functions(Some("NonexistentCategory"));
+        assert!(
+            invalid.is_empty(),
+            "Invalid category should return empty list, got {} functions",
+            invalid.len()
+        );
+    }
+
+    #[test]
+    fn test_functions_multi_match_category() {
+        let engine = JpxEngine::new();
+        let results = engine.functions(Some("multi-match"));
+        assert!(
+            !results.is_empty(),
+            "multi-match category should return functions"
+        );
         let all = engine.functions(None);
-        assert_eq!(
-            invalid.len(),
-            all.len(),
-            "Invalid category should fall back to returning all functions"
+        assert!(
+            results.len() < all.len(),
+            "multi-match should return a subset, not all {} functions",
+            all.len()
         );
     }
 


### PR DESCRIPTION
## Summary
- **Fixed `parse_category()`** to use `cat.name()` instead of `format!("{:?}", cat).to_lowercase()`, which produced `"multimatch"` instead of `"multi-match"` for hyphenated categories
- **Fixed `functions()`** to return an empty vec when an unrecognized category name is provided, instead of silently falling through to returning all 425 functions
- Updated `test_functions_invalid_category` and added `test_functions_multi_match_category` regression test

Closes #111

## Test plan
- [x] `cargo test -p jpx-engine` — all 248 unit tests, 15 integration tests, 46 doc-tests pass
- [ ] MCP: `functions` with category `"multi-match"` returns only MultiMatch functions (not all 425)
- [ ] MCP: `functions` with category `"String"` still works (case-insensitive)
- [ ] MCP: `functions` with invalid category returns empty, not all