### PR TITLE
feat: add --raw-input / -R flag for non-JSON text processing

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -387,6 +387,16 @@ pub(crate) struct Args {
     )]
     pub(crate) slurp: bool,
 
+    /// Read input as raw text lines, not JSON
+    #[arg(
+        short = 'R',
+        long = "raw-input",
+        conflicts_with_all = ["stream", "null_input"],
+        help = "Read input as raw text lines, not JSON",
+        long_help = "Raw input mode - read each line as a JSON string rather than parsing as JSON.\nCombined with --slurp, reads the entire input as an array of strings.\nUseful for processing log files, CSV data, and other non-JSON text."
+    )]
+    pub(crate) raw_input: bool,
+
     /// Process input line by line
     #[arg(long, visible_alias = "each", conflicts_with_all = ["slurp", "null_input"],
           help = "Process input line by line (NDJSON)",

--- a/crates/jpx/src/input.rs
+++ b/crates/jpx/src/input.rs
@@ -134,11 +134,23 @@ pub(crate) fn read_input_as_value(args: &Args) -> Result<Value> {
         }
     };
 
-    if args.slurp {
+    if args.raw_input {
+        parse_raw_input(&input)
+    } else if args.slurp {
         parse_slurp(&input)
     } else {
         serde_json::from_str(&input).map_err(|e| json_parse_error(&input, e))
     }
+}
+
+/// Parse raw text input into an array of strings (one per line).
+/// Used for `-R -s` (raw-input + slurp) mode.
+fn parse_raw_input(input: &str) -> Result<Value> {
+    let lines: Vec<Value> = input
+        .lines()
+        .map(|line| Value::String(line.to_string()))
+        .collect();
+    Ok(Value::Array(lines))
 }
 
 /// Parse multiple JSON values from input into an array

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -188,8 +188,8 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Handle --stream: process input line by line (NDJSON/JSON Lines)
-    if args.stream {
+    // Handle --stream or --raw-input (without slurp): process line by line
+    if args.stream || (args.raw_input && !args.slurp) {
         return streaming::run_streaming(&expressions, &args, &runtime);
     }
 

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -39,17 +39,21 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
         let trimmed = line.trim();
         line_count += 1;
 
-        if trimmed.is_empty() {
+        if trimmed.is_empty() && !args.raw_input {
             continue;
         }
 
-        let data: Value = match serde_json::from_str(trimmed) {
-            Ok(d) => d,
-            Err(e) => {
-                if !quiet {
-                    eprintln!("jpx: Failed to parse JSON: {}", e);
+        let data: Value = if args.raw_input {
+            Value::String(trimmed.to_string())
+        } else {
+            match serde_json::from_str(trimmed) {
+                Ok(d) => d,
+                Err(e) => {
+                    if !quiet {
+                        eprintln!("jpx: Failed to parse JSON: {}", e);
+                    }
+                    continue;
                 }
-                continue;
             }
         };
 

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -218,6 +218,70 @@ mod input_modes {
     }
 }
 
+mod raw_input {
+    use super::*;
+
+    #[test]
+    fn raw_input_single_line() {
+        jpx()
+            .args(["-R", "@"])
+            .write_stdin("hello world\n")
+            .assert()
+            .success()
+            .stdout("\"hello world\"\n");
+    }
+
+    #[test]
+    fn raw_input_multiple_lines() {
+        jpx()
+            .args(["-R", "upper(@)"])
+            .write_stdin("hello\nworld\n")
+            .assert()
+            .success()
+            .stdout("\"HELLO\"\n\"WORLD\"\n");
+    }
+
+    #[test]
+    fn raw_input_slurp() {
+        jpx()
+            .args(["-Rs", "@", "--color", "never"])
+            .write_stdin("a\nb\nc\n")
+            .assert()
+            .success()
+            .stdout("[\n  \"a\",\n  \"b\",\n  \"c\"\n]\n");
+    }
+
+    #[test]
+    fn raw_input_slurp_length() {
+        jpx()
+            .args(["-Rs", "length(@)"])
+            .write_stdin("a\nb\nc\n")
+            .assert()
+            .success()
+            .stdout("3\n");
+    }
+
+    #[test]
+    fn raw_input_with_expression() {
+        jpx()
+            .args(["-R", "-c", "split(@, ' ')"])
+            .write_stdin("hello world\n")
+            .assert()
+            .success()
+            .stdout("[\"hello\",\"world\"]\n");
+    }
+
+    #[test]
+    fn raw_input_empty_lines() {
+        jpx()
+            .args(["-R", "@"])
+            .write_stdin("a\n\nb\n")
+            .assert()
+            .success()
+            .stdout("\"a\"\n\"\"\n\"b\"\n");
+    }
+}
+
 mod output_formats {
     use super::*;
 


### PR DESCRIPTION
## Summary

- Adds `--raw-input` / `-R` flag that reads each input line as a JSON string instead of parsing as JSON
- `-R` alone processes lines independently (via streaming path); `-Rs` collects all lines into an array of strings
- Empty lines are preserved as empty strings, matching jq behavior
- Conflicts with `--stream` and `--null-input`

Closes #145

## Test plan

- [x] 6 new integration tests in `cli_io.rs` covering single line, multiple lines, slurp, slurp+length, expression (split), and empty lines
- [x] All existing tests pass (47 cli_io, 30 cli_args, 15 cli_env_config, 202 integration)
- [ ] Manual smoke tests:
  - `echo 'hello world' | jpx -R '@'` -> `"hello world"`
  - `printf 'hello\nworld\n' | jpx -R 'upper(@)'` -> `"HELLO"` / `"WORLD"`
  - `printf 'a\nb\nc\n' | jpx -Rs 'length(@)'` -> `3`