### PR TITLE
fix: replace chrono-english with interim (RUSTSEC-2024-0395)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,16 +536,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chrono-english"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a56613410c9249673f4676ab8d27c70949814accb27b6b738009e2ff1034a1"
-dependencies = [
- "chrono",
- "scanlex",
 ]
 
 [[package]]
@@ -1466,6 +1462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "interim"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ce9099a85f468663d3225bf87e85d0548968441e1db12248b996b24f0f5b5a"
+dependencies = [
+ "chrono",
+ "logos",
+]
+
+[[package]]
 name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,7 +1554,6 @@ dependencies = [
  "aho-corasick",
  "base64",
  "chrono",
- "chrono-english",
  "chrono-tz",
  "crc32fast",
  "criterion",
@@ -1560,6 +1565,7 @@ dependencies = [
  "heck",
  "hex",
  "hmac",
+ "interim",
  "ipnetwork",
  "jmespath",
  "json-patch",
@@ -1780,6 +1786,40 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "matchers"
@@ -2587,12 +2627,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scanlex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "schemars"

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -34,7 +34,7 @@ hex = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
 chrono = { version = "0.4", optional = true }
 chrono-tz = { version = "0.10", optional = true }
-chrono-english = { version = "0.1", optional = true }
+interim = { version = "0.2", features = ["chrono_0_4"], optional = true }
 dateparser = { version = "0.2", optional = true }
 strsim = { version = "0.11", optional = true }
 rphonetic = { version = "3.0", optional = true }
@@ -77,7 +77,7 @@ extensions = [
     "dep:regex",
     "dep:uuid",
     "dep:rand",
-    "dep:chrono", "dep:chrono-tz", "dep:chrono-english", "dep:dateparser",
+    "dep:chrono", "dep:chrono-tz", "dep:interim", "dep:dateparser",
     "dep:strsim",
     "dep:rphonetic",
     "dep:geoutils", "dep:geohash",

--- a/crates/jpx-core/src/extensions/datetime.rs
+++ b/crates/jpx-core/src/extensions/datetime.rs
@@ -949,7 +949,7 @@ impl Function for ParseNaturalDateFn {
 
         let input = args[0].as_str().unwrap();
 
-        match chrono_english::parse_date_string(input, Utc::now(), chrono_english::Dialect::Us) {
+        match interim::parse_date_string(input, Utc::now(), interim::Dialect::Us) {
             Ok(dt) => {
                 let iso = dt.format("%Y-%m-%dT%H:%M:%SZ").to_string();
                 Ok(Value::String(iso))


### PR DESCRIPTION
## Summary

- Replace unmaintained `chrono-english` with `interim` in jpx-core (fixes RUSTSEC-2024-0395)
- `interim` is a maintained fork by conradludgate with the same API surface
- Uses the `chrono_0_4` feature flag for chrono `DateTime` trait impl

## Test plan

- [x] All workspace lib tests pass (268)
- [x] All integration tests pass (202)
- [x] All compliance tests pass (861)
- [x] Clippy clean