### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arrow",
  "dirs",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.2.1" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.3.4" }
+jpx-core = { path = "crates/jpx-core", version = "0.2.2" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.3.5" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.1...jpx-core-v0.2.2) - 2026-03-16
+
+### Added
+
+- unify group_by, index_by, partition_by to accept exprefs ([#175](https://github.com/joshrotenberg/jpx/pull/175))
+
 ## [0.2.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.0...jpx-core-v0.2.1) - 2026-02-28
 
 ### Fixed

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.4...jpx-engine-v0.3.5) - 2026-03-16
+
+### Other
+
+- updated the following local packages: jpx-core
+
 ## [0.3.4](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.3...jpx-engine-v0.3.4) - 2026-02-28
 
 ### Other

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.3...jpx-mcp-v0.4.4) - 2026-03-16
+
+### Added
+
+- upgrade tower-mcp to 0.8 and add title field to all MCP tools ([#173](https://github.com/joshrotenberg/jpx/pull/173))
+
 ## [0.4.2](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.1...jpx-mcp-v0.4.2) - 2026-02-11
 
 ### Other

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.3...jpx-v0.4.4) - 2026-03-16
+
+### Added
+
+- support CSV/TSV output in streaming mode ([#176](https://github.com/joshrotenberg/jpx/pull/176))
+
 ## [0.4.3](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.2...jpx-v0.4.3) - 2026-02-28
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `jpx`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `jpx-mcp`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `jpx-engine`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.1...jpx-core-v0.2.2) - 2026-03-16

### Added

- unify group_by, index_by, partition_by to accept exprefs ([#175](https://github.com/joshrotenberg/jpx/pull/175))
</blockquote>

## `jpx`

<blockquote>

## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.3...jpx-v0.4.4) - 2026-03-16

### Added

- support CSV/TSV output in streaming mode ([#176](https://github.com/joshrotenberg/jpx/pull/176))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.3...jpx-mcp-v0.4.4) - 2026-03-16

### Added

- upgrade tower-mcp to 0.8 and add title field to all MCP tools ([#173](https://github.com/joshrotenberg/jpx/pull/173))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.3.5](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.4...jpx-engine-v0.3.5) - 2026-03-16

### Other

- updated the following local packages: jpx-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).