### PR TITLE
feat(duration): add duration_days, duration_add, duration_subtract

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -1022,6 +1022,30 @@ features = ["core"]
 # =============================================================================
 
 [[functions]]
+name = "duration_add"
+category = "duration"
+description = "Add two duration strings"
+signature = "string, string -> string"
+examples = [
+    { code = '''duration_add('1h', '30m') -> \"1h30m\"''', description = "Add 1 hour and 30 minutes" },
+    { code = '''duration_add('1d', '12h') -> \"1d12h\"''', description = "Add 1 day and 12 hours" },
+    { code = '''duration_add('1h', '0s') -> \"1h\"''', description = "Identity with zero" },
+]
+features = ["core"]
+
+[[functions]]
+name = "duration_days"
+category = "duration"
+description = "Get days component from seconds"
+signature = "number -> number"
+examples = [
+    { code = "duration_days(`86400`) -> 1", description = "1 day" },
+    { code = "duration_days(`90061`) -> 1", description = "1 day 1 hour 1 min 1 sec" },
+    { code = "duration_days(`691200`) -> 1", description = "8 days wraps to 1 (8 mod 7)" },
+]
+features = ["core"]
+
+[[functions]]
 name = "duration_hours"
 category = "duration"
 description = "Convert seconds to hours"
@@ -1054,6 +1078,18 @@ examples = [
     { code = "duration_seconds(`65`) -> 5", description = "65 seconds mod 60" },
     { code = "duration_seconds(`120`) -> 0", description = "Exact minutes" },
     { code = "duration_seconds(`3661`) -> 1", description = "1 hour 1 min 1 sec" },
+]
+features = ["core"]
+
+[[functions]]
+name = "duration_subtract"
+category = "duration"
+description = "Subtract second duration string from first"
+signature = "string, string -> string"
+examples = [
+    { code = '''duration_subtract('2h', '30m') -> \"1h30m\"''', description = "Subtract 30 minutes from 2 hours" },
+    { code = '''duration_subtract('1h', '1h') -> \"0s\"''', description = "Equal durations" },
+    { code = '''duration_subtract('30m', '2h') -> \"0s\"''', description = "Underflow clamps to zero" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/duration.rs
+++ b/crates/jpx-core/src/extensions/duration.rs
@@ -94,6 +94,69 @@ impl Function for DurationSecondsFn {
     }
 }
 
+defn!(DurationDaysFn, vec![arg!(number)], None);
+
+impl Function for DurationDaysFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let num = args[0]
+            .as_f64()
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Expected number"))?;
+
+        let total_secs = num as u64;
+        let days = (total_secs / 86400) % 7;
+
+        Ok(Value::Number(Number::from(days)))
+    }
+}
+
+defn!(DurationAddFn, vec![arg!(string), arg!(string)], None);
+
+impl Function for DurationAddFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let a = args[0]
+            .as_str()
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Expected string"))?;
+        let b = args[1]
+            .as_str()
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Expected string"))?;
+
+        let secs_a = parse_duration_str(a)
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Invalid duration string"))?;
+        let secs_b = parse_duration_str(b)
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Invalid duration string"))?;
+
+        Ok(Value::String(format_duration_secs(secs_a + secs_b)))
+    }
+}
+
+defn!(DurationSubtractFn, vec![arg!(string), arg!(string)], None);
+
+impl Function for DurationSubtractFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let a = args[0]
+            .as_str()
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Expected string"))?;
+        let b = args[1]
+            .as_str()
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Expected string"))?;
+
+        let secs_a = parse_duration_str(a)
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Invalid duration string"))?;
+        let secs_b = parse_duration_str(b)
+            .ok_or_else(|| crate::functions::custom_error(ctx, "Invalid duration string"))?;
+
+        Ok(Value::String(format_duration_secs(
+            secs_a.saturating_sub(secs_b),
+        )))
+    }
+}
+
 /// Parse a duration string into total seconds.
 fn parse_duration_str(s: &str) -> Option<u64> {
     let s = s.trim().to_lowercase();
@@ -201,6 +264,18 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     );
     register_if_enabled(
         runtime,
+        "duration_add",
+        enabled,
+        Box::new(DurationAddFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "duration_days",
+        enabled,
+        Box::new(DurationDaysFn::new()),
+    );
+    register_if_enabled(
+        runtime,
         "duration_hours",
         enabled,
         Box::new(DurationHoursFn::new()),
@@ -216,6 +291,12 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         "duration_seconds",
         enabled,
         Box::new(DurationSecondsFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "duration_subtract",
+        enabled,
+        Box::new(DurationSubtractFn::new()),
     );
 }
 
@@ -316,5 +397,60 @@ mod tests {
         let expr = runtime.compile("duration_seconds(`90061`)").unwrap();
         let result = expr.search(&json!(null)).unwrap();
         assert_eq!(result.as_i64().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_duration_days_via_runtime() {
+        let runtime = setup_runtime();
+        // 86400 seconds = 1d -> days component is 1
+        let expr = runtime.compile("duration_days(`86400`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+
+        // 90061 seconds = 1d 1h 1m 1s -> days component is 1
+        let expr = runtime.compile("duration_days(`90061`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+
+        // 691200 seconds = 8 days = 1w1d -> days component is 8%7 = 1
+        let expr = runtime.compile("duration_days(`691200`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_i64().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_duration_add_via_runtime() {
+        let runtime = setup_runtime();
+
+        let expr = runtime.compile("duration_add('1h', '30m')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1h30m");
+
+        let expr = runtime.compile("duration_add('1d', '12h')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1d12h");
+
+        let expr = runtime.compile("duration_add('1h', '0s')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1h");
+    }
+
+    #[test]
+    fn test_duration_subtract_via_runtime() {
+        let runtime = setup_runtime();
+
+        let expr = runtime.compile("duration_subtract('2h', '30m')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1h30m");
+
+        // Equal durations -> "0s"
+        let expr = runtime.compile("duration_subtract('1h', '1h')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "0s");
+
+        // Underflow clamps to "0s"
+        let expr = runtime.compile("duration_subtract('30m', '2h')").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "0s");
     }
 }

--- a/docs/src/functions/duration.md
+++ b/docs/src/functions/duration.md
@@ -6,13 +6,62 @@ Functions for working with time durations.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
+| [`duration_add`](#duration-add) | `string, string -> string` | Add two duration strings |
+| [`duration_days`](#duration-days) | `number -> number` | Get days component from seconds |
 | [`duration_hours`](#duration-hours) | `number -> number` | Convert seconds to hours |
 | [`duration_minutes`](#duration-minutes) | `number -> number` | Convert seconds to minutes |
 | [`duration_seconds`](#duration-seconds) | `number -> number` | Get seconds component |
+| [`duration_subtract`](#duration-subtract) | `string, string -> string` | Subtract second duration string from first |
 | [`format_duration`](#format-duration) | `number -> string` | Format seconds as duration string |
 | [`parse_duration`](#parse-duration) | `string -> number` | Parse duration string to seconds |
 
 ## Functions
+
+### duration_add
+
+Add two duration strings
+
+**Signature:** `string, string -> string`
+
+**Examples:**
+
+```text
+# Add 1 hour and 30 minutes
+duration_add('1h', '30m') -> "1h30m"
+# Add 1 day and 12 hours
+duration_add('1d', '12h') -> "1d12h"
+# Identity with zero
+duration_add('1h', '0s') -> "1h"
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'duration_add(`"1h"`, `"30m"`)'
+```
+
+### duration_days
+
+Get days component from seconds
+
+**Signature:** `number -> number`
+
+**Examples:**
+
+```text
+# 1 day
+duration_days(`86400`) -> 1
+# 1 day 1 hour 1 min 1 sec
+duration_days(`90061`) -> 1
+# 8 days wraps to 1 (8 mod 7)
+duration_days(`691200`) -> 1
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'duration_days(`86400`)'
+```
 
 ### duration_hours
 
@@ -81,6 +130,29 @@ duration_seconds(`3661`) -> 1
 
 ```bash
 echo '{}' | jpx 'duration_seconds(`65`)'
+```
+
+### duration_subtract
+
+Subtract second duration string from first
+
+**Signature:** `string, string -> string`
+
+**Examples:**
+
+```text
+# Subtract 30 minutes from 2 hours
+duration_subtract('2h', '30m') -> "1h30m"
+# Equal durations
+duration_subtract('1h', '1h') -> "0s"
+# Underflow clamps to zero
+duration_subtract('30m', '2h') -> "0s"
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'duration_subtract(`"2h"`, `"30m"`)'
 ```
 
 ### format_duration

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -32,7 +32,7 @@ jpx --describe upper
 | [Color](./color.md) | Color manipulation and conversion functions. | 8 |
 | [Computing](./computing.md) | Computing-related utility functions. | 9 |
 | [Date/Time](./datetime.md) | Functions for working with dates and times: parsing, formatt... | 26 |
-| [Duration](./duration.md) | Functions for working with time durations. | 5 |
+| [Duration](./duration.md) | Functions for working with time durations. | 8 |
 | [Encoding](./encoding.md) | Encoding and decoding functions: Base64, hex, URL encoding, ... | 8 |
 | [Expression](./expression.md) | Higher-order functions that work with JMESPath expressions a... | 33 |
 | [Format](./format.md) | Data formatting functions for numbers, currencies, and other... | 6 |


### PR DESCRIPTION
## Summary

- Add `duration_days(number) -> number` — extract the days component from a total seconds value (`(secs / 86400) % 7`), consistent with `duration_hours`, `duration_minutes`, `duration_seconds`
- Add `duration_add(string, string) -> string` — parse two duration strings, add them, return formatted result
- Add `duration_subtract(string, string) -> string` — parse two duration strings, subtract with `saturating_sub` (clamps to `"0s"`)

Closes #115

## Changes

- `crates/jpx-core/src/extensions/duration.rs` — 3 function structs, registration, 3 test functions (9 assertions)
- `crates/jpx-core/functions.toml` — 3 new entries in duration section
- `docs/src/functions/duration.md` — summary table + detail sections
- `docs/src/functions/overview.md` — duration count 5 → 8

## Test plan

- [x] `cargo fmt -p jpx-core` — clean
- [x] `cargo clippy -p jpx-core -- -D warnings` — clean
- [x] `cargo test -p jpx-core -- duration` — 12/12 pass
- [x] `cargo test -p jpx-core` — full suite passes
- [x] `cargo clippy -p jpx-mcp -- -D warnings` — downstream builds clean