### PR TITLE
feat: add --join-output / -j flag for newline-free output

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -297,6 +297,15 @@ pub(crate) struct Args {
     )]
     pub(crate) raw: bool,
 
+    /// Like --raw but without trailing newlines
+    #[arg(
+        short = 'j',
+        long = "join-output",
+        help = "Raw output without trailing newlines",
+        long_help = "Join output mode - like --raw but without a trailing newline after each output.\nUseful for building shell variables, URL-safe strings, or output for xargs -0."
+    )]
+    pub(crate) join_output: bool,
+
     /// Compact JSON output
     #[arg(
         short,

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -304,6 +304,16 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
+    // Join output mode: raw output without trailing newlines
+    if args.join_output {
+        if let Some(s) = result.as_str() {
+            print!("{}", s);
+        } else {
+            print!("{}", serde_json::to_string(&result)?);
+        }
+        return Ok(());
+    }
+
     #[allow(clippy::collapsible_if)]
     if args.raw {
         if let Some(s) = result.as_str() {

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -76,7 +76,7 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
             continue;
         }
 
-        let output = if raw {
+        let output = if args.join_output || raw {
             if let Some(s) = result.as_str() {
                 s.to_string()
             } else {
@@ -86,7 +86,11 @@ pub(crate) fn run_streaming(expressions: &[String], args: &Args, runtime: &Runti
             serde_json::to_string(&result)?
         };
 
-        writeln!(writer, "{}", output)?;
+        if args.join_output {
+            write!(writer, "{}", output)?;
+        } else {
+            writeln!(writer, "{}", output)?;
+        }
         if args.unbuffered {
             writer.flush()?;
         }

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -270,6 +270,36 @@ mod output_formats {
     }
 
     #[test]
+    fn join_output_no_newline() {
+        jpx()
+            .args(["-j", "name"])
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout("alice");
+    }
+
+    #[test]
+    fn join_output_non_string() {
+        jpx()
+            .args(["-j", "n"])
+            .write_stdin(r#"{"n":42}"#)
+            .assert()
+            .success()
+            .stdout("42");
+    }
+
+    #[test]
+    fn join_output_streaming() {
+        jpx()
+            .args(["-j", "--stream", "name"])
+            .write_stdin("{\"name\":\"a\"}\n{\"name\":\"b\"}")
+            .assert()
+            .success()
+            .stdout("ab");
+    }
+
+    #[test]
     fn yaml_output() {
         jpx()
             .arg("--yaml")


### PR DESCRIPTION
## Summary

- Adds `--join-output` / `-j` flag: like `--raw` but without trailing newlines
- String results are printed without quotes or newlines; non-strings are printed as compact JSON without newlines
- Works in both batch and streaming modes

Closes #144

## Test plan

- [x] 3 new integration tests: string output, non-string output, streaming concatenation
- [x] All existing tests pass (30 cli_args, 44 cli_io, 15 cli_env_config, 202 integration)
- [ ] Manual: `echo '{"name":"alice"}' | jpx -j 'name' | xxd` shows no trailing `0a`