### PR TITLE
fix: use exit_code in --join-output return path

### DIFF
--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -340,7 +340,7 @@ fn run() -> Result<i32> {
         } else {
             print!("{}", serde_json::to_string(&result)?);
         }
-        return Ok(());
+        return Ok(exit_code);
     }
 
     #[allow(clippy::collapsible_if)]


### PR DESCRIPTION
## Summary

- One-line fix: `return Ok(())` -> `return Ok(exit_code)` in the `--join-output` code path
- The `--join-output` merge (#167) introduced a `return Ok(())` but `run()` now returns `Result<i32>` after the `--exit-status` merge (#166)
- This broke CI on main with `--all-features` (the join-output path was only hit because it compiled without the parquet feature locally)

## Test plan

- [x] `cargo check --all-features --workspace` passes
- [x] `cargo clippy --all-features --workspace` passes
- [x] All tests pass (38 cli_args, 50 cli_io)