### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.1.2" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.3.1" }
+jpx-core = { path = "crates/jpx-core", version = "0.1.3" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.3.2" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.2...jpx-core-v0.1.3) - 2026-02-11
+
+### Added
+
+- *(path)* add path_stem, path_is_absolute, path_is_relative functions ([#130](https://github.com/joshrotenberg/jpx/pull/130))
+- *(rand)* add random_int and random_choice functions ([#117](https://github.com/joshrotenberg/jpx/pull/117)) ([#129](https://github.com/joshrotenberg/jpx/pull/129))
+- *(encoding)* add base64url_encode, base64url_decode ([#118](https://github.com/joshrotenberg/jpx/pull/118)) ([#128](https://github.com/joshrotenberg/jpx/pull/128))
+- *(duration)* add duration_days, duration_add, duration_subtract ([#115](https://github.com/joshrotenberg/jpx/pull/115)) ([#127](https://github.com/joshrotenberg/jpx/pull/127))
+- *(url)* add url_build, query_string_parse, query_string_build functions ([#114](https://github.com/joshrotenberg/jpx/pull/114)) ([#125](https://github.com/joshrotenberg/jpx/pull/125))
+- *(regex)* add regex_split and regex_count functions ([#113](https://github.com/joshrotenberg/jpx/pull/113)) ([#124](https://github.com/joshrotenberg/jpx/pull/124))
+- *(geo)* add containment, bounding box, midpoint, and geohash functions ([#123](https://github.com/joshrotenberg/jpx/pull/123))
+
 ## [0.1.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.1...jpx-core-v0.1.2) - 2026-02-11
 
 ### Other

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.1...jpx-engine-v0.3.2) - 2026-02-11
+
+### Fixed
+
+- functions category filter case-sensitive mismatch ([#111](https://github.com/joshrotenberg/jpx/pull/111)) ([#121](https://github.com/joshrotenberg/jpx/pull/121))
+
 ## [0.3.1](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.0...jpx-engine-v0.3.1) - 2026-02-11
 
 ### Other

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.1...jpx-mcp-v0.4.2) - 2026-02-11
+
+### Other
+
+- updated the following local packages: jpx-engine
+
 ## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.0...jpx-mcp-v0.4.1) - 2026-02-11
 
 ### Other

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.1...jpx-v0.4.2) - 2026-02-11
+
+### Other
+
+- updated the following local packages: jpx-engine
+
 ## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.0...jpx-v0.4.1) - 2026-02-11
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `jpx-engine`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `jpx`: 0.4.1 -> 0.4.2
* `jpx-mcp`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.2...jpx-core-v0.1.3) - 2026-02-11

### Added

- *(path)* add path_stem, path_is_absolute, path_is_relative functions ([#130](https://github.com/joshrotenberg/jpx/pull/130))
- *(rand)* add random_int and random_choice functions ([#117](https://github.com/joshrotenberg/jpx/pull/117)) ([#129](https://github.com/joshrotenberg/jpx/pull/129))
- *(encoding)* add base64url_encode, base64url_decode ([#118](https://github.com/joshrotenberg/jpx/pull/118)) ([#128](https://github.com/joshrotenberg/jpx/pull/128))
- *(duration)* add duration_days, duration_add, duration_subtract ([#115](https://github.com/joshrotenberg/jpx/pull/115)) ([#127](https://github.com/joshrotenberg/jpx/pull/127))
- *(url)* add url_build, query_string_parse, query_string_build functions ([#114](https://github.com/joshrotenberg/jpx/pull/114)) ([#125](https://github.com/joshrotenberg/jpx/pull/125))
- *(regex)* add regex_split and regex_count functions ([#113](https://github.com/joshrotenberg/jpx/pull/113)) ([#124](https://github.com/joshrotenberg/jpx/pull/124))
- *(geo)* add containment, bounding box, midpoint, and geohash functions ([#123](https://github.com/joshrotenberg/jpx/pull/123))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.3.2](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.1...jpx-engine-v0.3.2) - 2026-02-11

### Fixed

- functions category filter case-sensitive mismatch ([#111](https://github.com/joshrotenberg/jpx/pull/111)) ([#121](https://github.com/joshrotenberg/jpx/pull/121))
</blockquote>

## `jpx`

<blockquote>

## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.1...jpx-v0.4.2) - 2026-02-11

### Other

- updated the following local packages: jpx-engine
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.1...jpx-mcp-v0.4.2) - 2026-02-11

### Other

- updated the following local packages: jpx-engine
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).