### PR TITLE
docs: fix expref signatures in expression.md, revert group_by change

### DIFF
--- a/docs/src/functions/expression.md
+++ b/docs/src/functions/expression.md
@@ -9,18 +9,18 @@ Higher-order functions that work with JMESPath expressions as arguments.
 | [`all_expr`](#all-expr) | `array, expression -> boolean` | Return true if every element satisfies the expression (short-circuits on false) |
 | [`any_expr`](#any-expr) | `array, expression -> boolean` | Return true if any element satisfies the expression (short-circuits) |
 | [`apply`](#apply) | `object\|string, ...any -> any` | Apply a partial function or invoke a function by name with arguments |
-| [`count_by`](#count-by) | `string, array -> object` | Count occurrences grouped by expression result |
+| [`count_by`](#count-by) | `expref, array -> object` | Count occurrences grouped by expression result |
 | [`count_expr`](#count-expr) | `array, expression -> number` | Count how many elements satisfy the expression |
-| [`drop_while`](#drop-while) | `string, array -> array` | Drop elements from array while expression is truthy |
-| [`every`](#every) | `string, array -> boolean` | Check if all elements match (alias for all_expr) |
+| [`drop_while`](#drop-while) | `expref, array -> array` | Drop elements from array while expression is truthy |
+| [`every`](#every) | `expref, array -> boolean` | Check if all elements match (alias for all_expr) |
 | [`filter_expr`](#filter-expr) | `array, expression -> array` | Keep elements where JMESPath expression evaluates to truthy value |
 | [`find_expr`](#find-expr) | `array, expression -> any` | Return first element where expression is truthy, or null if none match |
 | [`find_index_expr`](#find-index-expr) | `array, expression -> number \| null` | Return zero-based index of first matching element, or -1 if none match |
 | [`flat_map_expr`](#flat-map-expr) | `array, expression -> array` | Apply expression to each element and flatten all results into one array |
 | [`group_by_expr`](#group-by-expr) | `array, expression -> object` | Group elements into object keyed by expression result |
 | [`map_expr`](#map-expr) | `array, expression -> array` | Apply a JMESPath expression to each element, returning transformed array |
-| [`map_keys`](#map-keys) | `string, object -> object` | Transform object keys using expression |
-| [`map_values`](#map-values) | `string, object -> object` | Transform object values using expression |
+| [`map_keys`](#map-keys) | `expref, object -> object` | Transform object keys using expression |
+| [`map_values`](#map-values) | `expref, object -> object` | Transform object values using expression |
 | [`max_by_expr`](#max-by-expr) | `array, expression -> any` | Return element with largest expression result, or null for empty array |
 | [`min_by_expr`](#min-by-expr) | `array, expression -> any` | Return element with smallest expression result, or null for empty array |
 | [`order_by`](#order-by) | `array, array[[string, string]] -> array` | Sort array by multiple fields with ascending/descending control |
@@ -28,17 +28,17 @@ Higher-order functions that work with JMESPath expressions as arguments.
 | [`partition_expr`](#partition-expr) | `array, expression -> array` | Split array into [matches, non-matches] based on expression |
 | [`recurse`](#recurse) | `any -> array` | Collect all nested values recursively (jq parity) |
 | [`recurse_with`](#recurse-with) | `any, expression -> array` | Recursive descent with expression filter (jq parity) |
-| [`reduce_expr`](#reduce-expr) | `string, array, any -> any` | Reduce array to single value using accumulator expression |
-| [`reject`](#reject) | `string, array -> array` | Keep elements where expression is falsy (inverse of filter_expr) |
-| [`scan_expr`](#scan-expr) | `string, array, any -> array` | Like reduce but returns array of intermediate accumulator values |
-| [`some`](#some) | `string, array -> boolean` | Check if any element matches (alias for any_expr) |
+| [`reduce_expr`](#reduce-expr) | `expref, array, any -> any` | Reduce array to single value using accumulator expression |
+| [`reject`](#reject) | `expref, array -> array` | Keep elements where expression is falsy (inverse of filter_expr) |
+| [`scan_expr`](#scan-expr) | `expref, array, any -> array` | Like reduce but returns array of intermediate accumulator values |
+| [`some`](#some) | `expref, array -> boolean` | Check if any element matches (alias for any_expr) |
 | [`sort_by_expr`](#sort-by-expr) | `array, expression -> array` | Sort array by expression result in ascending order |
-| [`take_while`](#take-while) | `string, array -> array` | Take elements from array while expression is truthy |
+| [`take_while`](#take-while) | `expref, array -> array` | Take elements from array while expression is truthy |
 | [`unique_by_expr`](#unique-by-expr) | `array, expression -> array` | Remove duplicates by expression result, keeping first occurrence |
 | [`until_expr`](#until-expr) | `any, expression, expression -> array` | Loop until condition becomes true, collecting intermediate values (jq parity) |
-| [`walk`](#walk) | `string, any -> any` | Recursively apply expression to all components of a value (bottom-up) |
+| [`walk`](#walk) | `expref, any -> any` | Recursively apply expression to all components of a value (bottom-up) |
 | [`while_expr`](#while-expr) | `any, expression, expression -> array` | Loop while condition is true, collecting intermediate values (jq parity) |
-| [`zip_with`](#zip-with) | `string, array, array -> array` | Zip two arrays with a custom combiner expression |
+| [`zip_with`](#zip-with) | `expref, array, array -> array` | Zip two arrays with a custom combiner expression |
 
 ## Functions
 
@@ -125,19 +125,19 @@ echo '{}' | jpx 'apply(partial(`"join"`, `\"-\"`), `[\"a\", \"b\"]`)'
 
 Count occurrences grouped by expression result
 
-**Signature:** `string, array -> object`
+**Signature:** `expref, array -> object`
 
 **Examples:**
 
 ```text
 # Count by field
-count_by('type', [{type: 'a'}, {type: 'b'}, {type: 'a'}]) -> {a: 2, b: 1}
+count_by(&type, [{type: 'a'}, {type: 'b'}, {type: 'a'}]) -> {a: 2, b: 1}
 # Count orders by status
-count_by('status', orders) -> {pending: 5, shipped: 3}
+count_by(&status, orders) -> {pending: 5, shipped: 3}
 # Count by condition
-count_by('@ > `50`', [30, 60, 70, 40]) -> {true: 2, false: 2}
+count_by(&@ > `50`, [30, 60, 70, 40]) -> {true: 2, false: 2}
 # Empty array
-count_by('category', []) -> {}
+count_by(&category, []) -> {}
 ```
 
 **CLI Usage:**
@@ -175,19 +175,19 @@ echo '{}' | jpx 'count_expr([1, 2, 3], &@ > `1`)'
 
 Drop elements from array while expression is truthy
 
-**Signature:** `string, array -> array`
+**Signature:** `expref, array -> array`
 
 **Examples:**
 
 ```text
 # Drop while < 4
-drop_while('@ < `4`', [1, 2, 3, 5, 1]) -> [5, 1]
+drop_while(&@ < `4`, [1, 2, 3, 5, 1]) -> [5, 1]
 # None dropped
-drop_while('@ < `0`', [1, 2, 3]) -> [1, 2, 3]
+drop_while(&@ < `0`, [1, 2, 3]) -> [1, 2, 3]
 # All dropped
-drop_while('@ < `10`', [1, 2, 3]) -> []
+drop_while(&@ < `10`, [1, 2, 3]) -> []
 # Drop short strings
-drop_while('length(@) < `3`', ['a', 'ab', 'abc', 'x']) -> ['abc', 'x']
+drop_while(&length(@) < `3`, ['a', 'ab', 'abc', 'x']) -> ['abc', 'x']
 ```
 
 **CLI Usage:**
@@ -200,19 +200,19 @@ echo '{}' | jpx 'drop_while(`"@ < `4`"`, [1, 2, 3, 5, 1])'
 
 Check if all elements match (alias for all_expr)
 
-**Signature:** `string, array -> boolean`
+**Signature:** `expref, array -> boolean`
 
 **Examples:**
 
 ```text
 # All positive
-every('@ > `0`', [1, 2, 3]) -> true
+every(&@ > `0`, [1, 2, 3]) -> true
 # Not all > 2
-every('@ > `2`', [1, 2, 3]) -> false
+every(&@ > `2`, [1, 2, 3]) -> false
 # All non-empty
-every('length(@) > `0`', ['a', 'b']) -> true
+every(&length(@) > `0`, ['a', 'b']) -> true
 # Empty is vacuously true
-every('@ > `0`', []) -> true
+every(&@ > `0`, []) -> true
 ```
 
 **CLI Usage:**
@@ -377,19 +377,19 @@ echo '{}' | jpx 'map_expr([1, 2], &@ * `2`)'
 
 Transform object keys using expression
 
-**Signature:** `string, object -> object`
+**Signature:** `expref, object -> object`
 
 **Examples:**
 
 ```text
 # Uppercase keys
-map_keys('upper(@)', {a: 1}) -> {A: 1}
+map_keys(&upper(@), {a: 1}) -> {A: 1}
 # Lowercase keys
-map_keys('lower(@)', {A: 1, B: 2}) -> {a: 1, b: 2}
+map_keys(&lower(@), {A: 1, B: 2}) -> {a: 1, b: 2}
 # Add suffix
-map_keys('concat(@, `"_suffix"`)', {x: 1}) -> {x_suffix: 1}
+map_keys(&concat(@, `"_suffix"`), {x: 1}) -> {x_suffix: 1}
 # Empty object
-map_keys('upper(@)', {}) -> {}
+map_keys(&upper(@), {}) -> {}
 ```
 
 **CLI Usage:**
@@ -402,19 +402,19 @@ echo '{}' | jpx 'map_keys(`"upper(@)"`, {a: 1})'
 
 Transform object values using expression
 
-**Signature:** `string, object -> object`
+**Signature:** `expref, object -> object`
 
 **Examples:**
 
 ```text
 # Double values
-map_values('@ * `2`', {a: 1, b: 2}) -> {a: 2, b: 4}
+map_values(&@ * `2`, {a: 1, b: 2}) -> {a: 2, b: 4}
 # Uppercase strings
-map_values('upper(@)', {a: 'x', b: 'y'}) -> {a: 'X', b: 'Y'}
+map_values(&upper(@), {a: 'x', b: 'y'}) -> {a: 'X', b: 'Y'}
 # Add to values
-map_values('@ + `10`', {x: 5}) -> {x: 15}
+map_values(&@ + `10`, {x: 5}) -> {x: 15}
 # Empty object
-map_values('@ * `2`', {}) -> {}
+map_values(&@ * `2`, {}) -> {}
 ```
 
 **CLI Usage:**
@@ -600,7 +600,7 @@ echo '{}' | jpx 'recurse_with({a: {a: 1}}, &a)'
 
 Reduce array to single value using accumulator expression
 
-**Signature:** `string, array, any -> any`
+**Signature:** `expref, array, any -> any`
 
 **Aliases:** `fold`
 
@@ -608,13 +608,13 @@ Reduce array to single value using accumulator expression
 
 ```text
 # Sum numbers
-reduce_expr('add(accumulator, current)', [1, 2, 3], `0`) -> 6
+reduce_expr(&add(accumulator, current), [1, 2, 3], `0`) -> 6
 # Product
-reduce_expr('multiply(accumulator, current)', [2, 3, 4], `1`) -> 24
+reduce_expr(&multiply(accumulator, current), [2, 3, 4], `1`) -> 24
 # Find max
-reduce_expr('max(accumulator, current)', [3, 1, 4], `0`) -> 4
+reduce_expr(&max(accumulator, current), [3, 1, 4], `0`) -> 4
 # Concat strings
-reduce_expr('concat(accumulator, current)', ['a', 'b'], '') -> 'ab'
+reduce_expr(&concat(accumulator, current), ['a', 'b'], '') -> 'ab'
 ```
 
 **CLI Usage:**
@@ -627,19 +627,19 @@ echo '{}' | jpx 'reduce_expr(`"add(accumulator, current)"`, [1, 2, 3], `0`)'
 
 Keep elements where expression is falsy (inverse of filter_expr)
 
-**Signature:** `string, array -> array`
+**Signature:** `expref, array -> array`
 
 **Examples:**
 
 ```text
 # Reject > 2
-reject('@ > `2`', [1, 2, 3, 4]) -> [1, 2]
+reject(&@ > `2`, [1, 2, 3, 4]) -> [1, 2]
 # Reject negatives
-reject('@ < `0`', [1, -1, 2, -2]) -> [1, 2]
+reject(&@ < `0`, [1, -1, 2, -2]) -> [1, 2]
 # Reject active users
-reject('active', users) -> inactive users
+reject(&active, users) -> inactive users
 # Empty array
-reject('@ > `0`', []) -> []
+reject(&@ > `0`, []) -> []
 ```
 
 **CLI Usage:**
@@ -652,19 +652,21 @@ echo '{}' | jpx 'reject(`"@ > `2`"`, [1, 2, 3, 4])'
 
 Like reduce but returns array of intermediate accumulator values
 
-**Signature:** `string, array, any -> array`
+**Signature:** `expref, array, any -> array`
+
+**Aliases:** `reductions`
 
 **Examples:**
 
 ```text
 # Running sum
-scan_expr('add(accumulator, current)', [1, 2, 3], `0`) -> [1, 3, 6]
+scan_expr(&add(accumulator, current), [1, 2, 3], `0`) -> [1, 3, 6]
 # Running product
-scan_expr('multiply(accumulator, current)', [2, 3, 4], `1`) -> [2, 6, 24]
+scan_expr(&multiply(accumulator, current), [2, 3, 4], `1`) -> [2, 6, 24]
 # Running max
-scan_expr('max(accumulator, current)', [3, 1, 4], `0`) -> [3, 3, 4]
+scan_expr(&max(accumulator, current), [3, 1, 4], `0`) -> [3, 3, 4]
 # Empty array
-scan_expr('add(accumulator, current)', [], `0`) -> []
+scan_expr(&add(accumulator, current), [], `0`) -> []
 ```
 
 **CLI Usage:**
@@ -677,19 +679,19 @@ echo '{}' | jpx 'scan_expr(`"add(accumulator, current)"`, [1, 2, 3], `0`)'
 
 Check if any element matches (alias for any_expr)
 
-**Signature:** `string, array -> boolean`
+**Signature:** `expref, array -> boolean`
 
 **Examples:**
 
 ```text
 # Some > 2
-some('@ > `2`', [1, 2, 3]) -> true
+some(&@ > `2`, [1, 2, 3]) -> true
 # None > 5
-some('@ > `5`', [1, 2, 3]) -> false
+some(&@ > `5`, [1, 2, 3]) -> false
 # Any active user
-some('active', users) -> true/false
+some(&active, users) -> true/false
 # Empty is false
-some('@ > `0`', []) -> false
+some(&@ > `0`, []) -> false
 ```
 
 **CLI Usage:**
@@ -727,25 +729,25 @@ echo '{}' | jpx 'sort_by_expr([{a: 2}, {a: 1}], &a)'
 
 Take elements from array while expression is truthy
 
-**Signature:** `string, array -> array`
+**Signature:** `expref, array -> array`
 
 **Examples:**
 
 ```text
 # Take while < 4
-take_while('@ < `4`', [1, 2, 3, 5, 1]) -> [1, 2, 3]
+take_while(&@ < `4`, [1, 2, 3, 5, 1]) -> [1, 2, 3]
 # Take while positive
-take_while('@ > `0`', [3, 2, 1, 0, 5]) -> [3, 2, 1]
+take_while(&@ > `0`, [3, 2, 1, 0, 5]) -> [3, 2, 1]
 # Take short strings
-take_while('length(@) < `3`', ['a', 'ab', 'abc']) -> ['a', 'ab']
+take_while(&length(@) < `3`, ['a', 'ab', 'abc']) -> ['a', 'ab']
 # None taken
-take_while('@ < `0`', [1, 2, 3]) -> []
+take_while(&@ < `0`, [1, 2, 3]) -> []
 ```
 
 **CLI Usage:**
 
 ```bash
-echo '{}' | jpx 'take_while(`"@ < `4`"`, [1, 2, 3, 5, 1])'
+echo '{}' | jpx 'take_while(&@ < `4`, [1, 2, 3, 5, 1])'
 ```
 
 ### unique_by_expr
@@ -800,25 +802,25 @@ echo '{}' | jpx 'until_expr(`1`, &@ >= `5`, &add(@, `1`))'
 
 Recursively apply expression to all components of a value (bottom-up)
 
-**Signature:** `string, any -> any`
+**Signature:** `expref, any -> any`
 
 **Examples:**
 
 ```text
 # Identity transform
-walk('@', data) -> data unchanged
+walk(&@, data) -> data unchanged
 # Get type of result
-walk('type(@)', {a: 1}) -> 'object'
+walk(&type(@), {a: 1}) -> 'object'
 # Lengths of nested arrays
-walk('length(@)', [[], []]) -> 2
+walk(&length(@), [[], []]) -> 2
 # Keys at each level
-walk('keys(@)', {a: {b: 1}}) -> ['a']
+walk(&keys(@), {a: {b: 1}}) -> ['a']
 ```
 
 **CLI Usage:**
 
 ```bash
-echo '{}' | jpx 'walk(`"@"`, data)'
+echo '{}' | jpx 'walk(&@, data)'
 ```
 
 ### while_expr
@@ -848,24 +850,24 @@ echo '{}' | jpx 'while_expr(`1`, &@ < `5`, &add(@, `1`))'
 
 Zip two arrays with a custom combiner expression
 
-**Signature:** `string, array, array -> array`
+**Signature:** `expref, array, array -> array`
 
 **Examples:**
 
 ```text
 # Add pairs
-zip_with('add([0], [1])', [1, 2], [10, 20]) -> [11, 22]
+zip_with(&add([0], [1]), [1, 2], [10, 20]) -> [11, 22]
 # Multiply pairs
-zip_with('multiply([0], [1])', [2, 3], [4, 5]) -> [8, 15]
+zip_with(&multiply([0], [1]), [2, 3], [4, 5]) -> [8, 15]
 # Concat pairs
-zip_with('concat([0], [1])', ['a', 'b'], ['1', '2']) -> ['a1', 'b2']
+zip_with(&concat([0], [1]), ['a', 'b'], ['1', '2']) -> ['a1', 'b2']
 # Empty arrays
-zip_with('add([0], [1])', [], []) -> []
+zip_with(&add([0], [1]), [], []) -> []
 ```
 
 **CLI Usage:**
 
 ```bash
-echo '{}' | jpx 'zip_with(`"add([0], [1])"`, [1, 2], [10, 20])'
+echo '{}' | jpx 'zip_with(&add([0], [1]), [1, 2], [10, 20])'
 ```
 

--- a/docs/src/presentations/demo-script.md
+++ b/docs/src/presentations/demo-script.md
@@ -152,7 +152,7 @@ The query:
 features[*].{
   region: last(split(properties.place, `", "`)),
   mag: properties.mag
-} | group_by(@, &region)
+} | group_by(@, 'region')
   | items(@)
   | [*].{region: [0], count: length([1]), max_mag: max([1][*].mag)}
   | sort_by(@, &count)


### PR DESCRIPTION
## Summary
- Fix 15 expression-category functions in `expression.md` that documented `string` signatures and `'expr'` syntax instead of `expref` and `&expr` (summary table + all detail sections)
- Revert incorrect `group_by(@, &region)` back to `group_by(@, 'region')` in demo script — the array-category `group_by` legitimately takes a string field name

Follow-up to the project-wide string-vs-expref audit (#132, #133).

## Functions fixed in expression.md
count_by, drop_while, every, map_keys, map_values, reduce_expr, reject, scan_expr, some, take_while, walk, zip_with

## Test plan
- [ ] Docs build correctly (`mkdocs serve`)
- [ ] No remaining `Signature.*string` entries for expref functions