### PR TITLE
fix(docker): MCP server container prints help instead of starting

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -30,4 +30,3 @@ USER jpx
 WORKDIR /home/jpx
 
 ENTRYPOINT ["jpx-mcp"]
-CMD ["--help"]


### PR DESCRIPTION
## Summary

- Removes `CMD ["--help"]` from the MCP server Dockerfile so the container starts the stdio MCP server by default instead of printing help and exiting

The `ENTRYPOINT ["jpx-mcp"]` is sufficient — without extra args it defaults to `--transport stdio`, which is the correct behavior for `docker run -i`.

## Test plan

- [x] `docker build -f docker/server/Dockerfile -t jpx-mcp-test .` builds successfully
- [x] MCP initialize handshake works: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | docker run --rm -i jpx-mcp-test` returns valid response
- [x] `docker run --rm -i jpx-mcp-test --help` still works for explicit help