### PR TITLE
feat(encoding): add base64url_encode, base64url_decode

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -1146,6 +1146,30 @@ examples = [
 features = ["core"]
 
 [[functions]]
+name = "base64url_decode"
+category = "encoding"
+description = "Decode base64url (RFC 4648 §5) string"
+signature = "string -> string"
+examples = [
+    { code = '''base64url_decode('aGVsbG8') -> \"hello\"''', description = "Decode hello" },
+    { code = '''base64url_decode('dGVzdA') -> \"test\"''', description = "Decode test" },
+    { code = '''base64url_decode('') -> \"\"''', description = "Empty string" },
+]
+features = ["core"]
+
+[[functions]]
+name = "base64url_encode"
+category = "encoding"
+description = "Encode string to base64url (RFC 4648 §5, no padding)"
+signature = "string -> string"
+examples = [
+    { code = '''base64url_encode('hello') -> \"aGVsbG8\"''', description = "Encode hello" },
+    { code = '''base64url_encode('test') -> \"dGVzdA\"''', description = "Encode test" },
+    { code = '''base64url_encode('') -> \"\"''', description = "Empty string" },
+]
+features = ["core"]
+
+[[functions]]
 name = "hex_decode"
 category = "encoding"
 description = "Decode hex string"

--- a/crates/jpx-core/src/extensions/encoding.rs
+++ b/crates/jpx-core/src/extensions/encoding.rs
@@ -28,6 +28,18 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         enabled,
         Box::new(Base64DecodeFn::new()),
     );
+    register_if_enabled(
+        runtime,
+        "base64url_decode",
+        enabled,
+        Box::new(Base64UrlDecodeFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "base64url_encode",
+        enabled,
+        Box::new(Base64UrlEncodeFn::new()),
+    );
     register_if_enabled(runtime, "hex_encode", enabled, Box::new(HexEncodeFn::new()));
     register_if_enabled(runtime, "hex_decode", enabled, Box::new(HexDecodeFn::new()));
     register_if_enabled(runtime, "jwt_decode", enabled, Box::new(JwtDecodeFn::new()));
@@ -104,6 +116,63 @@ impl Function for Base64DecodeFn {
             Err(_) => Err(crate::JmespathError::from_ctx(
                 ctx,
                 crate::ErrorReason::Parse("Invalid base64 input".to_owned()),
+            )),
+        }
+    }
+}
+
+// =============================================================================
+// base64url_encode(string) -> string
+// =============================================================================
+
+defn!(Base64UrlEncodeFn, vec![arg!(string)], None);
+
+impl Function for Base64UrlEncodeFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let input = args[0].as_str().ok_or_else(|| {
+            crate::JmespathError::from_ctx(
+                ctx,
+                crate::ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        let encoded = BASE64_URL_SAFE.encode(input.as_bytes());
+        Ok(Value::String(encoded))
+    }
+}
+
+// =============================================================================
+// base64url_decode(string) -> string
+// =============================================================================
+
+defn!(Base64UrlDecodeFn, vec![arg!(string)], None);
+
+impl Function for Base64UrlDecodeFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+
+        let input = args[0].as_str().ok_or_else(|| {
+            crate::JmespathError::from_ctx(
+                ctx,
+                crate::ErrorReason::Parse("Expected string argument".to_owned()),
+            )
+        })?;
+
+        match BASE64_URL_SAFE.decode(input.as_bytes()) {
+            Ok(decoded) => {
+                let s = String::from_utf8(decoded).map_err(|_| {
+                    crate::JmespathError::from_ctx(
+                        ctx,
+                        crate::ErrorReason::Parse("Decoded bytes are not valid UTF-8".to_owned()),
+                    )
+                })?;
+                Ok(Value::String(s))
+            }
+            Err(_) => Err(crate::JmespathError::from_ctx(
+                ctx,
+                crate::ErrorReason::Parse("Invalid base64url input".to_owned()),
             )),
         }
     }
@@ -578,5 +647,104 @@ mod tests {
         let data = json!("don't say 'hello'");
         let result = expr.search(&data).unwrap();
         assert_eq!(result, json!("'don'\\''t say '\\''hello'\\'''"));
+    }
+
+    // =========================================================================
+    // base64url function tests
+    // =========================================================================
+
+    #[test]
+    fn test_base64url_encode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_encode(@)").unwrap();
+        let data = json!("hello");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("aGVsbG8"));
+    }
+
+    #[test]
+    fn test_base64url_decode() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_decode(@)").unwrap();
+        let data = json!("aGVsbG8");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn test_base64url_roundtrip() {
+        let runtime = setup_runtime();
+        let encode = runtime.compile("base64url_encode(@)").unwrap();
+        let decode = runtime.compile("base64url_decode(@)").unwrap();
+        let original = "hello world! 🌍";
+        let data = json!(original);
+        let encoded = encode.search(&data).unwrap();
+        let roundtrip = decode.search(&encoded).unwrap();
+        assert_eq!(roundtrip, json!(original));
+    }
+
+    #[test]
+    fn test_base64url_no_padding() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_encode(@)").unwrap();
+        // "test" in standard base64 is "dGVzdA==" — url-safe should have no padding
+        let data = json!("test");
+        let result = expr.search(&data).unwrap();
+        let s = result.as_str().unwrap();
+        assert!(
+            !s.contains('='),
+            "base64url output should not contain padding"
+        );
+        assert_eq!(s, "dGVzdA");
+    }
+
+    #[test]
+    fn test_base64url_uses_url_safe_chars() {
+        let runtime = setup_runtime();
+        let encode_url = runtime.compile("base64url_encode(@)").unwrap();
+        let encode_std = runtime.compile("base64_encode(@)").unwrap();
+        // Input that produces +/ in standard base64: bytes 0xFB, 0xFF, 0xBF
+        // "????" encodes differently in standard vs url-safe
+        // Use a known input: "\xfb\xef\xbe" → standard: "u+++" url-safe: "u--+"
+        // Actually, let's use a string whose standard base64 contains + or /
+        let data = json!("subjects?_d");
+        let std_result = encode_std.search(&data).unwrap();
+        let url_result = encode_url.search(&data).unwrap();
+        let std_s = std_result.as_str().unwrap();
+        let url_s = url_result.as_str().unwrap();
+        // URL-safe should never contain + or /
+        assert!(!url_s.contains('+'), "base64url should not contain '+'");
+        assert!(!url_s.contains('/'), "base64url should not contain '/'");
+        // If standard contains + or /, url-safe should have - or _ instead
+        if std_s.contains('+') || std_s.contains('/') {
+            assert_ne!(std_s.trim_end_matches('='), url_s);
+        }
+    }
+
+    #[test]
+    fn test_base64url_decode_invalid() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_decode(@)").unwrap();
+        let data = json!("!!!invalid!!!");
+        let result = expr.search(&data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_base64url_encode_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_encode(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(""));
+    }
+
+    #[test]
+    fn test_base64url_decode_empty() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("base64url_decode(@)").unwrap();
+        let data = json!("");
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(""));
     }
 }

--- a/docs/src/functions/encoding.md
+++ b/docs/src/functions/encoding.md
@@ -8,6 +8,8 @@ Encoding and decoding functions: Base64, hex, URL encoding, and more.
 |----------|-----------|-------------|
 | [`base64_decode`](#base64-decode) | `string -> string` | Decode base64 string |
 | [`base64_encode`](#base64-encode) | `string -> string` | Encode string to base64 |
+| [`base64url_decode`](#base64url-decode) | `string -> string` | Decode base64url (RFC 4648 §5) string |
+| [`base64url_encode`](#base64url-encode) | `string -> string` | Encode string to base64url (RFC 4648 §5, no padding) |
 | [`hex_decode`](#hex-decode) | `string -> string` | Decode hex string |
 | [`hex_encode`](#hex-encode) | `string -> string` | Encode string to hex |
 | [`html_escape`](#html-escape) | `string -> string` | Escape HTML special characters |
@@ -61,6 +63,52 @@ base64_encode('') -> \"\"
 
 ```bash
 echo '{}' | jpx 'base64_encode(`"hello"`)'
+```
+
+### base64url_decode
+
+Decode base64url (RFC 4648 §5) string
+
+**Signature:** `string -> string`
+
+**Examples:**
+
+```text
+# Decode hello
+base64url_decode('aGVsbG8') -> "hello"
+# Decode test
+base64url_decode('dGVzdA') -> "test"
+# Empty string
+base64url_decode('') -> ""
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'base64url_decode(`"aGVsbG8"`)'
+```
+
+### base64url_encode
+
+Encode string to base64url (RFC 4648 §5, no padding)
+
+**Signature:** `string -> string`
+
+**Examples:**
+
+```text
+# Encode hello
+base64url_encode('hello') -> "aGVsbG8"
+# Encode test
+base64url_encode('test') -> "dGVzdA"
+# Empty string
+base64url_encode('') -> ""
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'base64url_encode(`"hello"`)'
 ```
 
 ### hex_decode

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -33,7 +33,7 @@ jpx --describe upper
 | [Computing](./computing.md) | Computing-related utility functions. | 9 |
 | [Date/Time](./datetime.md) | Functions for working with dates and times: parsing, formatt... | 26 |
 | [Duration](./duration.md) | Functions for working with time durations. | 8 |
-| [Encoding](./encoding.md) | Encoding and decoding functions: Base64, hex, URL encoding, ... | 8 |
+| [Encoding](./encoding.md) | Encoding and decoding functions: Base64, hex, URL encoding, ... | 10 |
 | [Expression](./expression.md) | Higher-order functions that work with JMESPath expressions a... | 33 |
 | [Format](./format.md) | Data formatting functions for numbers, currencies, and other... | 6 |
 | [Fuzzy](./fuzzy.md) | Fuzzy matching and string similarity functions. | 9 |


### PR DESCRIPTION
## Summary
- Add `base64url_encode` and `base64url_decode` functions using RFC 4648 §5 (URL-safe, no padding)
- Reuses the already-imported `BASE64_URL_SAFE` engine — no new dependencies
- Useful for JWT/OAuth/web-API workflows

Closes #118

## Changes
- **`crates/jpx-core/src/extensions/encoding.rs`** — `Base64UrlEncodeFn` / `Base64UrlDecodeFn` structs + 8 tests (roundtrip, no-padding, url-safe chars, invalid input, empty)
- **`crates/jpx-core/functions.toml`** — 2 new entries
- **`docs/src/functions/encoding.md`** — summary table rows + function detail sections
- **`docs/src/functions/overview.md`** — encoding count 8 → 10

## Test plan
- [x] `cargo fmt -p jpx-core`
- [x] `cargo clippy -p jpx-core -- -D warnings` (clean)
- [x] `cargo test -p jpx-core -- base64url` (8 passed)
- [x] `cargo test -p jpx-core` (full suite, 1029 tests passed)