### PR TITLE
feat: add --exit-status / -x flag for shell scripting

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -420,6 +420,15 @@ pub(crate) struct Args {
     )]
     pub(crate) output: Option<String>,
 
+    /// Set exit status based on result
+    #[arg(
+        short = 'x',
+        long = "exit-status",
+        help = "Exit with 1 if result is false or null",
+        long_help = "Exit status mode - set the process exit code based on the result value.\nExits with 0 if the result is truthy (non-null, non-false),\nexits with 1 if the result is false or null.\nUseful for shell scripting conditionals."
+    )]
+    pub(crate) exit_status: bool,
+
     /// Suppress errors and warnings
     #[arg(
         short = 'q',

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -22,13 +22,22 @@ use std::io::{self, Write};
 use std::time::Instant;
 
 fn main() {
-    if let Err(err) = run() {
-        eprintln!("jpx: {err:#}");
-        std::process::exit(1);
+    match run() {
+        Ok(code) => std::process::exit(code),
+        Err(err) => {
+            eprintln!("jpx: {err:#}");
+            std::process::exit(1);
+        }
     }
 }
 
-fn run() -> Result<()> {
+/// Check whether a JSON value is "truthy" for --exit-status purposes.
+/// null and false are falsy; everything else is truthy.
+fn is_truthy(value: &Value) -> bool {
+    !value.is_null() && value.as_bool() != Some(false)
+}
+
+fn run() -> Result<i32> {
     let mut args = Args::parse();
 
     // Load config and apply defaults (priority: config < env var < CLI flag)
@@ -41,7 +50,7 @@ fn run() -> Result<()> {
         let mut cmd = Args::command();
         let name = cmd.get_name().to_string();
         generate(shell, &mut cmd, name, &mut io::stdout());
-        return Ok(());
+        return Ok(0);
     }
 
     // Load engine config (jpx.toml discovery) and create runtime/registry
@@ -50,32 +59,33 @@ fn run() -> Result<()> {
 
     // Handle REPL mode
     if args.repl || args.demo.is_some() {
-        return repl::run(args.demo.as_deref(), runtime, registry);
+        repl::run(args.demo.as_deref(), runtime, registry)?;
+        return Ok(0);
     }
 
     if args.list_functions {
         discovery::print_functions(&registry);
-        return Ok(());
+        return Ok(0);
     }
 
     if let Some(category_name) = &args.list_category {
         discovery::print_category(&registry, category_name)?;
-        return Ok(());
+        return Ok(0);
     }
 
     if let Some(func_name) = &args.describe {
         discovery::describe_function(&registry, func_name)?;
-        return Ok(());
+        return Ok(0);
     }
 
     if let Some(query) = &args.search {
         discovery::search_functions(&registry, query);
-        return Ok(());
+        return Ok(0);
     }
 
     if let Some(func_name) = &args.similar {
         discovery::find_similar_functions(&registry, func_name)?;
-        return Ok(());
+        return Ok(0);
     }
 
     // Debug mode: show diagnostic information
@@ -85,45 +95,50 @@ fn run() -> Result<()> {
 
     // Handle --diff: generate JSON Patch from two files
     if let Some(files) = &args.diff {
-        return ops::diff_files(
+        ops::diff_files(
             &files[0],
             &files[1],
             args.compact,
             &args.color,
             args.sort_keys,
-        );
+        )?;
+        return Ok(0);
     }
 
     // Handle --patch: apply JSON Patch to document
     if let Some(patch_file) = &args.patch {
-        return ops::apply_patch(
+        ops::apply_patch(
             &args.file,
             patch_file,
             args.compact,
             &args.color,
             args.sort_keys,
-        );
+        )?;
+        return Ok(0);
     }
 
     // Handle --merge: apply JSON Merge Patch to document
     if let Some(merge_file) = &args.merge {
-        return ops::apply_merge(
+        ops::apply_merge(
             &args.file,
             merge_file,
             args.compact,
             &args.color,
             args.sort_keys,
-        );
+        )?;
+        return Ok(0);
     }
 
     // Handle --stats: show data statistics
     if args.stats {
-        return stats::show_stats(&args.file, &args.color);
+        stats::show_stats(&args.file, &args.color)?;
+        return Ok(0);
     }
 
     // Handle --paths: list all paths in JSON
     if args.paths {
-        return stats::show_paths(&args.file, &args.color, args.types, args.values);
+        stats::show_paths(&args.file, &args.color, args.types, args.values)?;
+        return Ok(0);
     }
 
     // Handle --list-queries: list available queries in a .jpx file
@@ -132,7 +147,8 @@ fn run() -> Result<()> {
             .query_file
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("--list-queries requires -Q/--query-file"))?;
-        return ops::list_queries(query_path, &args.color);
+        ops::list_queries(query_path, &args.color)?;
+        return Ok(0);
     }
 
     // Handle --check: validate queries without running
@@ -141,7 +157,8 @@ fn run() -> Result<()> {
             .query_file
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("--check requires -Q/--query-file"))?;
-        return ops::check_queries(query_path, &args.color, &runtime);
+        ops::check_queries(query_path, &args.color, &runtime)?;
+        return Ok(0);
     }
 
     // jq-style: if the last positional arg is an existing file and no -f was given, use it as input
@@ -185,12 +202,16 @@ fn run() -> Result<()> {
             explain::print_ast(&ast, 0);
             println!();
         }
-        return Ok(());
+        return Ok(0);
     }
 
     // Handle --stream or --raw-input (without slurp): process line by line
     if args.stream || (args.raw_input && !args.slurp) {
-        return streaming::run_streaming(&expressions, &args, &runtime);
+        let had_truthy = streaming::run_streaming(&expressions, &args, &runtime)?;
+        if args.exit_status && !had_truthy {
+            return Ok(1);
+        }
+        return Ok(0);
     }
 
     // Get input data
@@ -229,14 +250,15 @@ fn run() -> Result<()> {
 
     // Handle --bench: benchmark expression performance
     if let Some(iterations) = args.bench {
-        return bench::run_benchmark(
+        bench::run_benchmark(
             &runtime,
             &expressions,
             &data,
             iterations,
             args.warmup,
             &args.color,
-        );
+        )?;
+        return Ok(0);
     }
 
     // Compile and execute expression(s)
@@ -298,17 +320,24 @@ fn run() -> Result<()> {
         eprintln!();
     }
 
+    // Determine exit code for --exit-status before output
+    let exit_code = if args.exit_status && !is_truthy(&result) {
+        1
+    } else {
+        0
+    };
+
     // Output result
     if result.is_null() {
         // Don't print anything for null results (like jq)
-        return Ok(());
+        return Ok(exit_code);
     }
 
     #[allow(clippy::collapsible_if)]
     if args.raw {
         if let Some(s) = result.as_str() {
             println!("{}", s);
-            return Ok(());
+            return Ok(exit_code);
         }
     }
 
@@ -321,31 +350,35 @@ fn run() -> Result<()> {
 
     // Handle alternative output formats
     if args.yaml {
-        return output::output_as_yaml(&json_value, &args.output);
+        output::output_as_yaml(&json_value, &args.output)?;
+        return Ok(exit_code);
     }
     if args.toml_output {
-        return output::output_as_toml(&json_value, &args.output);
+        output::output_as_toml(&json_value, &args.output)?;
+        return Ok(exit_code);
     }
     if args.csv_output {
-        return output::output_as_csv(&json_value, &args.output);
+        output::output_as_csv(&json_value, &args.output)?;
+        return Ok(exit_code);
     }
     if args.tsv_output {
-        return output::output_as_tsv(&json_value, &args.output);
+        output::output_as_tsv(&json_value, &args.output)?;
+        return Ok(exit_code);
     }
     if args.lines_output {
-        return output::output_as_lines(&json_value, &args.output);
+        output::output_as_lines(&json_value, &args.output)?;
+        return Ok(exit_code);
     }
     #[cfg(feature = "parquet")]
     if args.parquet_output {
         let output_path = args.output.as_ref().expect("--parquet requires --output");
-        return jpx::parquet_support::write_json_to_parquet(
-            &json_value,
-            std::path::Path::new(output_path),
-        )
-        .context("Failed to write parquet file");
+        jpx::parquet_support::write_json_to_parquet(&json_value, std::path::Path::new(output_path))
+            .context("Failed to write parquet file")?;
+        return Ok(exit_code);
     }
     if args.table {
-        return output::output_as_table(&json_value, &args.output, &args.table_style, &args.color);
+        output::output_as_table(&json_value, &args.output, &args.table_style, &args.color)?;
+        return Ok(exit_code);
     }
 
     // When writing to file, don't colorize unless explicitly requested
@@ -391,7 +424,7 @@ fn run() -> Result<()> {
         println!("{}", output_str);
     }
 
-    Ok(())
+    Ok(exit_code)
 }
 
 fn print_debug_info(args: &Args, registry: &FunctionRegistry) {

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -5,8 +5,13 @@ use jpx_engine::Runtime;
 use serde_json::Value;
 use std::io::{self, BufRead, BufWriter, Write};
 
-/// Run streaming mode - process input line by line (NDJSON/JSON Lines)
-pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runtime) -> Result<()> {
+/// Run streaming mode - process input line by line (NDJSON/JSON Lines).
+/// Returns whether any truthy (non-null, non-false) result was produced.
+pub(crate) fn run_streaming(
+    expressions: &[String],
+    args: &Args,
+    runtime: &Runtime,
+) -> Result<bool> {
     // Set up input reader
     let input: Box<dyn BufRead> = match &args.file {
         Some(path) => {
@@ -33,6 +38,7 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
     let quiet = args.quiet;
     let raw = args.raw;
     let mut line_count = 0u64;
+    let mut had_truthy = false;
 
     for line in input.lines() {
         let line = line.context("Failed to read line")?;
@@ -76,6 +82,10 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
             result
         };
 
+        if !result.is_null() && result.as_bool() != Some(false) {
+            had_truthy = true;
+        }
+
         if result.is_null() {
             continue;
         }
@@ -101,5 +111,5 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
     }
 
     writer.flush()?;
-    Ok(())
+    Ok(had_truthy)
 }

--- a/crates/jpx/tests/cli_args.rs
+++ b/crates/jpx/tests/cli_args.rs
@@ -192,6 +192,82 @@ mod mode_flags {
                     .and(predicate::str::contains("Effective settings")),
             );
     }
+
+    #[test]
+    fn exit_status_truthy_exits_zero() {
+        jpx()
+            .args(["-x", "@"])
+            .write_stdin(r#"{"enabled":true}"#)
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn exit_status_false_exits_one() {
+        jpx()
+            .args(["-x", "enabled"])
+            .write_stdin(r#"{"enabled":false}"#)
+            .assert()
+            .failure()
+            .code(1);
+    }
+
+    #[test]
+    fn exit_status_null_exits_one() {
+        jpx()
+            .args(["-x", "missing"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .failure()
+            .code(1);
+    }
+
+    #[test]
+    fn exit_status_string_exits_zero() {
+        jpx()
+            .args(["-x", "name"])
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn exit_status_number_exits_zero() {
+        jpx()
+            .args(["-x", "count"])
+            .write_stdin(r#"{"count":0}"#)
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn exit_status_stream_truthy() {
+        jpx()
+            .args(["-x", "--stream", "a"])
+            .write_stdin("{\"a\":1}\n{\"a\":2}")
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn exit_status_stream_all_null() {
+        jpx()
+            .args(["-x", "--stream", "missing"])
+            .write_stdin("{\"a\":1}\n{\"a\":2}")
+            .assert()
+            .failure()
+            .code(1);
+    }
+
+    #[test]
+    fn without_exit_status_null_still_exits_zero() {
+        // Without -x, null results still exit 0
+        jpx()
+            .arg("missing")
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success();
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `--exit-status` / `-x` flag that sets the process exit code based on the result value
- Exit 0 if result is truthy (non-null, non-false), exit 1 if result is false or null
- Works in both batch and streaming modes (streaming exits 1 if no truthy results were produced)
- Uses `-x` since `-e` is taken by `--expression`

Closes #141

## Test plan

- [x] 8 new integration tests in `cli_args.rs` covering truthy, false, null, string, number, streaming truthy, streaming all-null, and without-flag baseline
- [x] All existing tests pass (38 cli_args, 41 cli_io, 15 cli_env_config, 202 integration)
- [ ] Manual smoke test: `if echo '{"ok":true}' | jpx -x 'ok' > /dev/null; then echo yes; fi`