### PR TITLE
feat(regex): add regex_split and regex_count functions

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -3622,6 +3622,18 @@ features = ["core"]
 # =============================================================================
 
 [[functions]]
+name = "regex_count"
+category = "regex"
+description = "Count the number of regex matches. Use backtick-JSON syntax: regex_count(text, `\"\\\\d+\"`)"
+signature = "string, string -> number"
+examples = [
+    { code = '''regex_count(`"a1b2c3"`, `"\\\\d+"`) -> 3''', description = "Count numbers" },
+    { code = '''regex_count(`"hello world"`, `"[aeiou]"`) -> 3''', description = "Count vowels" },
+    { code = '''regex_count(`"abc"`, `"\\\\d+"`) -> 0''', description = "No matches" },
+]
+features = ["core"]
+
+[[functions]]
 name = "regex_extract"
 category = "regex"
 description = "Extract regex matches. Use backtick-JSON syntax: regex_extract(text, `\"\\\\w+\"`)"
@@ -3654,6 +3666,18 @@ examples = [
     { code = '''regex_replace(`"a1b2"`, `"\\\\d+"`, `"X"`) -> \"aXbX\"''', description = "Replace digits" },
     { code = '''regex_replace(`"hello world"`, `"\\\\s+"`, `"-"`) -> \"hello-world\"''', description = "Replace spaces" },
     { code = '''regex_replace(`"abc"`, `"x"`, `"y"`) -> \"abc\"''', description = "No match unchanged" },
+]
+features = ["core"]
+
+[[functions]]
+name = "regex_split"
+category = "regex"
+description = "Split a string by a regex pattern. Use backtick-JSON syntax: regex_split(text, `\"\\\\s+\"`)"
+signature = "string, string -> array"
+examples = [
+    { code = '''regex_split(`"a,b,c"`, `","`) -> [\"a\", \"b\", \"c\"]''', description = "Split by comma" },
+    { code = '''regex_split(`"hello   world"`, `"\\\\s+"`) -> [\"hello\", \"world\"]''', description = "Split by whitespace" },
+    { code = '''regex_split(`"abc"`, `","`) -> [\"abc\"]''', description = "No match returns single element" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/regex_fns.rs
+++ b/crates/jpx-core/src/extensions/regex_fns.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use crate::functions::Function;
 use crate::functions::custom_error;
+use crate::functions::number_value;
 use crate::interpreter::SearchResult;
 use crate::registry::register_if_enabled;
 use crate::{Context, Runtime, arg, defn};
@@ -31,6 +32,18 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         "regex_replace",
         enabled,
         Box::new(RegexReplaceFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "regex_count",
+        enabled,
+        Box::new(RegexCountFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "regex_split",
+        enabled,
+        Box::new(RegexSplitFn::new()),
     );
 }
 
@@ -113,6 +126,54 @@ impl Function for RegexReplaceFn {
     }
 }
 
+// =============================================================================
+// regex_count(string, pattern) -> number
+// =============================================================================
+
+defn!(RegexCountFn, vec![arg!(string), arg!(string)], None);
+
+impl Function for RegexCountFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        // Safe to unwrap after signature validation
+        let input = args[0].as_str().unwrap();
+        let pattern = args[1].as_str().unwrap();
+
+        let re = Regex::new(pattern)
+            .map_err(|e| custom_error(ctx, &format!("Invalid regex pattern: {e}")))?;
+
+        let count = re.find_iter(input).count();
+        Ok(number_value(count as f64))
+    }
+}
+
+// =============================================================================
+// regex_split(string, pattern) -> array
+// =============================================================================
+
+defn!(RegexSplitFn, vec![arg!(string), arg!(string)], None);
+
+impl Function for RegexSplitFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        // Safe to unwrap after signature validation
+        let input = args[0].as_str().unwrap();
+        let pattern = args[1].as_str().unwrap();
+
+        let re = Regex::new(pattern)
+            .map_err(|e| custom_error(ctx, &format!("Invalid regex pattern: {e}")))?;
+
+        let parts: Vec<Value> = re
+            .split(input)
+            .map(|s| Value::String(s.to_string()))
+            .collect();
+
+        Ok(Value::Array(parts))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Runtime;
@@ -158,5 +219,65 @@ mod tests {
         let data = json!("abc123def456");
         let result = expr.search(&data).unwrap();
         assert_eq!(result.as_str().unwrap(), "abcXdefX");
+    }
+
+    #[test]
+    fn test_regex_count() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_count(@, '[0-9]+')").unwrap();
+
+        let data = json!("abc123def456ghi789");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(3.0));
+    }
+
+    #[test]
+    fn test_regex_count_no_matches() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_count(@, '[0-9]+')").unwrap();
+
+        let data = json!("abcdef");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(0.0));
+    }
+
+    #[test]
+    fn test_regex_count_overlapping_pattern() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_count(@, '[aeiou]')").unwrap();
+
+        let data = json!("hello world");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(3.0));
+    }
+
+    #[test]
+    fn test_regex_split() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_split(@, ',')").unwrap();
+
+        let data = json!("a,b,c");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn test_regex_split_whitespace() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_split(@, '\\s+')").unwrap();
+
+        let data = json!("hello   world\tfoo");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(["hello", "world", "foo"]));
+    }
+
+    #[test]
+    fn test_regex_split_no_match() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("regex_split(@, ',')").unwrap();
+
+        let data = json!("no delimiters here");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(["no delimiters here"]));
     }
 }

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -49,7 +49,7 @@ jpx --describe upper
 | [Path](./path.md) | File path manipulation functions. | 4 |
 | [Phonetic](./phonetic.md) | Phonetic encoding functions for sound-based string matching. | 9 |
 | [Random](./rand.md) | Functions for generating random values: numbers, strings, an... | 3 |
-| [Regular Expression](./regex.md) | Regular expression functions: matching, replacing, splitting... | 3 |
+| [Regular Expression](./regex.md) | Regular expression functions: matching, replacing, splitting... | 5 |
 | [Semantic Versioning](./semver.md) | Semantic versioning functions: parsing, comparing, and manip... | 7 |
 | [Standard JMESPath](./standard.md) | These are the standard JMESPath functions as defined in the ... | 26 |
 | [String](./string.md) | Functions for string manipulation: case conversion, splittin... | 36 |

--- a/docs/src/functions/regex.md
+++ b/docs/src/functions/regex.md
@@ -6,11 +6,36 @@ Regular expression functions: matching, replacing, splitting, and pattern extrac
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
+| [`regex_count`](#regex-count) | `string, string -> number` | Count regex matches |
 | [`regex_extract`](#regex-extract) | `string, string -> array` | Extract regex matches |
 | [`regex_match`](#regex-match) | `string, string -> boolean` | Test if string matches regex |
 | [`regex_replace`](#regex-replace) | `string, string, string -> string` | Replace regex matches |
+| [`regex_split`](#regex-split) | `string, string -> array` | Split string by regex pattern |
 
 ## Functions
+
+### regex_count
+
+Count the number of regex matches
+
+**Signature:** `string, string -> number`
+
+**Examples:**
+
+```text
+# Count numbers
+regex_count('a1b2c3', '\\\\d+') -> 3
+# Count vowels
+regex_count('hello world', '[aeiou]') -> 3
+# No matches
+regex_count('abc', '\\d+') -> 0
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'regex_count(`"a1b2c3"`, `"\\\\d+"`)'
+```
 
 ### regex_extract
 
@@ -79,5 +104,28 @@ regex_replace('abc', 'x', 'y') -> \"abc\"
 
 ```bash
 echo '{}' | jpx 'regex_replace(`"a1b2"`, `"\\\\d+"`, `"X"`)'
+```
+
+### regex_split
+
+Split a string by a regex pattern
+
+**Signature:** `string, string -> array`
+
+**Examples:**
+
+```text
+# Split by comma
+regex_split('a,b,c', ',') -> ["a", "b", "c"]
+# Split by whitespace
+regex_split('hello   world', '\\\\s+') -> ["hello", "world"]
+# No match returns single element
+regex_split('abc', ',') -> ["abc"]
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'regex_split(`"a,b,c"`, `","`)'
 ```
 


### PR DESCRIPTION
## Summary

Closes #113

- Add `regex_count(string, pattern) -> number` — counts non-overlapping regex matches in a string
- Add `regex_split(string, pattern) -> array` — splits a string by a regex pattern
- Add function metadata in `functions.toml`, docs in `regex.md`, and update overview count (3 → 5)
- Add 6 unit tests covering basic usage and edge cases (no matches, no delimiter)

## Test plan

- [x] `cargo clippy -p jpx-core -- -D warnings` passes
- [x] `cargo test -p jpx-core -- regex` — all 9 regex tests pass
- [x] `cargo test -p jpx-core` — full crate suite (1009 tests) passes