### PR TITLE
feat: add --unbuffered flag for streaming mode

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -385,6 +385,10 @@ pub(crate) struct Args {
           long_help = "Stream mode - process input line by line (for NDJSON/JSON Lines).\nEach line is parsed and evaluated independently with constant memory usage.")]
     pub(crate) stream: bool,
 
+    /// Flush output after each record in streaming mode
+    #[arg(long, help = "Flush output after each record in streaming mode")]
+    pub(crate) unbuffered: bool,
+
     /// Color output mode
     #[arg(long, value_enum, default_value = "auto")]
     pub(crate) color: ColorMode,

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -81,6 +81,9 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
         };
 
         writeln!(writer, "{}", output)?;
+        if args.unbuffered {
+            writer.flush()?;
+        }
     }
 
     if args.verbose {

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -191,6 +191,18 @@ mod input_modes {
     }
 
     #[test]
+    fn stream_unbuffered_outputs_records() {
+        jpx()
+            .arg("--stream")
+            .arg("--unbuffered")
+            .arg("id")
+            .write_stdin("{\"id\":1}\n{\"id\":2}\n{\"id\":3}")
+            .assert()
+            .success()
+            .stdout("1\n2\n3\n");
+    }
+
+    #[test]
     fn stream_no_expression_defaults_to_identity() {
         jpx()
             .arg("--stream")


### PR DESCRIPTION
## Summary

- Add `--unbuffered` CLI flag that flushes stdout after each record in streaming mode
- Enables real-time output visibility for pipeline processing (matches jq's `--unbuffered` flag)
- Default streaming behavior (buffered) is unchanged

Closes #147

## Test plan

- [x] New integration test `stream_unbuffered_outputs_records` verifies correct output with `--stream --unbuffered`
- [ ] Manual test: `cat large.ndjson | jpx --stream --unbuffered .name` shows output immediately