### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arrow",
  "dirs",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.1.3" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.3.2" }
+jpx-core = { path = "crates/jpx-core", version = "0.2.0" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.3.3" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.3...jpx-core-v0.2.0) - 2026-02-23
+
+### Added
+
+- add pivot/unpivot functions for data reshaping ([#158](https://github.com/joshrotenberg/jpx/pull/158))
+- add rank, dense_rank, lag, lead window functions ([#159](https://github.com/joshrotenberg/jpx/pull/159))
+- add skew, kurtosis, mad statistics functions ([#160](https://github.com/joshrotenberg/jpx/pull/160))
+- add unit conversion functions (temperature, length, mass, volume) ([#139](https://github.com/joshrotenberg/jpx/pull/139))
+
+### Fixed
+
+- correct expref signatures and examples in functions.toml ([#133](https://github.com/joshrotenberg/jpx/pull/133))
+
+### Other
+
+- improve coverage for thin extension modules ([#156](https://github.com/joshrotenberg/jpx/pull/156))
+- add stress tests for large/extreme inputs ([#154](https://github.com/joshrotenberg/jpx/pull/154))
+
 ## [0.1.3](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.2...jpx-core-v0.1.3) - 2026-02-11
 
 ### Added

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.2...jpx-engine-v0.3.3) - 2026-02-23
+
+### Other
+
+- updated the following local packages: jpx-core
+
 ## [0.3.2](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.1...jpx-engine-v0.3.2) - 2026-02-11
 
 ### Fixed

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.1.3 -> 0.2.0 (⚠ API breaking changes)
* `jpx`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `jpx-mcp`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `jpx-engine`: 0.3.2 -> 0.3.3

### ⚠ `jpx-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Category:Units in /tmp/.tmpQARUls/jpx/crates/jpx-core/src/registry.rs:50
  variant Category:Units in /tmp/.tmpQARUls/jpx/crates/jpx-core/src/registry.rs:50
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.1.3...jpx-core-v0.2.0) - 2026-02-23

### Added

- add pivot/unpivot functions for data reshaping ([#158](https://github.com/joshrotenberg/jpx/pull/158))
- add rank, dense_rank, lag, lead window functions ([#159](https://github.com/joshrotenberg/jpx/pull/159))
- add skew, kurtosis, mad statistics functions ([#160](https://github.com/joshrotenberg/jpx/pull/160))
- add unit conversion functions (temperature, length, mass, volume) ([#139](https://github.com/joshrotenberg/jpx/pull/139))

### Fixed

- correct expref signatures and examples in functions.toml ([#133](https://github.com/joshrotenberg/jpx/pull/133))

### Other

- improve coverage for thin extension modules ([#156](https://github.com/joshrotenberg/jpx/pull/156))
- add stress tests for large/extreme inputs ([#154](https://github.com/joshrotenberg/jpx/pull/154))
</blockquote>

## `jpx`

<blockquote>

## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.1...jpx-v0.4.2) - 2026-02-11

### Other

- updated the following local packages: jpx-engine
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.1...jpx-mcp-v0.4.2) - 2026-02-11

### Other

- updated the following local packages: jpx-engine
</blockquote>

## `jpx-engine`

<blockquote>

## [0.3.3](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.2...jpx-engine-v0.3.3) - 2026-02-23

### Other

- updated the following local packages: jpx-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).