### PR TITLE
feat(rand): add random_int and random_choice

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -3655,6 +3655,28 @@ examples = [
 features = ["core"]
 
 [[functions]]
+name = "random_choice"
+category = "rand"
+description = "Pick a random element from an array"
+signature = "array -> any"
+examples = [
+    { code = "random_choice(['a', 'b', 'c']) -> 'b'", description = "Random element" },
+    { code = "random_choice([]) -> null", description = "Empty array returns null" },
+]
+features = ["core"]
+
+[[functions]]
+name = "random_int"
+category = "rand"
+description = "Generate a random integer in an inclusive range [min, max]"
+signature = "number, number -> number"
+examples = [
+    { code = "random_int(`1`, `10`) -> 7", description = "Random integer 1-10" },
+    { code = "random_int(`0`, `1`) -> 0", description = "Coin flip" },
+]
+features = ["core"]
+
+[[functions]]
 name = "sample"
 category = "rand"
 description = "Random sample from array"

--- a/crates/jpx-core/src/extensions/random.rs
+++ b/crates/jpx-core/src/extensions/random.rs
@@ -12,8 +12,15 @@ use crate::{Context, Runtime, defn};
 /// Register random functions filtered by the enabled set.
 pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "random", enabled, Box::new(RandomFn::new()));
-    register_if_enabled(runtime, "shuffle", enabled, Box::new(ShuffleFn::new()));
+    register_if_enabled(
+        runtime,
+        "random_choice",
+        enabled,
+        Box::new(RandomChoiceFn::new()),
+    );
+    register_if_enabled(runtime, "random_int", enabled, Box::new(RandomIntFn::new()));
     register_if_enabled(runtime, "sample", enabled, Box::new(SampleFn::new()));
+    register_if_enabled(runtime, "shuffle", enabled, Box::new(ShuffleFn::new()));
     register_if_enabled(runtime, "uuid", enabled, Box::new(UuidFn::new()));
 }
 
@@ -62,6 +69,91 @@ impl Function for RandomFn {
         };
 
         Ok(number_value(value))
+    }
+}
+
+// =============================================================================
+// random_choice(array) -> any (random element from array)
+// =============================================================================
+
+pub struct RandomChoiceFn;
+
+impl Default for RandomChoiceFn {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RandomChoiceFn {
+    pub fn new() -> RandomChoiceFn {
+        RandomChoiceFn
+    }
+}
+
+impl Function for RandomChoiceFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        use rand::seq::SliceRandom;
+
+        if args.len() != 1 {
+            return Err(custom_error(ctx, "random_choice() takes 1 argument"));
+        }
+
+        let arr = args[0]
+            .as_array()
+            .ok_or_else(|| custom_error(ctx, "Expected array argument"))?;
+
+        if arr.is_empty() {
+            return Ok(Value::Null);
+        }
+
+        let chosen = arr
+            .choose(&mut rand::thread_rng())
+            .cloned()
+            .unwrap_or(Value::Null);
+
+        Ok(chosen)
+    }
+}
+
+// =============================================================================
+// random_int(min, max) -> number (random integer in [min, max])
+// =============================================================================
+
+pub struct RandomIntFn;
+
+impl Default for RandomIntFn {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RandomIntFn {
+    pub fn new() -> RandomIntFn {
+        RandomIntFn
+    }
+}
+
+impl Function for RandomIntFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        use rand::Rng;
+
+        if args.len() != 2 {
+            return Err(custom_error(ctx, "random_int() takes 2 arguments"));
+        }
+
+        let min = args[0]
+            .as_f64()
+            .ok_or_else(|| custom_error(ctx, "Expected number for min"))? as i64;
+        let max = args[1]
+            .as_f64()
+            .ok_or_else(|| custom_error(ctx, "Expected number for max"))? as i64;
+
+        if min > max {
+            return Err(custom_error(ctx, "min must be less than or equal to max"));
+        }
+
+        let value = rand::thread_rng().gen_range(min..=max);
+        Ok(Value::Number(serde_json::Number::from(value)))
     }
 }
 
@@ -193,7 +285,7 @@ impl Function for UuidFn {
 #[cfg(test)]
 mod tests {
     use crate::Runtime;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     fn setup_runtime() -> Runtime {
         Runtime::builder()
@@ -209,6 +301,60 @@ mod tests {
         let result = expr.search(&json!(null)).unwrap();
         let value = result.as_f64().unwrap();
         assert!((0.0..1.0).contains(&value));
+    }
+
+    #[test]
+    fn test_random_choice() {
+        let runtime = setup_runtime();
+        let data = json!(["a", "b", "c"]);
+        let expr = runtime.compile("random_choice(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert!(result.is_string());
+        let s = result.as_str().unwrap();
+        assert!(["a", "b", "c"].contains(&s));
+    }
+
+    #[test]
+    fn test_random_choice_single_element() {
+        let runtime = setup_runtime();
+        let data = json!([42]);
+        let expr = runtime.compile("random_choice(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, json!(42));
+    }
+
+    #[test]
+    fn test_random_choice_empty() {
+        let runtime = setup_runtime();
+        let data = json!([]);
+        let expr = runtime.compile("random_choice(@)").unwrap();
+        let result = expr.search(&data).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_random_int() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("random_int(`1`, `10`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        let value = result.as_i64().unwrap();
+        assert!((1..=10).contains(&value));
+    }
+
+    #[test]
+    fn test_random_int_min_equals_max() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("random_int(`5`, `5`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result, json!(5));
+    }
+
+    #[test]
+    fn test_random_int_min_greater_than_max() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("random_int(`10`, `1`)").unwrap();
+        let result = expr.search(&json!(null));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -48,7 +48,7 @@ jpx --describe upper
 | [Object](./object.md) | Functions for working with JSON objects: merging, filtering ... | 48 |
 | [Path](./path.md) | File path manipulation functions. | 4 |
 | [Phonetic](./phonetic.md) | Phonetic encoding functions for sound-based string matching. | 9 |
-| [Random](./rand.md) | Functions for generating random values: numbers, strings, an... | 3 |
+| [Random](./rand.md) | Functions for generating random values: numbers, strings, an... | 5 |
 | [Regular Expression](./regex.md) | Regular expression functions: matching, replacing, splitting... | 5 |
 | [Semantic Versioning](./semver.md) | Semantic versioning functions: parsing, comparing, and manip... | 7 |
 | [Standard JMESPath](./standard.md) | These are the standard JMESPath functions as defined in the ... | 26 |

--- a/docs/src/functions/rand.md
+++ b/docs/src/functions/rand.md
@@ -7,6 +7,8 @@ Functions for generating random values: numbers, strings, and selections.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | [`random`](#random) | `-> number` | Generate random number between 0 and 1 |
+| [`random_choice`](#random_choice) | `array -> any` | Pick a random element from an array |
+| [`random_int`](#random_int) | `number, number -> number` | Generate a random integer in an inclusive range |
 | [`sample`](#sample) | `array, number -> array` | Random sample from array |
 | [`shuffle`](#shuffle) | `array -> array` | Randomly shuffle array |
 
@@ -31,6 +33,52 @@ floor(multiply(random(), `100`)) -> 42
 
 ```bash
 echo '{}' | jpx 'random()'
+```
+
+### random_choice
+
+Pick a random element from an array
+
+**Signature:** `array -> any`
+
+**Examples:**
+
+```text
+# Pick a random element
+random_choice(['a', 'b', 'c']) -> 'b'
+# Empty array returns null
+random_choice([]) -> null
+# Single element
+random_choice([42]) -> 42
+```
+
+**CLI Usage:**
+
+```bash
+echo '["red", "green", "blue"]' | jpx 'random_choice(@)'
+```
+
+### random_int
+
+Generate a random integer in an inclusive range [min, max]
+
+**Signature:** `number, number -> number`
+
+**Examples:**
+
+```text
+# Random integer 1-10
+random_int(`1`, `10`) -> 7
+# Coin flip (0 or 1)
+random_int(`0`, `1`) -> 0
+# Fixed value when min == max
+random_int(`5`, `5`) -> 5
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'random_int(`1`, `100`)'
 ```
 
 ### sample


### PR DESCRIPTION
## Summary
- Add `random_int(min, max)` — generates a random integer in the inclusive range `[min, max]`, errors if `min > max`
- Add `random_choice(array)` — picks a random element from an array, returns `null` for empty arrays
- Both registered in the rand category; no new dependencies needed

Closes #117

## Test plan
- [x] `cargo fmt -p jpx-core` — clean
- [x] `cargo clippy -p jpx-core -- -D warnings` — clean
- [x] `cargo test -p jpx-core -- random` — 9 tests pass (6 new)
- [x] `cargo test -p jpx-core` — full crate passes