### PR TITLE
feat: add --sort-keys / -S flag for deterministic output

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -306,6 +306,14 @@ pub(crate) struct Args {
     )]
     pub(crate) compact: bool,
 
+    /// Sort object keys in output
+    #[arg(
+        short = 'S',
+        long = "sort-keys",
+        help = "Sort object keys alphabetically in output"
+    )]
+    pub(crate) sort_keys: bool,
+
     /// Output as YAML
     #[arg(short = 'y', long, conflicts_with_all = ["toml_output", "csv_output", "tsv_output", "lines_output"])]
     pub(crate) yaml: bool,

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -85,17 +85,35 @@ fn run() -> Result<()> {
 
     // Handle --diff: generate JSON Patch from two files
     if let Some(files) = &args.diff {
-        return ops::diff_files(&files[0], &files[1], args.compact, &args.color);
+        return ops::diff_files(
+            &files[0],
+            &files[1],
+            args.compact,
+            &args.color,
+            args.sort_keys,
+        );
     }
 
     // Handle --patch: apply JSON Patch to document
     if let Some(patch_file) = &args.patch {
-        return ops::apply_patch(&args.file, patch_file, args.compact, &args.color);
+        return ops::apply_patch(
+            &args.file,
+            patch_file,
+            args.compact,
+            &args.color,
+            args.sort_keys,
+        );
     }
 
     // Handle --merge: apply JSON Merge Patch to document
     if let Some(merge_file) = &args.merge {
-        return ops::apply_merge(&args.file, merge_file, args.compact, &args.color);
+        return ops::apply_merge(
+            &args.file,
+            merge_file,
+            args.compact,
+            &args.color,
+            args.sort_keys,
+        );
     }
 
     // Handle --stats: show data statistics
@@ -295,7 +313,11 @@ fn run() -> Result<()> {
     }
 
     // Result is already a serde_json::Value
-    let json_value = result;
+    let json_value = if args.sort_keys {
+        output::sort_value_keys(&result)
+    } else {
+        result
+    };
 
     // Handle alternative output formats
     if args.yaml {

--- a/crates/jpx/src/ops.rs
+++ b/crates/jpx/src/ops.rs
@@ -11,6 +11,7 @@ pub(crate) fn diff_files(
     target_path: &str,
     compact: bool,
     color_mode: &ColorMode,
+    sort_keys: bool,
 ) -> Result<()> {
     let source: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(source_path)
@@ -39,7 +40,7 @@ pub(crate) fn diff_files(
     );
 
     let patch_value = serde_json::to_value(&patch)?;
-    output_json(&patch_value, compact, color_mode)
+    output_json(&patch_value, compact, color_mode, sort_keys)
 }
 
 /// List queries in a .jpx query library file
@@ -190,6 +191,7 @@ pub(crate) fn apply_patch(
     patch_path: &str,
     compact: bool,
     color_mode: &ColorMode,
+    sort_keys: bool,
 ) -> Result<()> {
     // Read the document (from -f or stdin)
     let mut doc = read_json_from(doc_path.as_deref())?;
@@ -213,7 +215,7 @@ pub(crate) fn apply_patch(
         patch.0.len().to_string().yellow()
     );
 
-    output_json(&doc, compact, color_mode)
+    output_json(&doc, compact, color_mode, sort_keys)
 }
 
 /// Apply JSON Merge Patch (RFC 7396) to a document
@@ -222,6 +224,7 @@ pub(crate) fn apply_merge(
     merge_path: &str,
     compact: bool,
     color_mode: &ColorMode,
+    sort_keys: bool,
 ) -> Result<()> {
     // Read the document (from -f or stdin)
     let mut doc = read_json_from(doc_path.as_deref())?;
@@ -237,5 +240,5 @@ pub(crate) fn apply_merge(
 
     eprintln!("{} Applied merge patch", "✓".green());
 
-    output_json(&doc, compact, color_mode)
+    output_json(&doc, compact, color_mode, sort_keys)
 }

--- a/crates/jpx/src/output.rs
+++ b/crates/jpx/src/output.rs
@@ -5,6 +5,24 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
 
+/// Recursively sort all object keys alphabetically in a JSON value
+pub(crate) fn sort_value_keys(value: &serde_json::Value) -> serde_json::Value {
+    use serde_json::Value;
+    match value {
+        Value::Object(map) => {
+            let sorted: serde_json::Map<String, Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), sort_value_keys(v)))
+                .collect::<BTreeMap<_, _>>()
+                .into_iter()
+                .collect();
+            Value::Object(sorted)
+        }
+        Value::Array(arr) => Value::Array(arr.iter().map(sort_value_keys).collect()),
+        other => other.clone(),
+    }
+}
+
 /// Helper to write output to file or stdout
 pub(crate) fn write_output(content: &str, output_path: &Option<String>) -> Result<()> {
     if let Some(path) = output_path {
@@ -18,12 +36,19 @@ pub(crate) fn write_output(content: &str, output_path: &Option<String>) -> Resul
     Ok(())
 }
 
-/// Output JSON with optional coloring
+/// Output JSON with optional coloring and key sorting
 pub(crate) fn output_json(
     value: &serde_json::Value,
     compact: bool,
     color_mode: &ColorMode,
+    sort_keys: bool,
 ) -> Result<()> {
+    let value = if sort_keys {
+        std::borrow::Cow::Owned(sort_value_keys(value))
+    } else {
+        std::borrow::Cow::Borrowed(value)
+    };
+
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
@@ -31,13 +56,13 @@ pub(crate) fn output_json(
     };
 
     if compact {
-        println!("{}", serde_json::to_string(value)?);
+        println!("{}", serde_json::to_string(&*value)?);
     } else if use_color {
         use colored_json::{ColoredFormatter, PrettyFormatter};
         let formatter = ColoredFormatter::new(PrettyFormatter::new());
-        println!("{}", formatter.to_colored_json_auto(value)?);
+        println!("{}", formatter.to_colored_json_auto(&*value)?);
     } else {
-        println!("{}", serde_json::to_string_pretty(value)?);
+        println!("{}", serde_json::to_string_pretty(&*value)?);
     }
     Ok(())
 }

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -66,6 +66,12 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
             };
         }
 
+        let result = if args.sort_keys {
+            crate::output::sort_value_keys(&result)
+        } else {
+            result
+        };
+
         if result.is_null() {
             continue;
         }

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -483,6 +483,78 @@ mod file_output {
     }
 }
 
+mod sort_keys {
+    use super::*;
+
+    #[test]
+    fn sort_keys_alphabetical() {
+        jpx()
+            .arg("-S")
+            .arg("-c")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"z":3,"a":1,"m":2}"#)
+            .assert()
+            .success()
+            .stdout("{\"a\":1,\"m\":2,\"z\":3}\n");
+    }
+
+    #[test]
+    fn sort_keys_nested() {
+        jpx()
+            .arg("--sort-keys")
+            .arg("-c")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"b":{"z":1,"a":2},"a":3}"#)
+            .assert()
+            .success()
+            .stdout("{\"a\":3,\"b\":{\"a\":2,\"z\":1}}\n");
+    }
+
+    #[test]
+    fn sort_keys_preserves_array_order() {
+        jpx()
+            .arg("-S")
+            .arg("-c")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"[3,1,2]"#)
+            .assert()
+            .success()
+            .stdout("[3,1,2]\n");
+    }
+
+    #[test]
+    fn sort_keys_with_compact() {
+        jpx()
+            .arg("-S")
+            .arg("-c")
+            .arg("@")
+            .arg("--color")
+            .arg("never")
+            .write_stdin(r#"{"c":3,"a":1,"b":2}"#)
+            .assert()
+            .success()
+            .stdout("{\"a\":1,\"b\":2,\"c\":3}\n");
+    }
+
+    #[test]
+    fn sort_keys_streaming() {
+        jpx()
+            .arg("--stream")
+            .arg("-S")
+            .arg("@")
+            .write_stdin("{\"z\":1,\"a\":2}\n{\"b\":3,\"a\":4}\n")
+            .assert()
+            .success()
+            .stdout("{\"a\":2,\"z\":1}\n{\"a\":4,\"b\":3}\n");
+    }
+}
+
 mod color_mode {
     use super::*;
 


### PR DESCRIPTION
## Summary

- Add `--sort-keys` / `-S` CLI flag that recursively sorts all object keys alphabetically before output
- Applies to all output formats (JSON, YAML, TOML, CSV, TSV, lines, table, streaming) and ops (diff, patch, merge)
- Matches jq's `--sort-keys` / `-S` flag for familiarity

## Test plan

- [x] `sort_keys_alphabetical`: verifies top-level key reordering
- [x] `sort_keys_nested`: verifies nested objects are also sorted
- [x] `sort_keys_preserves_array_order`: verifies array element order is unchanged
- [x] `sort_keys_with_compact`: verifies `-S -c` works together
- [x] `sort_keys_streaming`: verifies `--stream -S` sorts keys in streaming mode
- [x] `cargo fmt`, `cargo clippy`, full test suite passing

Closes #140