### PR TITLE
feat(path): add path_stem, path_is_absolute, path_is_relative

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -3522,6 +3522,30 @@ examples = [
 features = ["core"]
 
 [[functions]]
+name = "path_is_absolute"
+category = "path"
+description = "Check if path is absolute"
+signature = "string -> boolean"
+examples = [
+    { code = '''path_is_absolute('/foo/bar') -> true''', description = "Absolute path" },
+    { code = '''path_is_absolute('foo/bar') -> false''', description = "Relative path" },
+    { code = '''path_is_absolute('file.txt') -> false''', description = "Filename only" },
+]
+features = ["core"]
+
+[[functions]]
+name = "path_is_relative"
+category = "path"
+description = "Check if path is relative"
+signature = "string -> boolean"
+examples = [
+    { code = '''path_is_relative('foo/bar') -> true''', description = "Relative path" },
+    { code = '''path_is_relative('file.txt') -> true''', description = "Filename only" },
+    { code = '''path_is_relative('/foo/bar') -> false''', description = "Absolute path" },
+]
+features = ["core"]
+
+[[functions]]
 name = "path_join"
 category = "path"
 description = "Join path segments"
@@ -3530,6 +3554,18 @@ examples = [
     { code = '''path_join('/foo', 'bar', 'baz') -> \"/foo/bar/baz\"''', description = "Multiple segments" },
     { code = '''path_join('/home', 'user', 'file.txt') -> \"/home/user/file.txt\"''', description = "Full path" },
     { code = '''path_join('a', 'b') -> \"a/b\"''', description = "Relative path" },
+]
+features = ["core"]
+
+[[functions]]
+name = "path_stem"
+category = "path"
+description = "Get filename without extension"
+signature = "string -> string"
+examples = [
+    { code = '''path_stem('file.txt') -> \"file\"''', description = "Simple file" },
+    { code = '''path_stem('/foo/bar.tar.gz') -> \"bar.tar\"''', description = "Double extension" },
+    { code = '''path_stem('noext') -> \"noext\"''', description = "No extension" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/path.rs
+++ b/crates/jpx-core/src/extensions/path.rs
@@ -24,7 +24,20 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(PathDirnameFn::new()),
     );
     register_if_enabled(runtime, "path_ext", enabled, Box::new(PathExtFn::new()));
+    register_if_enabled(
+        runtime,
+        "path_is_absolute",
+        enabled,
+        Box::new(PathIsAbsoluteFn::new()),
+    );
+    register_if_enabled(
+        runtime,
+        "path_is_relative",
+        enabled,
+        Box::new(PathIsRelativeFn::new()),
+    );
     register_if_enabled(runtime, "path_join", enabled, Box::new(PathJoinFn::new()));
+    register_if_enabled(runtime, "path_stem", enabled, Box::new(PathStemFn::new()));
 }
 
 // =============================================================================
@@ -83,6 +96,34 @@ impl Function for PathExtFn {
 }
 
 // =============================================================================
+// path_is_absolute(string) -> boolean
+// =============================================================================
+
+defn!(PathIsAbsoluteFn, vec![arg!(string)], None);
+
+impl Function for PathIsAbsoluteFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+        let path = args[0].as_str().unwrap();
+        Ok(Value::Bool(std::path::Path::new(path).is_absolute()))
+    }
+}
+
+// =============================================================================
+// path_is_relative(string) -> boolean
+// =============================================================================
+
+defn!(PathIsRelativeFn, vec![arg!(string)], None);
+
+impl Function for PathIsRelativeFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+        let path = args[0].as_str().unwrap();
+        Ok(Value::Bool(std::path::Path::new(path).is_relative()))
+    }
+}
+
+// =============================================================================
 // path_join(array) -> string
 // =============================================================================
 
@@ -100,6 +141,26 @@ impl Function for PathJoinFn {
         }
         let result = path.to_str().unwrap_or("").to_string();
         Ok(Value::String(result))
+    }
+}
+
+// =============================================================================
+// path_stem(string) -> string | null
+// =============================================================================
+
+defn!(PathStemFn, vec![arg!(string)], None);
+
+impl Function for PathStemFn {
+    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
+        self.signature.validate(args, ctx)?;
+        let path = args[0].as_str().unwrap();
+        let stem = std::path::Path::new(path)
+            .file_stem()
+            .and_then(|s| s.to_str());
+        match stem {
+            Some(s) => Ok(Value::String(s.to_string())),
+            None => Ok(Value::Null),
+        }
     }
 }
 
@@ -140,5 +201,39 @@ mod tests {
         let data = json!("/path/to/file.txt");
         let result = expr.search(&data).unwrap();
         assert_eq!(result.as_str().unwrap(), ".txt");
+    }
+
+    #[test]
+    fn test_path_is_absolute() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_is_absolute(@)").unwrap();
+
+        assert_eq!(expr.search(&json!("/foo/bar")).unwrap(), json!(true));
+        assert_eq!(expr.search(&json!("foo/bar")).unwrap(), json!(false));
+        assert_eq!(expr.search(&json!("file.txt")).unwrap(), json!(false));
+    }
+
+    #[test]
+    fn test_path_is_relative() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_is_relative(@)").unwrap();
+
+        assert_eq!(expr.search(&json!("foo/bar")).unwrap(), json!(true));
+        assert_eq!(expr.search(&json!("file.txt")).unwrap(), json!(true));
+        assert_eq!(expr.search(&json!("/foo/bar")).unwrap(), json!(false));
+    }
+
+    #[test]
+    fn test_path_stem() {
+        let runtime = setup_runtime();
+        let expr = runtime.compile("path_stem(@)").unwrap();
+
+        assert_eq!(expr.search(&json!("file.txt")).unwrap(), json!("file"));
+        assert_eq!(
+            expr.search(&json!("/foo/bar.tar.gz")).unwrap(),
+            json!("bar.tar")
+        );
+        assert_eq!(expr.search(&json!("noext")).unwrap(), json!("noext"));
+        assert_eq!(expr.search(&json!("/foo/bar/")).unwrap(), json!("bar"));
     }
 }

--- a/docs/src/functions/overview.md
+++ b/docs/src/functions/overview.md
@@ -46,7 +46,7 @@ jpx --describe upper
 | [Multi-Match](./multimatch.md) | Functions for matching multiple patterns or expressions in a... | 10 |
 | [Network](./network.md) | Network-related functions: IP addresses, CIDR notation, and ... | 7 |
 | [Object](./object.md) | Functions for working with JSON objects: merging, filtering ... | 48 |
-| [Path](./path.md) | File path manipulation functions. | 4 |
+| [Path](./path.md) | File path manipulation functions. | 7 |
 | [Phonetic](./phonetic.md) | Phonetic encoding functions for sound-based string matching. | 9 |
 | [Random](./rand.md) | Functions for generating random values: numbers, strings, an... | 3 |
 | [Regular Expression](./regex.md) | Regular expression functions: matching, replacing, splitting... | 5 |

--- a/docs/src/functions/path.md
+++ b/docs/src/functions/path.md
@@ -9,7 +9,10 @@ File path manipulation functions.
 | [`path_basename`](#path-basename) | `string -> string` | Get filename from path |
 | [`path_dirname`](#path-dirname) | `string -> string` | Get directory from path |
 | [`path_ext`](#path-ext) | `string -> string` | Get file extension |
+| [`path_is_absolute`](#path-is-absolute) | `string -> boolean` | Check if path is absolute |
+| [`path_is_relative`](#path-is-relative) | `string -> boolean` | Check if path is relative |
 | [`path_join`](#path-join) | `string... -> string` | Join path segments |
+| [`path_stem`](#path-stem) | `string -> string` | Get filename without extension |
 
 ## Functions
 
@@ -23,11 +26,11 @@ Get filename from path
 
 ```text
 # Unix path
-path_basename('/foo/bar.txt') -> \"bar.txt\"
+path_basename('/foo/bar.txt') -> "bar.txt"
 # Directory path
-path_basename('/foo/bar/') -> \"bar\"
+path_basename('/foo/bar/') -> "bar"
 # Just filename
-path_basename('file.txt') -> \"file.txt\"
+path_basename('file.txt') -> "file.txt"
 ```
 
 **CLI Usage:**
@@ -46,11 +49,11 @@ Get directory from path
 
 ```text
 # Unix path
-path_dirname('/foo/bar.txt') -> \"/foo\"
+path_dirname('/foo/bar.txt') -> "/foo"
 # Nested path
-path_dirname('/foo/bar/baz') -> \"/foo/bar\"
+path_dirname('/foo/bar/baz') -> "/foo/bar"
 # No directory
-path_dirname('file.txt') -> \"\"
+path_dirname('file.txt') -> ""
 ```
 
 **CLI Usage:**
@@ -69,17 +72,63 @@ Get file extension
 
 ```text
 # Text file
-path_ext('/foo/bar.txt') -> \"txt\"
+path_ext('/foo/bar.txt') -> "txt"
 # Image file
-path_ext('image.png') -> \"png\"
+path_ext('image.png') -> "png"
 # No extension
-path_ext('noext') -> \"\"
+path_ext('noext') -> ""
 ```
 
 **CLI Usage:**
 
 ```bash
 echo '{}' | jpx 'path_ext(`"/foo/bar.txt"`)'
+```
+
+### path_is_absolute
+
+Check if path is absolute
+
+**Signature:** `string -> boolean`
+
+**Examples:**
+
+```text
+# Absolute path
+path_is_absolute('/foo/bar') -> true
+# Relative path
+path_is_absolute('foo/bar') -> false
+# Filename only
+path_is_absolute('file.txt') -> false
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'path_is_absolute(`"/foo/bar"`)'
+```
+
+### path_is_relative
+
+Check if path is relative
+
+**Signature:** `string -> boolean`
+
+**Examples:**
+
+```text
+# Relative path
+path_is_relative('foo/bar') -> true
+# Filename only
+path_is_relative('file.txt') -> true
+# Absolute path
+path_is_relative('/foo/bar') -> false
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'path_is_relative(`"foo/bar"`)'
 ```
 
 ### path_join
@@ -92,11 +141,11 @@ Join path segments
 
 ```text
 # Multiple segments
-path_join('/foo', 'bar', 'baz') -> \"/foo/bar/baz\"
+path_join('/foo', 'bar', 'baz') -> "/foo/bar/baz"
 # Full path
-path_join('/home', 'user', 'file.txt') -> \"/home/user/file.txt\"
+path_join('/home', 'user', 'file.txt') -> "/home/user/file.txt"
 # Relative path
-path_join('a', 'b') -> \"a/b\"
+path_join('a', 'b') -> "a/b"
 ```
 
 **CLI Usage:**
@@ -105,3 +154,25 @@ path_join('a', 'b') -> \"a/b\"
 echo '{}' | jpx 'path_join(`"/foo"`, `"bar"`, `"baz"`)'
 ```
 
+### path_stem
+
+Get filename without extension
+
+**Signature:** `string -> string`
+
+**Examples:**
+
+```text
+# Simple file
+path_stem('file.txt') -> "file"
+# Double extension
+path_stem('/foo/bar.tar.gz') -> "bar.tar"
+# No extension
+path_stem('noext') -> "noext"
+```
+
+**CLI Usage:**
+
+```bash
+echo '{}' | jpx 'path_stem(`"/foo/bar.txt"`)'
+```


### PR DESCRIPTION
## Summary
- Adds `path_stem` — returns the filename without its extension (e.g. `file.txt` → `"file"`, `bar.tar.gz` → `"bar.tar"`)
- Adds `path_is_absolute` — returns `true` if the path is absolute
- Adds `path_is_relative` — returns `true` if the path is relative
- Brings the path category from 4 → 7 functions

Closes #116

## Test plan
- [x] `cargo fmt -p jpx-core`
- [x] `cargo clippy -p jpx-core -- -D warnings` — 0 warnings
- [x] `cargo test -p jpx-core -- path` — all path tests pass
- [x] `cargo test -p jpx-core` — full crate passes