### PR TITLE
feat: add --indent N and --tab flags for indentation control

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -315,6 +315,25 @@ pub(crate) struct Args {
     )]
     pub(crate) compact: bool,
 
+    /// Number of spaces for indentation
+    #[arg(
+        long,
+        value_name = "N",
+        conflicts_with_all = ["compact", "tab"],
+        value_parser = clap::value_parser!(u8).range(0..=8),
+        help = "Set indentation to N spaces (0-8)",
+        long_help = "Set the number of spaces for indentation in pretty-printed output.\nValid range: 0-8. Default is 2 spaces. Use 0 for no indentation\n(but still with newlines, unlike --compact)."
+    )]
+    pub(crate) indent: Option<u8>,
+
+    /// Use tabs for indentation
+    #[arg(
+        long,
+        conflicts_with_all = ["compact", "indent"],
+        help = "Use tab characters for indentation"
+    )]
+    pub(crate) tab: bool,
+
     /// Sort object keys in output
     #[arg(
         short = 'S',

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -398,6 +398,15 @@ fn run() -> Result<i32> {
         ColorMode::Auto => args.output.is_none() && atty::is(atty::Stream::Stdout),
     };
 
+    // Determine indent string
+    let indent_str = if args.tab {
+        "\t".to_string()
+    } else if let Some(n) = args.indent {
+        " ".repeat(n as usize)
+    } else {
+        "  ".to_string() // default: 2 spaces
+    };
+
     let output_str = if should_colorize && !args.compact {
         // Colored pretty output with custom color scheme
         use colored_json::{ColoredFormatter, PrettyFormatter, Style, Styler};
@@ -412,7 +421,8 @@ fn run() -> Result<i32> {
             ..Default::default()
         };
 
-        let formatter = ColoredFormatter::with_styler(PrettyFormatter::new(), styler);
+        let pf = PrettyFormatter::with_indent(indent_str.as_bytes());
+        let formatter = ColoredFormatter::with_styler(pf, styler);
         let mut writer = Vec::new();
         let mut serializer = serde_json::Serializer::with_formatter(&mut writer, formatter);
         use serde::Serialize;
@@ -421,7 +431,12 @@ fn run() -> Result<i32> {
     } else if args.compact {
         serde_json::to_string(&json_value)?
     } else {
-        serde_json::to_string_pretty(&json_value)?
+        let mut writer = Vec::new();
+        let formatter = serde_json::ser::PrettyFormatter::with_indent(indent_str.as_bytes());
+        let mut serializer = serde_json::Serializer::with_formatter(&mut writer, formatter);
+        use serde::Serialize;
+        json_value.serialize(&mut serializer)?;
+        String::from_utf8(writer)?
     };
 
     // Write output to file or stdout

--- a/crates/jpx/tests/cli_io.rs
+++ b/crates/jpx/tests/cli_io.rs
@@ -298,6 +298,36 @@ mod output_formats {
     }
 
     #[test]
+    fn indent_four_spaces() {
+        jpx()
+            .args(["--indent", "4", "--color", "never", "@"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("{\n    \"a\": 1\n}\n");
+    }
+
+    #[test]
+    fn indent_zero_still_has_newlines() {
+        jpx()
+            .args(["--indent", "0", "--color", "never", "@"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("{\n\"a\": 1\n}\n");
+    }
+
+    #[test]
+    fn tab_indent() {
+        jpx()
+            .args(["--tab", "--color", "never", "@"])
+            .write_stdin(r#"{"a":1}"#)
+            .assert()
+            .success()
+            .stdout("{\n\t\"a\": 1\n}\n");
+    }
+
+    #[test]
     fn compact_json() {
         jpx()
             .arg("-c")


### PR DESCRIPTION
## Summary

- `--indent N` sets indentation to N spaces (0-8, default 2)
- `--tab` uses tab characters for indentation
- Both conflict with `--compact`; `--indent` and `--tab` conflict with each other
- Works with both plain and colored output

Closes #143

## Test plan

- [x] 3 new tests: 4-space indent, zero indent (newlines but no indentation), tab indent
- [x] All existing tests pass (53 cli_io, 38 cli_args)
- [ ] Manual: `echo '{"a":1}' | jpx --indent 4 '@'` and `echo '{"a":1}' | jpx --tab '@'`