### PR TITLE
feat(url): add url_build, query_string_parse, query_string_build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "criterion",
  "csv",
  "dateparser",
+ "form_urlencoded",
  "geohash",
  "geoutils",
  "heck",

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -28,6 +28,7 @@ base64 = { version = "0.22", optional = true }
 urlencoding = { version = "2.1", optional = true }
 regex = { version = "1.5", optional = true }
 url = { version = "2.5", optional = true }
+form_urlencoded = { version = "1", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 hex = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
@@ -72,7 +73,7 @@ extensions = [
     "dep:heck",
     "dep:md-5", "dep:sha1", "dep:sha2", "dep:hmac", "dep:crc32fast",
     "dep:base64", "dep:hex",
-    "dep:urlencoding", "dep:url",
+    "dep:urlencoding", "dep:url", "dep:form_urlencoded",
     "dep:regex",
     "dep:uuid",
     "dep:rand",

--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -4998,6 +4998,42 @@ features = ["core"]
 # =============================================================================
 
 [[functions]]
+name = "query_string_build"
+category = "url"
+description = "Build a URL query string from an object"
+signature = "object -> string"
+examples = [
+    { code = "query_string_build({foo: 'bar', baz: 'qux'}) -> \"foo=bar&baz=qux\"", description = "Basic query string" },
+    { code = "query_string_build({q: 'hello world'}) -> \"q=hello+world\"", description = "With special characters" },
+    { code = "query_string_build({}) -> \"\"", description = "Empty object" },
+]
+features = ["core"]
+
+[[functions]]
+name = "query_string_parse"
+category = "url"
+description = "Parse a URL query string into an object"
+signature = "string -> object"
+examples = [
+    { code = "query_string_parse('foo=bar&baz=qux') -> {foo: 'bar', baz: 'qux'}", description = "Basic parsing" },
+    { code = "query_string_parse('greeting=hello%20world') -> {greeting: 'hello world'}", description = "Encoded values" },
+    { code = "query_string_parse('') -> {}", description = "Empty string" },
+]
+features = ["core"]
+
+[[functions]]
+name = "url_build"
+category = "url"
+description = "Build a URL from component parts"
+signature = "object -> string"
+examples = [
+    { code = "url_build({scheme: 'https', host: 'example.com'}) -> \"https://example.com/\"", description = "Minimal URL" },
+    { code = "url_build({scheme: 'https', host: 'example.com', port: 8080, path: '/api'}) -> full URL", description = "With port and path" },
+    { code = "url_build(url_parse('https://example.com/path')) -> roundtrip", description = "Roundtrip with url_parse" },
+]
+features = ["core"]
+
+[[functions]]
 name = "url_decode"
 category = "url"
 description = "URL decode a string"

--- a/crates/jpx-core/src/extensions/url_fns.rs
+++ b/crates/jpx-core/src/extensions/url_fns.rs
@@ -2,9 +2,10 @@
 
 use std::collections::HashSet;
 
+use form_urlencoded;
 use serde_json::Value;
 
-use crate::functions::Function;
+use crate::functions::{Function, custom_error};
 use crate::interpreter::SearchResult;
 use crate::registry::register_if_enabled;
 use crate::{Context, Runtime, arg, defn};
@@ -14,6 +15,19 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "url_encode", enabled, Box::new(UrlEncodeFn::new()));
     register_if_enabled(runtime, "url_decode", enabled, Box::new(UrlDecodeFn::new()));
     register_if_enabled(runtime, "url_parse", enabled, Box::new(UrlParseFn::new()));
+    register_if_enabled(runtime, "url_build", enabled, Box::new(UrlBuildFn::new()));
+    register_if_enabled(
+        runtime,
+        "query_string_parse",
+        enabled,
+        Box::new(QueryStringParseFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "query_string_build",
+        enabled,
+        Box::new(QueryStringBuildFn::new()),
+    );
 }
 
 // =============================================================================
@@ -143,6 +157,120 @@ impl Function for UrlParseFn {
     }
 }
 
+// =============================================================================
+// url_build(object) -> string (build URL from components)
+// =============================================================================
+
+defn!(UrlBuildFn, vec![arg!(object)], None);
+
+impl Function for UrlBuildFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let obj = args[0]
+            .as_object()
+            .ok_or_else(|| custom_error(ctx, "Expected object argument"))?;
+
+        let scheme = obj
+            .get("scheme")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| custom_error(ctx, "url_build: 'scheme' is required"))?;
+
+        let host = obj
+            .get("host")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| custom_error(ctx, "url_build: 'host' is required"))?;
+
+        let base = format!("{scheme}://{host}");
+        let mut url = url::Url::parse(&base)
+            .map_err(|e| custom_error(ctx, &format!("url_build: invalid scheme/host: {e}")))?;
+
+        if let Some(port) = obj.get("port")
+            && let Some(p) = port.as_u64()
+        {
+            url.set_port(Some(p as u16))
+                .map_err(|()| custom_error(ctx, "url_build: cannot set port on this URL"))?;
+        }
+
+        if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
+            url.set_path(path);
+        }
+
+        if let Some(query) = obj.get("query").and_then(|v| v.as_str()) {
+            url.set_query(Some(query));
+        }
+
+        if let Some(fragment) = obj.get("fragment").and_then(|v| v.as_str()) {
+            url.set_fragment(Some(fragment));
+        }
+
+        if let Some(username) = obj.get("username").and_then(|v| v.as_str()) {
+            url.set_username(username)
+                .map_err(|()| custom_error(ctx, "url_build: cannot set username on this URL"))?;
+        }
+
+        if let Some(password) = obj.get("password").and_then(|v| v.as_str()) {
+            url.set_password(Some(password))
+                .map_err(|()| custom_error(ctx, "url_build: cannot set password on this URL"))?;
+        }
+
+        Ok(Value::String(url.to_string()))
+    }
+}
+
+// =============================================================================
+// query_string_parse(string) -> object
+// =============================================================================
+
+defn!(QueryStringParseFn, vec![arg!(string)], None);
+
+impl Function for QueryStringParseFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let input = args[0]
+            .as_str()
+            .ok_or_else(|| custom_error(ctx, "Expected string argument"))?;
+
+        let mut map = serde_json::Map::new();
+        for (key, value) in form_urlencoded::parse(input.as_bytes()) {
+            map.insert(key.into_owned(), Value::String(value.into_owned()));
+        }
+
+        Ok(Value::Object(map))
+    }
+}
+
+// =============================================================================
+// query_string_build(object) -> string
+// =============================================================================
+
+defn!(QueryStringBuildFn, vec![arg!(object)], None);
+
+impl Function for QueryStringBuildFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let obj = args[0]
+            .as_object()
+            .ok_or_else(|| custom_error(ctx, "Expected object argument"))?;
+
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in obj {
+            let val_str = match value {
+                Value::String(s) => s.clone(),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                Value::Null => "null".to_string(),
+                _ => serde_json::to_string(value).unwrap_or_default(),
+            };
+            serializer.append_pair(key, &val_str);
+        }
+
+        Ok(Value::String(serializer.finish()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Runtime;
@@ -205,5 +333,120 @@ mod tests {
         let data = json!("not a valid url");
         let result = expr.search(&data).unwrap();
         assert!(result.is_null());
+    }
+
+    // url_build tests
+
+    #[test]
+    fn test_url_build_minimal() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_build(@)").unwrap();
+        let data = json!({"scheme": "https", "host": "example.com"});
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "https://example.com/");
+    }
+
+    #[test]
+    fn test_url_build_full() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("url_build(@)").unwrap();
+        let data = json!({
+            "scheme": "https",
+            "host": "example.com",
+            "port": 8080,
+            "path": "/api/v1",
+            "query": "key=value",
+            "fragment": "section",
+            "username": "user",
+            "password": "pass"
+        });
+        let result = expr.search(&data).unwrap();
+        assert_eq!(
+            result.as_str().unwrap(),
+            "https://user:pass@example.com:8080/api/v1?key=value#section"
+        );
+    }
+
+    #[test]
+    fn test_url_build_roundtrip() {
+        let runtime = setup_runtime();
+        let original = "https://example.com:8080/path?q=1#frag";
+        let parse_expr = runtime.compile("url_parse(@)").unwrap();
+        let parsed = parse_expr.search(&json!(original)).unwrap();
+
+        let build_expr = runtime.compile("url_build(@)").unwrap();
+        let rebuilt = build_expr.search(&parsed).unwrap();
+        assert_eq!(rebuilt.as_str().unwrap(), original);
+    }
+
+    // query_string_parse tests
+
+    #[test]
+    fn test_query_string_parse_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_parse(@)").unwrap();
+        let data = json!("foo=bar&baz=qux");
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.get("foo").unwrap().as_str().unwrap(), "bar");
+        assert_eq!(obj.get("baz").unwrap().as_str().unwrap(), "qux");
+    }
+
+    #[test]
+    fn test_query_string_parse_encoded() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_parse(@)").unwrap();
+        let data = json!("greeting=hello%20world&special=a%2Bb");
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert_eq!(
+            obj.get("greeting").unwrap().as_str().unwrap(),
+            "hello world"
+        );
+        assert_eq!(obj.get("special").unwrap().as_str().unwrap(), "a+b");
+    }
+
+    #[test]
+    fn test_query_string_parse_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_parse(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        let obj = result.as_object().unwrap();
+        assert!(obj.is_empty());
+    }
+
+    // query_string_build tests
+
+    #[test]
+    fn test_query_string_build_basic() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_build(@)").unwrap();
+        let data = json!({"foo": "bar", "baz": "qux"});
+        let result = expr.search(&data).unwrap();
+        let qs = result.as_str().unwrap();
+        // Object key order is deterministic in serde_json
+        assert!(qs.contains("foo=bar"));
+        assert!(qs.contains("baz=qux"));
+    }
+
+    #[test]
+    fn test_query_string_build_special_chars() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_build(@)").unwrap();
+        let data = json!({"greeting": "hello world", "op": "a+b"});
+        let result = expr.search(&data).unwrap();
+        let qs = result.as_str().unwrap();
+        assert!(qs.contains("greeting=hello+world"));
+        assert!(qs.contains("op=a%2Bb"));
+    }
+
+    #[test]
+    fn test_query_string_build_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("query_string_build(@)").unwrap();
+        let data = json!({});
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result.as_str().unwrap(), "");
     }
 }

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -55,7 +55,7 @@ jpx --describe upper
 | [String](./string.md) | Functions for string manipulation: case conversion, splittin... | 36 |
 | [Text](./text.md) | Text analysis and processing functions. | 11 |
 | [Type](./type.md) | Type conversion and checking functions. | 13 |
-| [URL](./url.md) | Functions for parsing and manipulating URLs and their compon... | 3 |
+| [URL](./url.md) | Functions for parsing and manipulating URLs and their compon... | 6 |
 | [Utility](./utility.md) | General utility functions that don't fit other categories. | 11 |
 | [UUID](./uuid.md) | Functions for generating and working with UUIDs. | 1 |
 | [Validation](./validation.md) | Functions for validating data: email, URL, UUID, and format ... | 13 |

--- a/docs/src/functions/url.md
+++ b/docs/src/functions/url.md
@@ -6,11 +6,94 @@ Functions for parsing and manipulating URLs and their components.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
+| [`query_string_build`](#query-string-build) | `object -> string` | Build a URL query string from an object |
+| [`query_string_parse`](#query-string-parse) | `string -> object` | Parse a URL query string into an object |
+| [`url_build`](#url-build) | `object -> string` | Build a URL from component parts |
 | [`url_decode`](#url-decode) | `string -> string` | URL decode a string |
 | [`url_encode`](#url-encode) | `string -> string` | URL encode a string |
 | [`url_parse`](#url-parse) | `string -> object` | Parse URL into components |
 
 ## Functions
+
+### query_string_build
+
+Build a URL query string from an object
+
+**Signature:** `object -> string`
+
+**Examples:**
+
+```text
+# Basic query string
+query_string_build({foo: 'bar', baz: 'qux'}) -> "foo=bar&baz=qux"
+# Special characters are encoded
+query_string_build({q: 'hello world'}) -> "q=hello+world"
+# Empty object
+query_string_build({}) -> ""
+```
+
+**CLI Usage:**
+
+```bash
+echo '{"q": "hello world", "page": "1"}' | jpx 'query_string_build(@)'
+```
+
+### query_string_parse
+
+Parse a URL query string into an object
+
+**Signature:** `string -> object`
+
+**Examples:**
+
+```text
+# Basic parsing
+query_string_parse('foo=bar&baz=qux') -> {"foo": "bar", "baz": "qux"}
+# Encoded values are decoded
+query_string_parse('greeting=hello%20world') -> {"greeting": "hello world"}
+# Empty string
+query_string_parse('') -> {}
+```
+
+**CLI Usage:**
+
+```bash
+echo '"foo=bar&baz=qux"' | jpx 'query_string_parse(@)'
+```
+
+### url_build
+
+Build a URL from component parts (inverse of `url_parse`)
+
+**Signature:** `object -> string`
+
+The input object supports these fields:
+
+- `scheme` (required): URL scheme (e.g., `"https"`)
+- `host` (required): Hostname (e.g., `"example.com"`)
+- `port` (optional): Port number
+- `path` (optional): URL path
+- `query` (optional): Query string
+- `fragment` (optional): Fragment identifier
+- `username` (optional): Username for authentication
+- `password` (optional): Password for authentication
+
+**Examples:**
+
+```text
+# Minimal URL
+url_build({scheme: 'https', host: 'example.com'}) -> "https://example.com/"
+# With port and path
+url_build({scheme: 'https', host: 'example.com', port: 8080, path: '/api/v1'}) -> "https://example.com:8080/api/v1"
+# Roundtrip with url_parse
+url_build(url_parse('https://example.com/path')) -> "https://example.com/path"
+```
+
+**CLI Usage:**
+
+```bash
+echo '{"scheme": "https", "host": "example.com", "path": "/api"}' | jpx 'url_build(@)'
+```
 
 ### url_decode
 


### PR DESCRIPTION
## Summary

- Adds `url_build(object) -> string` — build a URL from component parts (inverse of `url_parse`), with `scheme` and `host` required and optional `port`, `path`, `query`, `fragment`, `username`, `password`
- Adds `query_string_parse(string) -> object` — parse a URL query string like `foo=bar&baz=qux` into `{"foo": "bar", "baz": "qux"}` with URL decoding
- Adds `query_string_build(object) -> string` — build a URL-encoded query string from an object

Closes #114

## Changes

- `crates/jpx-core/Cargo.toml` — added `form_urlencoded` optional dependency
- `crates/jpx-core/src/extensions/url_fns.rs` — 3 function implementations + 9 unit tests
- `crates/jpx-core/functions.toml` — 3 new function entries
- `docs/src/functions/url.md` — documentation for all 3 functions
- `docs/src/functions/overview.md` — URL category count 3 → 6

## Test plan

- [x] `cargo fmt -p jpx-core` passes
- [x] `cargo clippy -p jpx-core -- -D warnings` passes
- [x] `cargo test -p jpx-core -- url` — all 14 URL tests pass
- [x] `cargo test -p jpx-core` — full crate (1896 tests) passes