### PR TITLE
chore: upgrade tower-mcp from 0.5 to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,9 +3184,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65dc3cd2b853a0aa855ebd2d8d353a21c8351573758339d4ba4e323622977a0"
+checksum = "1c6fdbe3a253a465a9089d0caefee33cbc8d2f91b0c70af810af742100fccb67"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ strsim = "0.11"
 json-patch = "4.0"
 
 # MCP server dependencies
-tower-mcp = "0.5"
+tower-mcp = "0.6"
 schemars = "1.2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- Upgrades `tower-mcp` from 0.5 to 0.6
- Picks up MCP spec compliance fixes, cursor-based pagination, dynamic tool registry, `_meta` fields, and more
- Clean upgrade — no API changes needed

## Test plan
- [x] `cargo clippy -p jpx-mcp -- -D warnings` — 0 warnings
- [x] `cargo test -p jpx-mcp` — all 58 tool tests pass