### PR TITLE
feat: add Agent Skills directory for AI agent integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 Instructions for AI coding agents working on the jpx project.
 
+## Agent Skills
+
+This project includes [Agent Skills](https://agentskills.io/) in the `skills/` directory for in-depth guidance on specific topics:
+
+| Skill | When to use |
+|-------|-------------|
+| [`jmespath-query`](skills/jmespath-query/SKILL.md) | Writing JMESPath expressions (syntax, patterns, built-in functions) |
+| [`jpx-functions`](skills/jpx-functions/SKILL.md) | Using the 400+ extension functions (signatures, categories, examples) |
+| [`jpx-cli`](skills/jpx-cli/SKILL.md) | Using the jpx CLI (output formats, streaming, pipelines, REPL) |
+| [`jpx-mcp`](skills/jpx-mcp/SKILL.md) | Using the jpx MCP server (32 tools, discovery, query store) |
+
+Each skill has a SKILL.md overview and a `references/` directory with detailed docs loaded on demand.
+
 ## Project overview
 
 jpx is a JMESPath CLI and toolchain with 400+ extension functions — a `jq` alternative.
@@ -14,7 +27,7 @@ Written in Rust (edition 2024, rust-version 1.90), dual-licensed MIT/Apache-2.0.
 | `jpx` | `crates/jpx/` | CLI with REPL, streaming, multiple output formats (JSON, YAML, CSV, TSV, table) |
 | `jpx-core` | `crates/jpx-core/` | From-scratch JMESPath parser and interpreter, 425 functions across 32 categories |
 | `jpx-engine` | `crates/jpx-engine/` | Query engine, introspection, BM25 discovery index, config |
-| `jpx-mcp` | `crates/jpx-mcp/` | MCP server (29 tools) built on `tower-mcp` |
+| `jpx-mcp` | `crates/jpx-mcp/` | MCP server (32 tools) built on `tower-mcp` |
 | `python` | `python/` | Python bindings via PyO3 (`jmespath-extensions` on PyPI) |
 
 ## Build and test
@@ -84,13 +97,14 @@ items[?status == `"active"`]       — string comparison (backtick + JSON string
 items[?enabled == `true`]          — boolean comparison
 ```
 
-### Expref (&) vs string key
+### Expref (&) arguments
 
-Some functions take an expref (`&field`), others take a string key (`'field'`):
+Functions that key on a field use expression references, matching the JMESPath spec:
 
 ```
 sort_by(arr, &name)       — expref (standard JMESPath)
-group_by(arr, 'name')     — string key (jpx extension)
+group_by(arr, &name)      — expref (preferred)
+group_by(arr, 'name')     — string key (legacy, still works)
 ```
 
 Check function signatures with `jpx --describe <function>` or the MCP `describe` tool.
@@ -161,7 +175,7 @@ Always use `describe` to check a function's exact signature before using it.
 
 ## MCP server tools
 
-The MCP server exposes 29 tools. Key patterns:
+The MCP server exposes 32 tools. Key patterns:
 
 - **`evaluate`** / **`evaluate_file`** — run a JMESPath expression against JSON input or a file
 - **`batch_evaluate`** — run multiple expressions against the same input

--- a/skills/jmespath-query/SKILL.md
+++ b/skills/jmespath-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jmespath-query
-description: "Write JMESPath expressions to query and transform JSON data. Use when the user needs to extract, filter, project, or reshape JSON -- or when JMESPath is mentioned. Covers the full JMESPath specification including identifiers, projections, filters, multi-select, pipes, functions, and let expressions. Applicable to any JMESPath implementation (AWS CLI, Azure CLI, Boto3, jpx, etc.)."
+description: "Write JMESPath expressions to query and transform JSON. Use when extracting, filtering, projecting, or reshaping JSON data. Covers identifiers, projections, filters, multi-select, pipes, functions, and let expressions. Works with any JMESPath implementation."
 license: MIT OR Apache-2.0
 metadata:
   author: joshrotenberg

--- a/skills/jmespath-query/SKILL.md
+++ b/skills/jmespath-query/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: jmespath-query
+description: "Write JMESPath expressions to query and transform JSON data. Use when the user needs to extract, filter, project, or reshape JSON -- or when JMESPath is mentioned. Covers the full JMESPath specification including identifiers, projections, filters, multi-select, pipes, functions, and let expressions. Applicable to any JMESPath implementation (AWS CLI, Azure CLI, Boto3, jpx, etc.)."
+license: MIT OR Apache-2.0
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+---
+
+# Writing JMESPath Expressions
+
+JMESPath is a query language for JSON. Given a JSON document and an expression, it produces a new JSON value. This skill covers the full specification.
+
+## Quick Reference
+
+| Syntax | What it does | Example |
+|--------|-------------|---------|
+| `name` | Access field | `{"name":"jo"}` -> `"jo"` |
+| `a.b.c` | Nested access | `{"a":{"b":{"c":1}}}` -> `1` |
+| `[0]` | Array index | `[10,20,30]` -> `10` |
+| `[-1]` | Last element | `[10,20,30]` -> `30` |
+| `[0:3]` | Slice | `[0,1,2,3,4]` -> `[0,1,2]` |
+| `[*].name` | List projection | `[{"name":"a"},{"name":"b"}]` -> `["a","b"]` |
+| `*.size` | Object projection | `{"a":{"size":1},"b":{"size":2}}` -> `[1,2]` |
+| `[]` | Flatten | `[[1,2],[3,4]]` -> `[1,2,3,4]` |
+| `[?age > \`30\`]` | Filter | Keep elements matching condition |
+| `{a: x, b: y}` | Multi-select hash | Build new object |
+| `[x, y]` | Multi-select list | Build new array |
+| `expr \| func(@)` | Pipe | Chain expressions |
+| `length(@)` | Function call | Built-in functions |
+
+## Identifiers and Sub-expressions
+
+Access object fields by name. Chain with `.` for nested access.
+
+```
+Input:  {"user": {"name": "alice", "age": 30}}
+
+user          -> {"name": "alice", "age": 30}
+user.name     -> "alice"
+user.age      -> 30
+missing       -> null
+user.missing  -> null
+```
+
+Quoted identifiers handle special characters: `"my-field"`, `"with spaces"`, `"123starts-with-number"`.
+
+## Index and Slice Expressions
+
+```
+Input:  [0, 1, 2, 3, 4, 5]
+
+[0]      -> 0
+[2]      -> 2
+[-1]     -> 5        (last element)
+[-2]     -> 4        (second to last)
+[1:4]    -> [1,2,3]  (start:stop, exclusive end)
+[:3]     -> [0,1,2]  (first 3)
+[-2:]    -> [4,5]    (last 2)
+[::2]    -> [0,2,4]  (every other)
+[::-1]   -> [5,4,3,2,1,0]  (reverse)
+```
+
+## Projections
+
+Projections apply an expression to each element, collecting results. Null results are omitted.
+
+### List projections (`[*]`)
+
+```
+Input:  [{"name": "alice", "age": 30}, {"name": "bob", "age": 25}]
+
+[*].name       -> ["alice", "bob"]
+[*].age        -> [30, 25]
+[*].missing    -> []            (nulls are omitted)
+```
+
+### Object projections (`*`)
+
+```
+Input:  {"web": {"port": 80}, "db": {"port": 5432}}
+
+*.port         -> [80, 5432]
+```
+
+### Flatten projections (`[]`)
+
+```
+Input:  [[1, 2], [3, 4], [5]]
+
+[]             -> [1, 2, 3, 4, 5]
+
+Input:  [{"tags": ["a","b"]}, {"tags": ["c"]}]
+
+[*].tags[]     -> ["a", "b", "c"]    (project then flatten)
+```
+
+## Filter Expressions
+
+Filter arrays with `[?condition]`. The current element is `@`.
+
+```
+Input:  [{"name": "alice", "age": 30}, {"name": "bob", "age": 25}, {"name": "carol", "age": 35}]
+
+[?age > `30`]                -> [{"name": "carol", "age": 35}]
+[?age >= `30`]               -> [alice, carol objects]
+[?name == 'alice']           -> [{"name": "alice", "age": 30}]
+[?name != 'bob']             -> [alice, carol objects]
+[?age > `25` && age < `35`]  -> [{"name": "alice", "age": 30}]
+[?age < `26` || age > `34`]  -> [bob, carol objects]
+[?!active]                   -> elements where active is falsy
+[?contains(name, 'a')]       -> elements where name contains "a"
+```
+
+**Important:** Literal numbers use backticks: `` `30` ``, not `30`. Strings use single quotes: `'alice'`. This is the most common mistake.
+
+## Multi-Select
+
+### Multi-select hash (build objects)
+
+```
+Input:  {"first": "alice", "last": "smith", "age": 30}
+
+{name: first, surname: last}  -> {"name": "alice", "surname": "smith"}
+{full: join(' ', [first, last]), age: age}  -> {"full": "alice smith", "age": 30}
+```
+
+### Multi-select list (build arrays)
+
+```
+Input:  {"a": 1, "b": 2, "c": 3}
+
+[a, b]        -> [1, 2]
+[a, b, c]     -> [1, 2, 3]
+```
+
+### Combined with projections
+
+```
+Input:  [{"name": "alice", "score": 95}, {"name": "bob", "score": 80}]
+
+[*].{student: name, grade: score}  -> [{"student":"alice","grade":95}, {"student":"bob","grade":80}]
+```
+
+## Pipe Expressions
+
+Use `|` to chain expressions. The right side receives the output of the left side. Pipes stop projections -- the right side gets the full result, not each element.
+
+```
+Input:  [{"name": "alice"}, {"name": "bob"}, {"name": "carol"}]
+
+[*].name                  -> ["alice", "bob", "carol"]
+[*].name | sort(@)        -> ["alice", "bob", "carol"]
+[*].name | sort(@) | [0]  -> "alice"
+[*].name | length(@)      -> 3
+[?score > `80`] | [0]     -> first element matching filter
+```
+
+**Key insight:** Without the pipe, `[*].name | [0]` takes the first of the projected names. With the pipe, `[0]` operates on the collected array, not on each element.
+
+## Literal Values
+
+Backtick-quoted values are JSON literals within expressions:
+
+```
+`42`           -> number 42
+`"hello"`      -> string "hello"
+`true`         -> boolean true
+`null`         -> null
+`[1, 2, 3]`   -> array [1, 2, 3]
+`{"a": 1}`    -> object {"a": 1}
+```
+
+Strings can also use single quotes (simpler for shell usage): `'hello'` is equivalent to `` `"hello"` ``.
+
+## Built-in Functions
+
+JMESPath spec defines 26 functions. The most commonly used:
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `length(x)` | Array/string/object size | `length([1,2,3])` -> `3` |
+| `sort(arr)` | Sort array | `sort([3,1,2])` -> `[1,2,3]` |
+| `sort_by(arr, &key)` | Sort by expression | `sort_by(users, &age)` |
+| `reverse(x)` | Reverse array/string | `reverse([1,2,3])` -> `[3,2,1]` |
+| `contains(subject, search)` | Check membership | `contains([1,2], `1`)` -> `true` |
+| `keys(obj)` | Object keys | `keys({"a":1})` -> `["a"]` |
+| `values(obj)` | Object values | `values({"a":1})` -> `[1]` |
+| `join(sep, arr)` | Join strings | `join(', ', ["a","b"])` -> `"a, b"` |
+| `to_string(x)` | Convert to string | `to_string(`42`)` -> `"42"` |
+| `to_number(x)` | Convert to number | `to_number('42')` -> `42` |
+| `type(x)` | Type name | `type([])` -> `"array"` |
+| `not_null(a, b, ...)` | First non-null | `not_null(null, 'ok')` -> `"ok"` |
+| `max(arr)` / `min(arr)` | Max/min value | `max([1,3,2])` -> `3` |
+| `max_by(arr, &key)` | Max by expression | `max_by(users, &score)` |
+| `min_by(arr, &key)` | Min by expression | `min_by(users, &age)` |
+| `starts_with(s, prefix)` | String prefix check | `starts_with('hello', 'he')` -> `true` |
+| `ends_with(s, suffix)` | String suffix check | `ends_with('hello', 'lo')` -> `true` |
+| `map(&expr, arr)` | Transform each element | `map(&age, users)` |
+| `merge(obj1, obj2)` | Merge objects | `merge({"a":1}, {"b":2})` |
+| `sum(arr)` | Sum of numbers | `sum([1,2,3])` -> `6` |
+| `avg(arr)` | Average of numbers | `avg([1,2,3])` -> `2.0` |
+| `floor(n)` / `ceil(n)` | Round down/up | `floor(`3.7`)` -> `3` |
+| `abs(n)` | Absolute value | `abs(`-5`)` -> `5` |
+
+### Expression references (exprefs)
+
+Functions like `sort_by`, `max_by`, `min_by`, and `map` take an **expression reference** using `&`:
+
+```
+sort_by(users, &age)         -- sort by the "age" field
+sort_by(users, &to_number(id))  -- sort by numeric id
+max_by(items, &price)        -- item with highest price
+map(&name, users)            -- extract all names
+```
+
+The `&` prefix creates a reference to the expression that the function evaluates against each element.
+
+## Let Expressions (JEP-18)
+
+Let expressions bind intermediate results to variables. Supported by jpx and some other implementations.
+
+```
+let $names = [*].name in sort($names) | [0]
+
+let $adults = [?age >= `18`],
+    $count = length($adults)
+in {adults: $adults, count: $count}
+```
+
+Variables are scoped to the `in` body. Use let expressions to name intermediate results and avoid repeating sub-expressions.
+
+See [references/let-expressions.md](references/let-expressions.md) for advanced patterns.
+
+## Common Patterns
+
+### Extract and reshape
+```
+[*].{id: id, full_name: join(' ', [first, last])}
+```
+
+### Filter, sort, take top N
+```
+[?status == 'active'] | sort_by(@, &score) | reverse(@) | [:5]
+```
+
+### Nested array flattening
+```
+departments[*].employees[] | [?role == 'engineer']
+```
+
+### Conditional value
+```
+not_null(preferred_name, display_name, email)
+```
+
+### Count by filtering
+```
+length([?type == 'error'])
+```
+
+### Check if any/all match
+```
+length([?status == 'failed']) > `0`     -- any failed?
+length([?status != 'ok']) == `0`        -- all ok?
+```
+
+## Common Mistakes
+
+1. **Forgetting backticks for numbers:** `[?age > 30]` is wrong -- use `[?age > `30`]`
+2. **Using double quotes for strings in expressions:** `[?name == "alice"]` is wrong -- use single quotes `[?name == 'alice']`
+3. **Expecting nulls in projections:** `[*].missing` returns `[]`, not `[null, null]` -- projections skip nulls
+4. **Pipe vs no pipe:** `[*].name[0]` gets first char of each name; `[*].name | [0]` gets first name
+5. **Filter on nested field:** `[?address.city == 'NYC']` works -- you can use sub-expressions in filters
+
+## Extended Functions
+
+jpx extends JMESPath with 400+ additional functions for strings, math, dates, hashing, encoding, regex, and more. See the [jpx-functions skill](../jpx-functions/SKILL.md) for details.

--- a/skills/jmespath-query/references/filter-patterns.md
+++ b/skills/jmespath-query/references/filter-patterns.md
@@ -1,0 +1,145 @@
+# JMESPath Filter Patterns
+
+Cookbook of common filter and projection patterns.
+
+## Basic Filtering
+
+### Filter by field value
+```
+[?status == 'active']
+[?type != 'draft']
+[?priority == `1`]
+```
+
+### Filter by numeric range
+```
+[?age >= `18` && age <= `65`]
+[?price < `100`]
+[?score > `90`]
+```
+
+### Filter by string content
+```
+[?contains(name, 'admin')]
+[?starts_with(email, 'test')]
+[?ends_with(filename, '.json')]
+```
+
+### Filter by null/non-null
+```
+[?email != null]           -- has email
+[?deleted_at == null]      -- not deleted
+```
+
+### Filter by boolean
+```
+[?active]                  -- active is truthy
+[?!archived]               -- archived is falsy
+```
+
+## Combining Conditions
+
+### AND
+```
+[?status == 'active' && role == 'admin']
+[?age >= `18` && country == 'US']
+```
+
+### OR
+```
+[?status == 'error' || status == 'warning']
+[?role == 'admin' || role == 'superadmin']
+```
+
+### Nested conditions
+```
+[?(status == 'active' && role == 'admin') || priority == `1`]
+```
+
+## Filter + Transform Patterns
+
+### Filter then extract fields
+```
+[?active].name                                    -- names of active items
+[?score > `90`].{student: name, grade: score}     -- reshape high scorers
+```
+
+### Filter, sort, take top N
+```
+[?status == 'published'] | sort_by(@, &date) | reverse(@) | [:10]
+```
+
+### Count matches
+```
+length([?type == 'error'])
+```
+
+### Check existence
+```
+length([?status == 'failed']) > `0`     -- any failures?
+length([?status != 'ok']) == `0`        -- all OK?
+```
+
+## Nested Data Patterns
+
+### Filter on nested field
+```
+[?address.country == 'US']
+[?config.enabled]
+[?metadata.tags[0] == 'important']
+```
+
+### Filter nested arrays
+```
+departments[*].employees[?role == 'engineer']     -- engineers per dept (nested arrays)
+departments[*].employees[?role == 'engineer'][]   -- all engineers (flattened)
+```
+
+### Filter then navigate deeper
+```
+[?type == 'order'].items[*].product_id            -- nested arrays per filtered item
+[?type == 'order'].items[].product_id             -- flattened product IDs
+```
+
+## Projection Patterns
+
+### Extract specific fields from array of objects
+```
+[*].{id: id, name: name}
+```
+
+### Compute derived values
+```
+[*].{name: name, full: join(' ', [first, last]), age_group: type(age)}
+```
+
+### Flatten nested arrays
+```
+[*].tags[]                 -- all tags from all items
+[*].orders[*].items[]      -- all items from all orders
+```
+
+### Object to array of entries
+```
+keys(@)                    -- just keys
+values(@)                  -- just values
+```
+
+## Aggregation Patterns
+
+### Sum/avg/min/max of projected values
+```
+[*].price | sum(@)
+[*].score | avg(@)
+[*].age | max(@)
+```
+
+### Group then aggregate (with jpx extensions)
+```
+group_by(@, &category)     -- group into object by category
+```
+
+### Distinct values
+```
+[*].status | sort(@)       -- sorted (spec only, no unique)
+```

--- a/skills/jmespath-query/references/let-expressions.md
+++ b/skills/jmespath-query/references/let-expressions.md
@@ -1,0 +1,93 @@
+# JMESPath Let Expressions (JEP-18)
+
+Let expressions allow binding intermediate results to named variables.
+
+**Support:** jpx, jpx-core. Not all JMESPath implementations support let expressions.
+
+## Basic Syntax
+
+```
+let $variable = expression in body
+```
+
+The `$variable` is available within `body`. Variable names are prefixed with `$`.
+
+## Examples
+
+### Name an intermediate result
+```
+Input:  [{"name": "alice", "score": 95}, {"name": "bob", "score": 80}]
+
+let $top = sort_by(@, &score) | reverse(@) | [0]
+in $top.name
+
+-> "alice"
+```
+
+### Multiple bindings
+```
+let $active = [?status == 'active'],
+    $count = length($active)
+in {items: $active, total: $count}
+```
+
+### Avoid repeating sub-expressions
+Without let (repeated work):
+```
+{
+  high: length([?score > `90`]),
+  low: length([?score <= `90`]),
+  total: length(@)
+}
+```
+
+With let (cleaner):
+```
+let $high = [?score > `90`],
+    $low = [?score <= `90`]
+in {
+  high: length($high),
+  low: length($low),
+  total: length(@)
+}
+```
+
+### Nested let expressions
+```
+let $users = [?type == 'user']
+in let $admins = $users[?role == 'admin']
+   in {all_users: length($users), admins: length($admins)}
+```
+
+## Variable Scoping
+
+- Variables are scoped to the `in` body
+- Inner let expressions can shadow outer variables
+- Variables cannot be referenced before they are defined
+- The current node `@` still refers to the original input within the body
+
+## When to Use Let vs Pipe
+
+**Use pipe** for simple linear chains:
+```
+[*].name | sort(@) | [0]
+```
+
+**Use let** when you need the same intermediate result more than once:
+```
+let $names = [*].name | sort(@)
+in {first: $names[0], last: $names[-1], count: length($names)}
+```
+
+**Use let** when building complex results from multiple derived values:
+```
+let $errors = [?level == 'error'],
+    $warnings = [?level == 'warn'],
+    $total = length(@)
+in {
+  error_count: length($errors),
+  warning_count: length($warnings),
+  error_rate: length($errors) / $total,
+  latest_error: $errors | sort_by(@, &timestamp) | [-1]
+}
+```

--- a/skills/jmespath-query/references/syntax-reference.md
+++ b/skills/jmespath-query/references/syntax-reference.md
@@ -1,0 +1,151 @@
+# JMESPath Syntax Reference
+
+Complete reference for every JMESPath node type.
+
+## Expression Types
+
+### Identifier
+```
+field_name
+```
+Accesses a field on the current object. Returns `null` if missing.
+
+### Sub-expression
+```
+a.b.c
+```
+Chained field access. Equivalent to evaluating `b.c` against the result of `a`.
+
+### Quoted Identifier
+```
+"field-with-dashes"
+"123numeric"
+"has spaces"
+```
+Access fields with names that aren't valid unquoted identifiers.
+
+### Index Expression
+```
+[N]      -- Nth element (0-based)
+[-N]     -- Nth from end
+```
+Negative indices count from the end: `[-1]` is last, `[-2]` is second-to-last.
+
+### Slice Expression
+```
+[start:stop]       -- elements from start to stop-1
+[start:stop:step]  -- with step
+[:stop]            -- from beginning
+[start:]           -- to end
+[::step]           -- every Nth element
+[::-1]             -- reverse
+```
+All parameters are optional. Default start=0, stop=end, step=1.
+
+### List Projection
+```
+[*].expr
+```
+Evaluate `expr` against each element of an array. Null results are omitted.
+
+### Object Projection
+```
+*.expr
+```
+Evaluate `expr` against each value of an object. Null results are omitted.
+
+### Flatten Projection
+```
+[].expr
+```
+Flatten one level of nesting, then project. `[[1],[2,3]]` -> `[1,2,3]`.
+
+### Filter Expression
+```
+[?condition]
+```
+Keep array elements where `condition` is truthy. Inside the filter, `@` refers to each element.
+
+#### Comparators
+```
+==    equal
+!=    not equal
+<     less than
+<=    less than or equal
+>     greater than
+>=    greater than or equal
+```
+
+#### Logical Operators
+```
+&&    and
+||    or
+!     not (prefix)
+```
+
+### Multi-Select Hash
+```
+{key1: expr1, key2: expr2}
+```
+Evaluate each expression and build a new object with the given keys.
+
+### Multi-Select List
+```
+[expr1, expr2, expr3]
+```
+Evaluate each expression and build a new array.
+
+### Pipe Expression
+```
+left | right
+```
+Evaluate `left`, then evaluate `right` against its result. Stops projections.
+
+### Literal
+```
+`42`           number
+`"string"`     string
+`true`         boolean
+`false`        boolean
+`null`         null
+`[1, 2]`      array
+`{"a": 1}`    object
+'string'       shorthand for `"string"`
+```
+
+### Current Node
+```
+@
+```
+Refers to the current value being evaluated. Useful in filters and function arguments.
+
+### Function Call
+```
+function_name(arg1, arg2, ...)
+```
+Call a built-in function. Arguments are expressions evaluated against the current node.
+
+### Expression Reference
+```
+&expression
+```
+Creates a reference to an expression (not evaluated immediately). Used by functions like `sort_by`, `max_by`, `map`.
+
+### Let Expression (JEP-18)
+```
+let $var = expr in body
+let $a = expr1, $b = expr2 in body
+```
+Bind variables for use in the body expression. Variables are prefixed with `$`.
+
+## Operator Precedence (highest to lowest)
+
+1. `.` (sub-expression)
+2. `[]` (index/slice/filter/flatten)
+3. `*` (object projection)
+4. Function calls
+5. `|` (pipe)
+6. Comparisons (`==`, `!=`, `<`, `>`, `<=`, `>=`)
+7. `&&` (and)
+8. `||` (or)
+9. `!` (not)

--- a/skills/jpx-cli/SKILL.md
+++ b/skills/jpx-cli/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: jpx-cli
+description: "Use the jpx command-line tool to query and transform JSON data. Covers output formats (CSV, TSV, table, YAML, TOML), streaming NDJSON processing, input modes (slurp, raw-input, null-input), query files, variable binding, shell pipelines, and the interactive REPL. Use when the user needs to process JSON from the command line or in shell scripts."
+license: MIT OR Apache-2.0
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+allowed-tools: Bash(jpx:*)
+---
+
+# jpx CLI Usage Guide
+
+jpx is a JMESPath CLI with 400+ extended functions. It reads JSON, applies expressions, and outputs results in multiple formats.
+
+## Basic Usage
+
+```bash
+# Expression as positional argument
+echo '{"name":"alice"}' | jpx 'name'
+# -> "alice"
+
+# File input
+jpx 'users[*].name' data.json
+
+# Explicit file flag
+jpx -f data.json 'users[*].name'
+
+# Null input (no stdin needed)
+jpx -n 'now()'
+
+# Multiple expressions (chained pipeline)
+jpx '[*].name' 'sort(@)' '[0]' data.json
+
+# Same with -e flags
+jpx -e '[*].name' -e 'sort(@)' -e '[0]' -f data.json
+```
+
+## Output Formats
+
+### JSON (default)
+```bash
+jpx 'expression' data.json              # pretty-printed, colored
+jpx -c 'expression' data.json           # compact (one line)
+jpx --indent 4 'expression' data.json   # 4-space indent
+jpx --tab 'expression' data.json        # tab indent
+jpx -S 'expression' data.json           # sort object keys
+jpx --color never 'expression' data.json  # no color
+```
+
+### Raw strings
+```bash
+jpx -r 'name' data.json                 # "alice" -> alice (no quotes)
+jpx -j 'name' data.json                 # raw, no trailing newline
+```
+
+### CSV / TSV
+```bash
+jpx --csv 'users[*]' data.json          # CSV with headers from object keys
+jpx --tsv 'users[*]' data.json          # tab-separated
+# Nested objects are flattened: {"addr":{"city":"NYC"}} -> addr.city column
+```
+
+### Table
+```bash
+jpx -t 'users[*]' data.json             # formatted table
+jpx -t --table-style ascii 'users[*]' data.json
+# Styles: unicode (default), ascii, markdown, plain, rounded, sharp, modern
+```
+
+### YAML / TOML
+```bash
+jpx -y 'config' data.json               # YAML output
+jpx --toml 'config' data.json           # TOML output
+```
+
+### Lines (NDJSON)
+```bash
+jpx -l 'users[*]' data.json             # one JSON value per line
+```
+
+### Output to file
+```bash
+jpx -o result.json 'expression' data.json
+jpx --csv -o data.csv 'users[*]' data.json
+```
+
+## Input Modes
+
+### Slurp (`-s`)
+Combine multiple JSON values from stdin into a single array:
+```bash
+echo -e '{"id":1}\n{"id":2}\n{"id":3}' | jpx -s 'length(@)'
+# -> 3
+```
+
+### Raw input (`-R`)
+Read each line as a JSON string (not parsed as JSON):
+```bash
+echo -e "hello\nworld" | jpx -R -s '[*] | sort(@)'
+# -> ["hello", "world"]
+```
+
+### Null input (`-n`)
+Use `null` as input, don't read stdin:
+```bash
+jpx -n 'now()'                    # current timestamp
+jpx -n 'range(`1`, `11`)'         # [1,2,...,10]
+jpx -n 'uuid()'                   # random UUID
+```
+
+## Streaming Mode
+
+Process NDJSON line by line with constant memory:
+```bash
+# Each line processed independently
+cat events.ndjson | jpx --stream 'user.name'
+
+# Null results are automatically skipped
+cat events.ndjson | jpx --stream '[?level == `error`] | [0]'
+
+# Streaming with CSV output (headers from first record)
+cat events.ndjson | jpx --stream --csv '{user: user.name, action: event}'
+
+# Streaming with TSV
+cat events.ndjson | jpx --stream --tsv '@'
+
+# Unbuffered output (flush after each record)
+tail -f events.ndjson | jpx --stream --unbuffered 'message'
+```
+
+**Note:** `--stream` is incompatible with `--table`, `--yaml`, `--toml`, and `--lines` (these need the full dataset). Use `--slurp` instead if you need those formats.
+
+See [references/streaming.md](references/streaming.md) for more streaming patterns.
+
+## Variable Binding
+
+Bind variables for use in expressions:
+```bash
+# String variable
+jpx --arg name Alice '[?name == $name]' data.json
+
+# JSON variable (parsed)
+jpx --argjson threshold 42 '[?score > $threshold]' data.json
+jpx --argjson ids '[1,2,3]' '[?contains($ids, id)]' data.json
+```
+
+## Query Files
+
+Save and reuse expressions with `.jpx` query files:
+```bash
+# Run a named query
+jpx -Q queries.jpx:active-users data.json
+
+# Alternative syntax
+jpx -Q queries.jpx --query active-users data.json
+
+# List available queries
+jpx -Q queries.jpx --list-queries
+
+# Validate queries without running
+jpx -Q queries.jpx --check
+```
+
+See [references/query-files.md](references/query-files.md) for the `.jpx` file format.
+
+## Function Discovery
+
+```bash
+jpx --list-functions                     # all 400+ functions
+jpx --list-category String              # functions in a category
+jpx --describe format_date              # detailed function info
+jpx --search "date format"             # fuzzy search
+jpx --similar group_by                  # find related functions
+```
+
+## Data Inspection
+
+```bash
+jpx --stats -f data.json                # type, size, depth analysis
+jpx --paths -f data.json                # all paths in dot notation
+jpx --paths --types -f data.json        # paths with types
+jpx --paths --values -f data.json       # paths with values
+```
+
+## JSON Operations
+
+```bash
+# Diff two files (RFC 6902 JSON Patch)
+jpx --diff before.json after.json
+
+# Apply a patch
+jpx --patch changes.json -f original.json
+
+# Merge (RFC 7396)
+jpx --merge overlay.json -f base.json
+```
+
+## Other Features
+
+```bash
+# Explain expression (AST breakdown)
+jpx --explain 'sort_by([*], &name) | [0]'
+
+# Benchmark
+jpx --bench 1000 'complex.expression' data.json
+
+# Interactive REPL
+jpx --repl -f data.json
+jpx --repl --demo users                 # with demo dataset
+
+# Exit status (for shell conditionals)
+jpx -x '[?critical]' data.json && echo "found critical items"
+```
+
+## Shell Pipeline Recipes
+
+```bash
+# Fetch API, extract, and format as table
+curl -s https://api.example.com/users | jpx -t '[*].{name: name, email: email}'
+
+# Process log file, count errors by type
+cat app.log | jpx --stream -s '[*]' | jpx 'group_by(@, &error_type)'
+
+# Convert JSON to CSV for spreadsheet
+jpx --csv 'records[*]' -o export.csv data.json
+
+# Find largest files in package.json dependencies
+jpx 'dependencies | keys(@) | sort(@)' package.json
+```
+
+## Related Skills
+
+- [jmespath-query](../jmespath-query/SKILL.md) -- JMESPath expression syntax
+- [jpx-functions](../jpx-functions/SKILL.md) -- 400+ extension functions
+- [jpx-mcp](../jpx-mcp/SKILL.md) -- MCP server for AI agent integration

--- a/skills/jpx-cli/SKILL.md
+++ b/skills/jpx-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jpx-cli
-description: "Use the jpx command-line tool to query and transform JSON data. Covers output formats (CSV, TSV, table, YAML, TOML), streaming NDJSON processing, input modes (slurp, raw-input, null-input), query files, variable binding, shell pipelines, and the interactive REPL. Use when the user needs to process JSON from the command line or in shell scripts."
+description: "Run jpx to query and transform JSON from the command line. Covers output formats (CSV, TSV, table, YAML), streaming NDJSON, input modes (slurp, raw-input, null-input), query files, variable binding, and shell pipelines. Use when building shell pipelines or exporting JSON data."
 license: MIT OR Apache-2.0
 metadata:
   author: joshrotenberg

--- a/skills/jpx-cli/references/output-formats.md
+++ b/skills/jpx-cli/references/output-formats.md
@@ -1,0 +1,136 @@
+# jpx Output Formats
+
+## JSON (default)
+
+Pretty-printed with syntax coloring when output is a terminal.
+
+```bash
+jpx 'expression' data.json              # pretty, colored (if terminal)
+jpx -c 'expression' data.json           # compact (single line)
+jpx --indent 4 'expression' data.json   # custom indent (0-8 spaces)
+jpx --tab 'expression' data.json        # tab indentation
+jpx -S 'expression' data.json           # sort object keys alphabetically
+jpx --color always 'expression' data.json  # force color even in pipes
+jpx --color never 'expression' data.json   # disable color
+```
+
+## Raw Strings (`-r`, `-j`)
+
+Output string values without JSON quotes. Non-string values are still JSON-encoded.
+
+```bash
+echo '{"msg":"hello"}' | jpx -r 'msg'    # hello (no quotes)
+echo '{"n":42}' | jpx -r 'n'             # 42 (numbers unchanged)
+
+# Join output: raw without trailing newline
+echo '{"id":"abc"}' | jpx -j 'id'        # abc (no newline)
+```
+
+## CSV (`--csv`)
+
+Best for arrays of objects. Keys become column headers. Nested objects are flattened with dot notation.
+
+```bash
+echo '[{"name":"alice","age":30},{"name":"bob","age":25}]' | jpx --csv '@'
+# age,name
+# 30,alice
+# 25,bob
+```
+
+**Nesting:** `{"user":{"name":"alice"}}` produces column `user.name`.
+
+**Primitives:** Arrays of non-objects produce a single headerless column.
+
+**Single object:** Treated as a one-row table.
+
+**Output to file:**
+```bash
+jpx --csv -o data.csv 'users[*]' data.json
+```
+
+## TSV (`--tsv`)
+
+Same as CSV but tab-delimited:
+```bash
+jpx --tsv 'users[*]' data.json
+```
+
+## Table (`-t`)
+
+Formatted table output. Best for arrays of objects.
+
+```bash
+jpx -t 'users[*].{name: name, age: age}' data.json
+```
+
+### Table styles (`--table-style`)
+
+| Style | Description |
+|-------|-------------|
+| `unicode` | Box-drawing characters (default) |
+| `rounded` | Rounded corners |
+| `ascii` | ASCII only |
+| `markdown` | GitHub-flavored markdown table |
+| `plain` | No borders |
+| `sharp` | Sharp corners |
+| `modern` | Modern style |
+
+```bash
+jpx -t --table-style markdown 'users[*]' data.json
+jpx -t --table-style ascii 'users[*]' data.json
+```
+
+**Display notes:**
+- Boolean values are colored (green/red) when color is enabled
+- Null values appear dimmed
+- Long strings are truncated at 40 characters
+- Arrays show `[N items]`, objects show `{N keys}`
+
+## YAML (`-y`)
+
+```bash
+jpx -y 'config' data.json
+```
+
+Works with any JSON value. Objects and arrays use standard YAML formatting.
+
+## TOML (`--toml`)
+
+```bash
+jpx --toml 'config' data.json
+```
+
+Requires an object or array at the root level. Arrays are wrapped in an `items` key.
+
+## Lines (`-l`)
+
+One JSON value per line (NDJSON format). Useful for piping array elements:
+
+```bash
+jpx -l 'users[*]' data.json | while read line; do echo "$line"; done
+```
+
+Non-arrays output a single line.
+
+## Parquet (`--parquet`)
+
+Requires the `parquet` feature and an output file:
+```bash
+jpx --parquet -o data.parquet 'records[*]' data.json
+```
+
+Best for arrays of objects. Uses Snappy compression.
+
+## Format Compatibility
+
+| Format | Arrays | Objects | Primitives | Streaming |
+|--------|--------|---------|------------|-----------|
+| JSON | Yes | Yes | Yes | Yes (default) |
+| Raw | Yes | Yes | Yes | Yes |
+| CSV | Yes | Yes | Partial | Yes |
+| TSV | Yes | Yes | Partial | Yes |
+| Table | Yes | Yes | No | No |
+| YAML | Yes | Yes | Yes | No |
+| TOML | Yes | Yes | No | No |
+| Lines | Yes | Yes | Yes | No |
+| Parquet | Yes | No | No | No |

--- a/skills/jpx-cli/references/query-files.md
+++ b/skills/jpx-cli/references/query-files.md
@@ -1,0 +1,52 @@
+# jpx Query Files (.jpx)
+
+Query files let you save and reuse named JMESPath expressions.
+
+## File Format
+
+A `.jpx` file contains named queries, one per line, in `name: expression` format:
+
+```
+# Comments start with #
+active-users: [?status == 'active']
+user-names: [*].name | sort(@)
+error-count: length([?level == 'error'])
+
+# Multi-word names use hyphens
+top-scorers: sort_by(@, &score) | reverse(@) | [:10]
+```
+
+## Usage
+
+```bash
+# Run a named query
+jpx -Q queries.jpx:active-users data.json
+
+# Alternative: separate --query flag
+jpx -Q queries.jpx --query active-users data.json
+
+# List available queries in a file
+jpx -Q queries.jpx --list-queries
+
+# Validate all queries without executing
+jpx -Q queries.jpx --check
+```
+
+## Validation
+
+The `--check` flag parses all queries and reports errors without executing:
+
+```bash
+jpx -Q queries.jpx --check
+# Exit 0 if all valid, exit 1 if any errors
+```
+
+Useful in CI/CD to catch syntax errors in query libraries.
+
+## Tips
+
+- Keep related queries in the same file (e.g., `user-queries.jpx`, `metrics.jpx`)
+- Use descriptive names -- they appear in `--list-queries` output
+- Comments document what each query expects as input
+- Query files work with all output formats: `jpx -Q q.jpx:name --csv data.json`
+- Combine with variable binding: `jpx -Q q.jpx:name --arg status active data.json`

--- a/skills/jpx-cli/references/streaming.md
+++ b/skills/jpx-cli/references/streaming.md
@@ -1,0 +1,97 @@
+# jpx Streaming Mode
+
+Process NDJSON (newline-delimited JSON) input line by line with constant memory usage.
+
+## How It Works
+
+- Each line is parsed as an independent JSON value
+- Expressions are evaluated per-line
+- Null results are automatically skipped
+- Invalid JSON lines produce a warning on stderr (suppressed with `-q`)
+- Empty lines are skipped
+
+## Basic Streaming
+
+```bash
+# Input: one JSON object per line
+echo '{"name":"alice","age":30}
+{"name":"bob","age":25}
+{"name":"carol","age":35}' | jpx --stream 'name'
+
+# Output:
+# "alice"
+# "bob"
+# "carol"
+```
+
+## Streaming with CSV/TSV
+
+Headers are derived from the first result object. Subsequent records use the same column order.
+
+```bash
+# CSV output
+cat users.ndjson | jpx --stream --csv '@'
+# age,name
+# 30,alice
+# 25,bob
+
+# TSV output
+cat users.ndjson | jpx --stream --tsv '@'
+
+# CSV with expression (reshape before output)
+cat events.ndjson | jpx --stream --csv '{user: user.name, action: event_type}'
+```
+
+**Behavior notes:**
+- Extra fields in later records (not in the first record) are silently dropped
+- Missing fields in later records produce empty cells
+- Non-object results get a single "value" column
+- Nested objects are flattened with dot notation (e.g., `addr.city`)
+
+## Filtering in Streaming Mode
+
+Since each line is independent, you can't use array filters directly. Instead, return null for lines you want to skip:
+
+```bash
+# Using if() to filter (null results are skipped)
+cat events.ndjson | jpx --stream 'if(level == `error`, @, null)'
+
+# Expression that naturally returns null skips the line
+cat events.ndjson | jpx --stream '[?level == `error`] | [0]'
+```
+
+## Multiple Expressions
+
+Expressions are chained -- each receives the output of the previous:
+
+```bash
+cat data.ndjson | jpx --stream 'items[*]' 'sort(@)' '[0]'
+```
+
+## Unbuffered Output
+
+For real-time processing (e.g., tailing a log):
+
+```bash
+tail -f events.ndjson | jpx --stream --unbuffered '{ts: timestamp, msg: message}'
+```
+
+## Incompatible Flags
+
+These require buffering the full dataset and cannot be used with `--stream`:
+- `--table` / `-t`
+- `--yaml` / `-y`
+- `--toml`
+- `--lines` / `-l`
+- `--slurp` / `-s`
+- `--null-input` / `-n`
+
+Use `--slurp` to collect streaming input into an array first if you need these formats.
+
+## Performance
+
+Streaming mode processes input with O(1) memory regardless of file size. Useful for:
+- Large NDJSON files (gigabytes)
+- Log file processing
+- Continuous data streams (with `--unbuffered`)
+- Pipelines where you don't need the full dataset in memory

--- a/skills/jpx-functions/SKILL.md
+++ b/skills/jpx-functions/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: jpx-functions
+description: "Look up and use the 400+ extension functions in jpx beyond standard JMESPath. Covers array, string, math, datetime, hash, encoding, regex, object, expression (higher-order), geo, text, validation, and 20+ more categories. Use when the user needs a function beyond the 26 standard JMESPath built-ins, or when working with jpx-core, jpx-engine, or jpx-python."
+license: MIT OR Apache-2.0
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+compatibility: Requires jpx, jpx-core, jpx-engine, or jpx-python
+---
+
+# jpx Extension Functions
+
+jpx extends JMESPath with 400+ functions across 33 categories. This skill covers function discovery, the most commonly used functions, and key conventions.
+
+## Discovering Functions
+
+### CLI
+```bash
+jpx --list-functions                    # all functions by category
+jpx --list-category String             # functions in a category
+jpx --describe split                   # detailed function info
+jpx --search "group array"            # fuzzy search
+jpx --similar group_by                 # find related functions
+```
+
+### MCP tools
+Use `search`, `describe`, `functions`, `categories`, `similar`, or `suggest_function`.
+
+## Key Conventions
+
+### Expref arguments
+
+Functions that operate "by key" use expression references (`&expr`), matching the JMESPath spec:
+
+```
+sort_by(users, &age)              -- standard
+group_by(users, &department)      -- jpx extension (also accepts string for backward compat)
+index_by(users, &id)              -- jpx extension
+```
+
+### Expression functions
+
+Higher-order functions in the Expression category take `&expr` as their first argument:
+
+```
+map_expr(&upper(name), users)     -- transform each element
+filter_expr(&(age > `18`), users) -- filter by expression
+sort_by_expr(&score, users)       -- sort by expression
+group_by_expr(&type, items)       -- group by expression
+reduce_expr(&(@ + @@), [1,2,3], `0`)  -- reduce with accumulator
+```
+
+In expression function callbacks, `@` is the current element and `@@` is the accumulator (for reduce).
+
+## Categories
+
+| Category | Count | Key Functions |
+|----------|-------|---------------|
+| [Array](references/array-functions.md) | 36 | `unique`, `chunk`, `group_by`, `index_by`, `zip`, `flatten_deep`, ... |
+| [String](references/string-functions.md) | 36 | `split`, `upper`, `lower`, `trim`, `replace`, `pad_left`, `template`, ... |
+| [Math](references/math-functions.md) | 42 | `sum`, `avg`, `median`, `round`, `clamp`, `range`, `std_dev`, ... |
+| [Object](references/object-functions.md) | 51 | `omit`, `pick`, `deep_merge`, `defaults`, `rename_keys`, `flatten_keys`, ... |
+| [Expression](references/expression-functions.md) | 41 | `map_expr`, `filter_expr`, `reduce_expr`, `sort_by_expr`, `group_by_expr`, ... |
+| [Datetime](references/datetime-functions.md) | 28 | `now`, `format_date`, `parse_date`, `date_add`, `date_diff`, ... |
+| [Text](references/text-functions.md) | 21 | `word_count`, `sentences`, `slug`, `truncate_words`, `ngrams`, ... |
+| [Type](references/type-functions.md) | 13 | `to_number`, `to_string`, `type_of`, `is_number`, `auto_parse`, ... |
+| [Validation](references/validation-functions.md) | 13 | `is_email`, `is_url`, `is_uuid`, `is_ipv4`, `is_base64`, ... |
+| [Utility](references/utility-functions.md) | 11 | `coalesce`, `default`, `env`, `identity`, `if`, ... |
+| [Encoding](references/encoding-functions.md) | 10 | `base64_encode`, `base64_decode`, `url_encode`, `url_decode`, `hex`, ... |
+| [Geo](references/geo-functions.md) | 10 | `geo_distance`, `geo_bearing`, `geo_midpoint`, `geohash_encode`, ... |
+| [Multimatch](references/multimatch-functions.md) | 10 | `match_all`, `extract_all`, `extract_between`, `scan`, ... |
+| [Hash](references/hash-functions.md) | 9 | `md5`, `sha256`, `sha512`, `hmac_sha256`, `crc32`, ... |
+| [Computing](references/computing-functions.md) | 9 | `bit_and`, `bit_or`, `bit_xor`, `bit_shift_left`, ... |
+| [Fuzzy](references/fuzzy-functions.md) | 9 | `levenshtein`, `jaro_winkler`, `soundex`, `hamming`, ... |
+| [Phonetic](references/phonetic-functions.md) | 9 | `metaphone`, `double_metaphone`, `soundex`, `nysiis`, ... |
+| [Duration](references/duration-functions.md) | 8 | `parse_duration`, `format_duration`, `duration_add`, ... |
+| [Color](references/color-functions.md) | 8 | `hex_to_rgb`, `rgb_to_hex`, `color_lighten`, `color_darken`, ... |
+| [Path](references/path-functions.md) | 7 | `path_basename`, `path_dirname`, `path_ext`, `path_join`, ... |
+| [Network](references/network-functions.md) | 7 | `cidr_contains`, `ip_to_int`, `int_to_ip`, `cidr_network`, ... |
+| [Semver](references/semver-functions.md) | 7 | `semver_compare`, `semver_major`, `semver_minor`, `semver_is_valid`, ... |
+| [Format](references/format-functions.md) | 6 | `to_csv`, `from_csv`, `to_tsv`, `from_tsv`, `to_json_string`, ... |
+| [URL](references/url-functions.md) | 6 | `url_parse`, `url_build`, `query_string_parse`, `query_string_build`, ... |
+| [Regex](references/regex-functions.md) | 5 | `regex_match`, `regex_replace`, `regex_extract`, `regex_split`, ... |
+| [Rand](references/rand-functions.md) | 5 | `random`, `random_int`, `random_choice`, `random_sample`, ... |
+| [Language](references/language-functions.md) | 5 | `detect_language`, `stems`, `remove_stopwords`, ... |
+| [Units](references/units-functions.md) | 4 | `convert_temperature`, `convert_length`, `convert_mass`, ... |
+| [IDs](references/ids-functions.md) | 3 | `nanoid`, `ulid`, `ulid_timestamp` |
+| [JSON Patch](references/jsonpatch-functions.md) | 3 | `json_diff`, `json_patch`, `json_merge_patch` |
+| [Discovery](references/discovery-functions.md) | 3 | `fuzzy_match`, `fuzzy_score`, `fuzzy_search` |
+| [UUID](references/uuid-functions.md) | 1 | `uuid` |
+
+## Most Used Functions (Quick Reference)
+
+### Array
+```
+unique([1,2,2,3])                        -> [1,2,3]
+chunk([1,2,3,4,5], `2`)                  -> [[1,2],[3,4],[5]]
+group_by(users, &role)                   -> {"admin":[...], "user":[...]}
+index_by(users, &id)                     -> {"1":{...}, "2":{...}}
+zip([1,2], ['a','b'])                    -> [[1,"a"],[2,"b"]]
+flatten_deep([[1,[2]],[3]])              -> [1,2,3]
+first([1,2,3])                           -> 1
+last([1,2,3])                            -> 3
+range(`1`, `6`)                          -> [1,2,3,4,5]
+```
+
+### String
+```
+split('a,b,c', ',')                      -> ["a","b","c"]
+upper('hello')                           -> "HELLO"
+lower('HELLO')                           -> "hello"
+trim('  hi  ')                           -> "hi"
+replace('hello', 'l', 'r')              -> "herro"
+pad_left('42', `5`, '0')                -> "00042"
+template('Hello, {name}!', {"name":"Jo"}) -> "Hello, Jo!"
+snake_case('helloWorld')                 -> "hello_world"
+```
+
+### Math
+```
+sum([1,2,3])                             -> 6
+avg([1,2,3])                             -> 2.0
+median([1,2,3,4])                        -> 2.5
+round(`3.14159`, `2`)                    -> 3.14
+clamp(`15`, `0`, `10`)                   -> 10
+std_dev([2,4,4,4,5,5,7,9])              -> 2.0
+```
+
+### Datetime
+```
+now()                                    -> "2024-01-15T10:30:00Z"
+format_date('2024-01-15', '%B %d, %Y')  -> "January 15, 2024"
+date_add('2024-01-15', `30`, 'days')     -> "2024-02-14..."
+date_diff('2024-03-01', '2024-01-01', 'days') -> 60
+```
+
+### Object
+```
+omit(obj, ['password', 'secret'])        -> obj without those keys
+pick(obj, ['name', 'email'])             -> obj with only those keys
+deep_merge(base, overlay)               -> recursively merged object
+defaults(obj, {"color": "blue"})        -> fills in missing keys
+rename_keys(obj, {"old": "new"})        -> renamed keys
+```
+
+### Utility
+```
+if(condition, then_val, else_val)        -> conditional
+coalesce(null, null, 'found')            -> "found"
+default(value, 'fallback')              -> value or fallback if null
+```
+
+## Runtime Setup (Rust)
+
+For embedding jpx-core in Rust applications:
+
+```rust
+let mut runtime = jpx_core::Runtime::new();
+runtime.register_builtin_functions();  // 26 spec functions
+let mut registry = jpx_core::FunctionRegistry::new();
+registry.register_all();               // loads extensions from functions.toml
+registry.apply(&mut runtime);          // registers enabled functions
+```
+
+## Related Skills
+
+- [jmespath-query](../jmespath-query/SKILL.md) -- JMESPath expression syntax (covers the 26 standard functions)
+- [jpx-cli](../jpx-cli/SKILL.md) -- CLI tool usage
+- [jpx-mcp](../jpx-mcp/SKILL.md) -- MCP server tools

--- a/skills/jpx-functions/SKILL.md
+++ b/skills/jpx-functions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jpx-functions
-description: "Look up and use the 400+ extension functions in jpx beyond standard JMESPath. Covers array, string, math, datetime, hash, encoding, regex, object, expression (higher-order), geo, text, validation, and 20+ more categories. Use when the user needs a function beyond the 26 standard JMESPath built-ins, or when working with jpx-core, jpx-engine, or jpx-python."
+description: "Look up and call the 400+ extension functions in jpx beyond standard JMESPath. Covers array, string, math, datetime, hash, encoding, regex, object, expression (higher-order), geo, text, validation, and 20+ more categories. Use when a task needs functions beyond the 26 standard JMESPath built-ins."
 license: MIT OR Apache-2.0
 metadata:
   author: joshrotenberg
@@ -161,6 +161,13 @@ let mut registry = jpx_core::FunctionRegistry::new();
 registry.register_all();               // loads extensions from functions.toml
 registry.apply(&mut runtime);          // registers enabled functions
 ```
+
+## Common Errors
+
+- **"Unknown function 'xyz'"** -- the function doesn't exist or is misspelled. Use `jpx --search xyz` or the MCP `search` tool to find the correct name.
+- **"Invalid argument type"** -- wrong argument type (e.g., passing a string where a number is expected). Use `jpx --describe function_name` to check the signature.
+- **"Expected expref"** -- the function expects `&expr` but got a plain value. Add `&` prefix: `sort_by(arr, &field)` not `sort_by(arr, field)`.
+- **Extension function in strict mode** -- strict mode (`--strict` or `JPX_STRICT=1`) disables all extensions. Only the 26 standard functions are available.
 
 ## Related Skills
 

--- a/skills/jpx-functions/references/array-functions.md
+++ b/skills/jpx-functions/references/array-functions.md
@@ -1,0 +1,650 @@
+# Array Functions (36)
+
+## `bsearch`
+
+**Signature:** `array, any -> number`
+
+Binary search in a sorted array, returns index or negative insertion point (jq parity)
+
+```
+bsearch([1, 3, 5, 7, 9], `5`) -> 2
+```
+_Found at index 2_
+
+```
+bsearch([1, 3, 5, 7, 9], `4`) -> -3
+```
+_Not found, would insert at index 2_
+
+---
+
+## `butlast`
+
+**Signature:** `array -> array`
+
+Return all elements except the last (alias for initial)
+
+```
+butlast([1, 2, 3, 4]) -> [1, 2, 3]
+```
+_Remove last element_
+
+```
+butlast(['a', 'b', 'c']) -> ['a', 'b']
+```
+_String values_
+
+---
+
+## `cartesian`
+
+**Signature:** `array, array? -> array`
+
+Compute cartesian product of arrays (jq parity for N-way product)
+
+```
+cartesian([1, 2], [3, 4]) -> [[1, 3], [1, 4], [2, 3], [2, 4]]
+```
+_Two-array product_
+
+```
+cartesian([[1, 2], [3, 4]]) -> [[1, 3], [1, 4], [2, 3], [2, 4]]
+```
+_N-way product (jq style)_
+
+---
+
+## `chunk`
+
+**Signature:** `array, number -> array`
+
+Split array into chunks of size n
+
+```
+chunk([1, 2, 3, 4], `2`) -> [[1, 2], [3, 4]]
+```
+_Basic chunking_
+
+```
+chunk([1, 2, 3, 4, 5], `2`) -> [[1, 2], [3, 4], [5]]
+```
+_Uneven chunks_
+
+---
+
+## `compact`
+
+**Signature:** `array -> array`
+
+Remove null values from array
+
+```
+compact([1, null, 2, null]) -> [1, 2]
+```
+_Remove nulls_
+
+```
+compact([null, null]) -> []
+```
+_All nulls_
+
+---
+
+## `cycle`
+
+**Signature:** `array, number -> array`
+
+Cycle through array elements n times
+
+```
+cycle([1, 2, 3], `2`) -> [1, 2, 3, 1, 2, 3]
+```
+_Cycle twice_
+
+```
+cycle(["a", "b"], `3`) -> ["a", "b", "a", "b", "a", "b"]
+```
+_Cycle strings_
+
+---
+
+## `dedupe`
+
+**Signature:** `array -> array`
+
+Remove consecutive duplicate values (unlike unique, allows non-adjacent duplicates)
+
+```
+dedupe([1, 1, 2, 2, 1, 1]) -> [1, 2, 1]
+```
+_Remove adjacent duplicates_
+
+```
+dedupe(['a', 'a', 'b', 'a']) -> ['a', 'b', 'a']
+```
+_String values_
+
+---
+
+## `difference`
+
+**Signature:** `array, array -> array`
+
+Elements in first array not in second
+
+```
+difference([1, 2, 3], [2]) -> [1, 3]
+```
+_Remove matching elements_
+
+```
+difference([1, 2, 3], [4, 5]) -> [1, 2, 3]
+```
+_No overlap_
+
+---
+
+## `drop`
+
+**Signature:** `array, number -> array`
+
+Drop first n elements
+
+```
+drop([1, 2, 3, 4], `2`) -> [3, 4]
+```
+_Drop first 2_
+
+```
+drop([1, 2, 3], `0`) -> [1, 2, 3]
+```
+_Drop none_
+
+---
+
+## `find_index`
+
+**Signature:** `array, any -> number | null`
+
+Find index of value in array
+
+```
+find_index([1, 2, 3], `2`) -> 1
+```
+_Find existing value_
+
+```
+find_index(['a', 'b', 'c'], 'b') -> 1
+```
+_Find string_
+
+---
+
+## `first`
+
+**Signature:** `array -> any`
+
+Get first element of array
+
+```
+first([1, 2, 3]) -> 1
+```
+_Get first number_
+
+```
+first(['a', 'b']) -> 'a'
+```
+_Get first string_
+
+---
+
+## `flatten`
+
+**Signature:** `array -> array`
+
+Flatten array one level deep
+
+```
+flatten([[1, 2], [3]]) -> [1, 2, 3]
+```
+_Flatten nested arrays_
+
+```
+flatten([[1, [2]], [3]]) -> [1, [2], 3]
+```
+_Only one level deep_
+
+---
+
+## `flatten_deep`
+
+**Signature:** `array -> array`
+
+Recursively flatten nested arrays
+
+```
+flatten_deep([[1, [2]], [3]]) -> [1, 2, 3]
+```
+_Deeply nested_
+
+```
+flatten_deep([[[1]], [[2]], [[3]]]) -> [1, 2, 3]
+```
+_Multiple levels_
+
+---
+
+## `frequencies`
+
+**Signature:** `array -> object`
+
+Count occurrences of each value
+
+```
+frequencies(['a', 'b', 'a']) -> {a: 2, b: 1}
+```
+_Count strings_
+
+```
+frequencies([1, 2, 1, 1]) -> {1: 3, 2: 1}
+```
+_Count numbers_
+
+---
+
+## `group_by`
+
+**Signature:** `array, expression|string -> object`
+
+Group array elements by expression or field name
+
+```
+group_by([{t: 'a'}, {t: 'b'}, {t: 'a'}], &t) -> {a: [{t:'a'}, {t:'a'}], b: [{t:'b'}]}
+```
+_Group by field (expref)_
+
+```
+group_by([{t: 'a'}, {t: 'b'}, {t: 'a'}], 't') -> {a: [{t:'a'}, {t:'a'}], b: [{t:'b'}]}
+```
+_Group by field (string, legacy)_
+
+---
+
+## `includes`
+
+**Signature:** `array, any -> boolean`
+
+Check if array contains value
+
+```
+includes([1, 2, 3], `2`) -> true
+```
+_Value found_
+
+```
+includes([1, 2, 3], `99`) -> false
+```
+_Value not found_
+
+---
+
+## `index_at`
+
+**Signature:** `array, number -> any`
+
+Get element at index (supports negative)
+
+```
+index_at([1, 2, 3], `0`) -> 1
+```
+_First element_
+
+```
+index_at([1, 2, 3], `-1`) -> 3
+```
+_Last element (negative index)_
+
+---
+
+## `index_by`
+
+**Signature:** `array, expression|string -> object`
+
+Create lookup map from array using expression or key field (last value wins for duplicates)
+
+```
+index_by([{id: 1, name: "alice"}, {id: 2, name: "bob"}], &id) -> {"1": {id: 1, name: "alice"}, "2": {id: 2, name: "bob"}}
+```
+_Index by id (expref)_
+
+```
+index_by([{id: 1, name: "alice"}, {id: 2, name: "bob"}], "id") -> {"1": {id: 1, name: "alice"}, "2": {id: 2, name: "bob"}}
+```
+_Index by id (string, legacy)_
+
+---
+
+## `indices_array`
+
+**Signature:** `array, any -> array`
+
+Find all indices where a value appears in an array (jq parity)
+
+```
+indices_array([1, 2, 3, 2, 4, 2], `2`) -> [1, 3, 5]
+```
+_Find all occurrences_
+
+```
+indices_array(['a', 'b', 'a', 'c'], `'a'`) -> [0, 2]
+```
+_String values_
+
+---
+
+## `inside_array`
+
+**Signature:** `array, array -> boolean`
+
+Check if all elements of first array are contained in second array (inverse of contains, jq parity)
+
+```
+inside_array([1, 2], [1, 2, 3, 4]) -> true
+```
+_Subset check_
+
+```
+inside_array([1, 5], [1, 2, 3, 4]) -> false
+```
+_Not a subset_
+
+---
+
+## `interpose`
+
+**Signature:** `array, any -> array`
+
+Insert separator value between each element of array
+
+```
+interpose([1, 2, 3], `0`) -> [1, 0, 2, 0, 3]
+```
+_Insert zeros between numbers_
+
+```
+interpose(['a', 'b', 'c'], `"-"`) -> ['a', '-', 'b', '-', 'c']
+```
+_Insert separator strings_
+
+---
+
+## `intersection`
+
+**Signature:** `array, array -> array`
+
+Elements common to both arrays
+
+```
+intersection([1, 2], [2, 3]) -> [2]
+```
+_Common elements_
+
+```
+intersection([1, 2], [3, 4]) -> []
+```
+_No overlap_
+
+---
+
+## `lag`
+
+**Signature:** `array, number -> array`
+
+Shift array by n positions forward, prepending nulls
+
+```
+lag([1, 2, 3], `1`) -> [null, 1, 2]
+```
+_Lag by 1_
+
+```
+lag([1, 2, 3], `2`) -> [null, null, 1]
+```
+_Lag by 2_
+
+---
+
+## `last`
+
+**Signature:** `array -> any`
+
+Get last element of array
+
+```
+last([1, 2, 3]) -> 3
+```
+_Get last number_
+
+```
+last(['a', 'b']) -> 'b'
+```
+_Get last string_
+
+---
+
+## `lead`
+
+**Signature:** `array, number -> array`
+
+Shift array by n positions backward, appending nulls
+
+```
+lead([1, 2, 3], `1`) -> [2, 3, null]
+```
+_Lead by 1_
+
+```
+lead([1, 2, 3], `2`) -> [3, null, null]
+```
+_Lead by 2_
+
+---
+
+## `pairwise`
+
+**Signature:** `array -> array`
+
+Return adjacent pairs from array
+
+```
+pairwise([1, 2, 3]) -> [[1, 2], [2, 3]]
+```
+_Adjacent pairs_
+
+```
+pairwise([1, 2]) -> [[1, 2]]
+```
+_Single pair_
+
+---
+
+## `partition_by`
+
+**Signature:** `array, expression|string -> array`
+
+Split array into partitions when expression or field value changes (preserves order unlike group_by)
+
+```
+partition_by([{t: "a"}, {t: "a"}, {t: "b"}, {t: "a"}], &t) -> [[{t: "a"}, {t: "a"}], [{t: "b"}], [{t: "a"}]]
+```
+_Split on field change (expref)_
+
+```
+partition_by([{t: "a"}, {t: "a"}, {t: "b"}, {t: "a"}], "t") -> [[{t: "a"}, {t: "a"}], [{t: "b"}], [{t: "a"}]]
+```
+_Split on field change (string, legacy)_
+
+---
+
+## `range`
+
+**Signature:** `number, number -> array`
+
+Generate array of numbers
+
+```
+range(`1`, `5`) -> [1, 2, 3, 4]
+```
+_Range 1 to 4_
+
+```
+range(`0`, `3`) -> [0, 1, 2]
+```
+_Range from zero_
+
+---
+
+## `repeat_array`
+
+**Signature:** `any, number -> array`
+
+Create array with value repeated n times
+
+```
+repeat_array(`1`, `3`) -> [1, 1, 1]
+```
+_Repeat number_
+
+```
+repeat_array(`"x"`, `4`) -> ["x", "x", "x", "x"]
+```
+_Repeat string_
+
+---
+
+## `sliding_window`
+
+**Signature:** `array, number -> array`
+
+Create overlapping windows of size n (alias for window)
+
+```
+sliding_window([1, 2, 3, 4], `2`) -> [[1, 2], [2, 3], [3, 4]]
+```
+_Size 2 windows_
+
+```
+sliding_window([1, 2, 3, 4], `3`) -> [[1, 2, 3], [2, 3, 4]]
+```
+_Size 3 windows_
+
+---
+
+## `take`
+
+**Signature:** `array, number -> array`
+
+Take first n elements
+
+```
+take([1, 2, 3, 4], `2`) -> [1, 2]
+```
+_Take first 2_
+
+```
+take([1, 2, 3], `0`) -> []
+```
+_Take none_
+
+---
+
+## `transpose`
+
+**Signature:** `array -> array`
+
+Transpose a 2D array (swap rows and columns)
+
+```
+transpose([[1, 2], [3, 4]]) -> [[1, 3], [2, 4]]
+```
+_Swap rows/columns_
+
+```
+transpose([[1, 2, 3], [4, 5, 6]]) -> [[1, 4], [2, 5], [3, 6]]
+```
+_2x3 to 3x2_
+
+---
+
+## `union`
+
+**Signature:** `array, array -> array`
+
+Unique elements from both arrays
+
+```
+union([1, 2], [2, 3]) -> [1, 2, 3]
+```
+_Combine with dedup_
+
+```
+union([1, 2], [3, 4]) -> [1, 2, 3, 4]
+```
+_No overlap_
+
+---
+
+## `unique`
+
+**Signature:** `array -> array`
+
+Remove duplicate values
+
+```
+unique([1, 2, 1, 3]) -> [1, 2, 3]
+```
+_Basic deduplication_
+
+```
+unique(['a', 'b', 'a']) -> ['a', 'b']
+```
+_String values_
+
+---
+
+## `zip`
+
+**Signature:** `array, array -> array`
+
+Zip two arrays together
+
+```
+zip([1, 2], ['a', 'b']) -> [[1, 'a'], [2, 'b']]
+```
+_Basic zip_
+
+```
+zip([1, 2, 3], ['a', 'b']) -> [[1, 'a'], [2, 'b']]
+```
+_Unequal lengths (truncates)_
+
+---
+
+## `zipmap`
+
+**Signature:** `array, array -> object`
+
+Create object from parallel arrays of keys and values
+
+```
+zipmap(["a", "b", "c"], [1, 2, 3]) -> {"a": 1, "b": 2, "c": 3}
+```
+_Basic zipmap_
+
+```
+zipmap(["x", "y"], [10, 20, 30]) -> {"x": 10, "y": 20}
+```
+_Uses shorter length_
+
+---
+

--- a/skills/jpx-functions/references/color-functions.md
+++ b/skills/jpx-functions/references/color-functions.md
@@ -1,0 +1,146 @@
+# Color Functions (8)
+
+## `color_complement`
+
+**Signature:** `string -> string`
+
+Get complementary color
+
+```
+color_complement('#ff0000') -> \"#00ffff\"
+```
+_Red to cyan_
+
+```
+color_complement('#00ff00') -> \"#ff00ff\"
+```
+_Green to magenta_
+
+---
+
+## `color_grayscale`
+
+**Signature:** `string -> string`
+
+Convert to grayscale
+
+```
+color_grayscale('#ff0000') -> \"#4c4c4c\"
+```
+_Red to gray_
+
+```
+color_grayscale('#00ff00') -> \"#969696\"
+```
+_Green to gray_
+
+---
+
+## `color_invert`
+
+**Signature:** `string -> string`
+
+Invert a color
+
+```
+color_invert('#ff0000') -> \"#00ffff\"
+```
+_Invert red_
+
+```
+color_invert('#000000') -> \"#ffffff\"
+```
+_Black to white_
+
+---
+
+## `color_mix`
+
+**Signature:** `string, string, number -> string`
+
+Mix two colors
+
+```
+color_mix('#ff0000', '#0000ff', `50`) -> \"#800080\"
+```
+_Red and blue to purple_
+
+```
+color_mix('#ff0000', '#00ff00', `50`) -> \"#808000\"
+```
+_Red and green_
+
+---
+
+## `darken`
+
+**Signature:** `string, number -> string`
+
+Darken a color by percentage
+
+```
+darken('#3366cc', `20`) -> \"#2952a3\"
+```
+_Darken blue by 20%_
+
+```
+darken('#ff0000', `50`) -> \"#800000\"
+```
+_Darken red by 50%_
+
+---
+
+## `hex_to_rgb`
+
+**Signature:** `string -> object`
+
+Convert hex color to RGB
+
+```
+hex_to_rgb('#ff5500') -> {b: 0, g: 85, r: 255}
+```
+_Orange_
+
+```
+hex_to_rgb('#000000') -> {b: 0, g: 0, r: 0}
+```
+_Black_
+
+---
+
+## `lighten`
+
+**Signature:** `string, number -> string`
+
+Lighten a color by percentage
+
+```
+lighten('#3366cc', `20`) -> \"#5c85d6\"
+```
+_Lighten blue by 20%_
+
+```
+lighten('#800000', `50`) -> \"#ff0000\"
+```
+_Lighten dark red_
+
+---
+
+## `rgb_to_hex`
+
+**Signature:** `number, number, number -> string`
+
+Convert RGB to hex color
+
+```
+rgb_to_hex(`255`, `85`, `0`) -> \"#ff5500\"
+```
+_Orange_
+
+```
+rgb_to_hex(`0`, `0`, `0`) -> \"#000000\"
+```
+_Black_
+
+---
+

--- a/skills/jpx-functions/references/computing-functions.md
+++ b/skills/jpx-functions/references/computing-functions.md
@@ -1,0 +1,164 @@
+# Computing Functions (9)
+
+## `bit_and`
+
+**Signature:** `number, number -> number`
+
+Bitwise AND
+
+```
+bit_and(`12`, `10`) -> 8
+```
+_1100 AND 1010 = 1000_
+
+```
+bit_and(`255`, `15`) -> 15
+```
+_Mask lower 4 bits_
+
+---
+
+## `bit_not`
+
+**Signature:** `number -> number`
+
+Bitwise NOT
+
+```
+bit_not(`0`) -> -1
+```
+_Invert zero_
+
+```
+bit_not(`-1`) -> 0
+```
+_Invert all ones_
+
+---
+
+## `bit_or`
+
+**Signature:** `number, number -> number`
+
+Bitwise OR
+
+```
+bit_or(`12`, `10`) -> 14
+```
+_1100 OR 1010 = 1110_
+
+```
+bit_or(`1`, `2`) -> 3
+```
+_0001 OR 0010 = 0011_
+
+---
+
+## `bit_shift_left`
+
+**Signature:** `number, number -> number`
+
+Bitwise left shift
+
+```
+bit_shift_left(`1`, `4`) -> 16
+```
+_Shift 1 left by 4_
+
+```
+bit_shift_left(`1`, `0`) -> 1
+```
+_Shift by 0 unchanged_
+
+---
+
+## `bit_shift_right`
+
+**Signature:** `number, number -> number`
+
+Bitwise right shift
+
+```
+bit_shift_right(`16`, `2`) -> 4
+```
+_Divide by 4_
+
+```
+bit_shift_right(`255`, `4`) -> 15
+```
+_Shift right by 4_
+
+---
+
+## `bit_xor`
+
+**Signature:** `number, number -> number`
+
+Bitwise XOR
+
+```
+bit_xor(`12`, `10`) -> 6
+```
+_1100 XOR 1010 = 0110_
+
+```
+bit_xor(`255`, `255`) -> 0
+```
+_Same values = 0_
+
+---
+
+## `format_bytes`
+
+**Signature:** `number -> string`
+
+Format bytes (decimal)
+
+```
+format_bytes(`1500000000`) -> \"1.50 GB\"
+```
+_Gigabytes_
+
+```
+format_bytes(`1000`) -> \"1.00 KB\"
+```
+_Kilobytes_
+
+---
+
+## `format_bytes_binary`
+
+**Signature:** `number -> string`
+
+Format bytes (binary)
+
+```
+format_bytes_binary(`1073741824`) -> \"1.00 GiB\"
+```
+_Gibibytes_
+
+```
+format_bytes_binary(`1024`) -> \"1.00 KiB\"
+```
+_Kibibytes_
+
+---
+
+## `parse_bytes`
+
+**Signature:** `string -> number`
+
+Parse byte size string
+
+```
+parse_bytes('1.5 GB') -> 1500000000
+```
+_Gigabytes_
+
+```
+parse_bytes('1 KB') -> 1000
+```
+_Kilobytes_
+
+---
+

--- a/skills/jpx-functions/references/datetime-functions.md
+++ b/skills/jpx-functions/references/datetime-functions.md
@@ -1,0 +1,506 @@
+# Datetime Functions (28)
+
+## `business_days_between`
+
+**Signature:** `number, number -> number`
+
+Count business days (weekdays) between two timestamps
+
+```
+business_days_between(`1704067200`, `1705276800`) -> 10
+```
+_Count weekdays_
+
+```
+business_days_between(start_ts, end_ts) -> count
+```
+_Between two timestamps_
+
+---
+
+## `date_add`
+
+**Signature:** `number, number, string -> number`
+
+Add time to timestamp
+
+```
+date_add(`0`, `1`, 'days') -> 86400
+```
+_Add 1 day_
+
+```
+date_add(`0`, `2`, 'hours') -> 7200
+```
+_Add 2 hours_
+
+---
+
+## `date_diff`
+
+**Signature:** `number, number, string -> number`
+
+Difference between timestamps
+
+```
+date_diff(`86400`, `0`, 'days') -> 1
+```
+_Diff in days_
+
+```
+date_diff(`7200`, `0`, 'hours') -> 2
+```
+_Diff in hours_
+
+---
+
+## `duration_since`
+
+**Signature:** `number|string -> object`
+
+Get detailed duration object from timestamp to now
+
+```
+duration_since(`1702396800`) -> {days: 1, hours: 0, ...}
+```
+_From timestamp_
+
+```
+duration_since('2023-01-01') -> {days: N, ...}
+```
+_From date string_
+
+---
+
+## `end_of_day`
+
+**Signature:** `number|string -> string`
+
+Get ISO 8601 string for end of day (23:59:59)
+
+```
+end_of_day('2023-12-13T15:30:00Z') -> \"2023-12-13T23:59:59Z\"
+```
+_From ISO string_
+
+```
+end_of_day(`1702483200`) -> end of that day
+```
+_From timestamp_
+
+---
+
+## `epoch_ms`
+
+**Signature:** `-> number`
+
+Current Unix timestamp in milliseconds (alias for now_ms)
+
+```
+epoch_ms() -> 1702483200000
+```
+_Current time in ms_
+
+```
+epoch_ms() / `1000` -> seconds
+```
+_Convert to seconds_
+
+---
+
+## `format_date`
+
+**Signature:** `number, string -> string`
+
+Format timestamp to string
+
+```
+format_date(`1705276800`, '%Y-%m-%d') -> \"2024-01-15\"
+```
+_ISO date format_
+
+```
+format_date(ts, '%B %d, %Y') -> \"January 15, 2024\"
+```
+_Long date format_
+
+---
+
+## `from_epoch`
+
+**Signature:** `number -> string`
+
+Convert Unix timestamp (seconds) to ISO 8601 string
+
+```
+from_epoch(`1702483200`) -> \"2023-12-13T16:00:00Z\"
+```
+_Convert seconds_
+
+```
+from_epoch(`0`) -> \"1970-01-01T00:00:00Z\"
+```
+_Unix epoch_
+
+---
+
+## `from_epoch_ms`
+
+**Signature:** `number -> string`
+
+Convert Unix timestamp (milliseconds) to ISO 8601 string
+
+```
+from_epoch_ms(`1702483200000`) -> \"2023-12-13T16:00:00Z\"
+```
+_From milliseconds_
+
+```
+from_epoch_ms(`0`) -> \"1970-01-01T00:00:00Z\"
+```
+_Unix epoch_
+
+---
+
+## `is_after`
+
+**Signature:** `number|string, number|string -> boolean`
+
+Check if first date is after second date (accepts timestamps or date strings)
+
+```
+is_after('2024-07-15', '2024-01-01') -> true
+```
+_String comparison_
+
+```
+is_after(`1705276800`, `1704067200`) -> true
+```
+_Timestamp comparison_
+
+---
+
+## `is_before`
+
+**Signature:** `number|string, number|string -> boolean`
+
+Check if first date is before second date (accepts timestamps or date strings)
+
+```
+is_before('2024-01-01', '2024-07-15') -> true
+```
+_String comparison_
+
+```
+is_before(`1704067200`, `1705276800`) -> true
+```
+_Timestamp comparison_
+
+---
+
+## `is_between`
+
+**Signature:** `number|string, number|string, number|string -> boolean`
+
+Check if date is between start and end (inclusive, accepts timestamps or date strings)
+
+```
+is_between('2024-06-15', '2024-01-01', '2024-12-31') -> true
+```
+_Within range_
+
+```
+is_between('2023-06-15', '2024-01-01', '2024-12-31') -> false
+```
+_Before range_
+
+---
+
+## `is_same_day`
+
+**Signature:** `number|string, number|string -> boolean`
+
+Check if two timestamps/dates are on the same day
+
+```
+is_same_day('2023-12-13T10:00:00Z', '2023-12-13T23:00:00Z') -> true
+```
+_Same day, different time_
+
+```
+is_same_day('2023-12-13', '2023-12-14') -> false
+```
+_Different days_
+
+---
+
+## `is_weekday`
+
+**Signature:** `number -> boolean`
+
+Check if timestamp falls on weekday (Monday-Friday)
+
+```
+is_weekday(`1705276800`) -> true
+```
+_Monday is weekday_
+
+```
+is_weekday(now()) -> true/false
+```
+_Check current day_
+
+---
+
+## `is_weekend`
+
+**Signature:** `number -> boolean`
+
+Check if timestamp falls on weekend (Saturday or Sunday)
+
+```
+is_weekend(`1705104000`) -> true
+```
+_Saturday is weekend_
+
+```
+is_weekend(now()) -> true/false
+```
+_Check current day_
+
+---
+
+## `parse_date`
+
+**Signature:** `string, string? -> number`
+
+Parse date string to timestamp
+
+```
+parse_date('2024-01-15', '%Y-%m-%d') -> 1705276800
+```
+_ISO date format_
+
+```
+parse_date('01/15/2024', '%m/%d/%Y') -> timestamp
+```
+_US date format_
+
+---
+
+## `parse_datetime`
+
+**Signature:** `string -> string | null`
+
+Parse structured date/time string to ISO 8601 UTC
+
+```
+parse_datetime("2024-01-15") -> "2024-01-15T00:00:00Z"
+```
+_ISO date_
+
+```
+parse_datetime("2024-01-15T10:30:00Z") -> "2024-01-15T10:30:00Z"
+```
+_ISO datetime_
+
+---
+
+## `parse_natural_date`
+
+**Signature:** `string -> string | null`
+
+Parse natural language date expression to ISO 8601 UTC (relative to now)
+
+```
+parse_natural_date("yesterday") -> "2026-01-25T00:00:00Z"
+```
+_Yesterday_
+
+```
+parse_natural_date("tomorrow") -> "2026-01-27T00:00:00Z"
+```
+_Tomorrow_
+
+---
+
+## `quarter`
+
+**Signature:** `number -> number`
+
+Get quarter of year (1-4) from timestamp
+
+```
+quarter(`1713139200`) -> 2
+```
+_April is Q2_
+
+```
+quarter(`1704067200`) -> 1
+```
+_January is Q1_
+
+---
+
+## `relative_time`
+
+**Signature:** `number -> string`
+
+Human-readable relative time from timestamp
+
+```
+relative_time(now() - 3600) -> \"1 hour ago\"
+```
+_One hour ago_
+
+```
+relative_time(now() - 60) -> \"1 minute ago\"
+```
+_One minute ago_
+
+---
+
+## `start_of_day`
+
+**Signature:** `number|string -> string`
+
+Get ISO 8601 string for start of day (00:00:00)
+
+```
+start_of_day('2023-12-13T15:30:00Z') -> \"2023-12-13T00:00:00Z\"
+```
+_From ISO string_
+
+```
+start_of_day(`1702483200`) -> start of that day
+```
+_From timestamp_
+
+---
+
+## `start_of_month`
+
+**Signature:** `number|string -> string`
+
+Get ISO 8601 string for start of month
+
+```
+start_of_month('2023-12-13T15:30:00Z') -> \"2023-12-01T00:00:00Z\"
+```
+_From ISO string_
+
+```
+start_of_month(now()) -> first of month
+```
+_Current month start_
+
+---
+
+## `start_of_week`
+
+**Signature:** `number|string -> string`
+
+Get ISO 8601 string for start of week (Monday 00:00:00)
+
+```
+start_of_week('2023-12-13T15:30:00Z') -> \"2023-12-11T00:00:00Z\"
+```
+_Wednesday to Monday_
+
+```
+start_of_week(now()) -> this Monday
+```
+_Current week start_
+
+---
+
+## `start_of_year`
+
+**Signature:** `number|string -> string`
+
+Get ISO 8601 string for start of year
+
+```
+start_of_year('2023-12-13T15:30:00Z') -> \"2023-01-01T00:00:00Z\"
+```
+_From ISO string_
+
+```
+start_of_year(now()) -> Jan 1st
+```
+_Current year start_
+
+---
+
+## `time_ago`
+
+**Signature:** `number|string -> string`
+
+Human-readable time since date (accepts timestamps or date strings)
+
+```
+time_ago('2020-01-01') -> \"4 years ago\"
+```
+_From date string_
+
+```
+time_ago(now() - 3600) -> \"1 hour ago\"
+```
+_One hour ago_
+
+---
+
+## `timezone_convert`
+
+**Signature:** `string, string, string -> string`
+
+Convert timestamp between timezones (IANA timezone names)
+
+```
+timezone_convert('2024-01-15T10:00:00', 'America/New_York', 'Europe/London') -> \"2024-01-15T15:00:00\"
+```
+_NY to London_
+
+```
+timezone_convert(time, 'UTC', 'America/Los_Angeles') -> PST time
+```
+_UTC to Pacific_
+
+---
+
+## `to_epoch`
+
+**Signature:** `number|string -> number`
+
+Convert date string or timestamp to Unix timestamp (seconds)
+
+```
+to_epoch('2023-12-13T16:00:00Z') -> 1702483200
+```
+_From ISO string_
+
+```
+to_epoch('2024-01-01') -> timestamp
+```
+_From date only_
+
+---
+
+## `to_epoch_ms`
+
+**Signature:** `number|string -> number`
+
+Convert date string or timestamp to Unix timestamp (milliseconds)
+
+```
+to_epoch_ms('2023-12-13T16:00:00Z') -> 1702483200000
+```
+_From ISO string_
+
+```
+to_epoch_ms('2024-01-01') -> timestamp_ms
+```
+_From date only_
+
+---
+

--- a/skills/jpx-functions/references/discovery-functions.md
+++ b/skills/jpx-functions/references/discovery-functions.md
@@ -1,0 +1,56 @@
+# Discovery Functions (3)
+
+## `fuzzy_match`
+
+**Signature:** `string, string -> object`
+
+Check if a single string value matches a query, returning match details
+
+```
+fuzzy_match('get_user', 'get_user') -> {matches: true, score: 1000, match_type: 'exact'}
+```
+_Exact match_
+
+```
+fuzzy_match('get_user_info', 'get') -> {matches: true, score: 800, match_type: 'prefix'}
+```
+_Prefix match_
+
+---
+
+## `fuzzy_score`
+
+**Signature:** `string, string -> number`
+
+Get the numeric match score between a value and query (higher is better match)
+
+```
+fuzzy_score('hello', 'hello') -> 1000
+```
+_Exact match score (highest)_
+
+```
+fuzzy_score('hello_world', 'hello') -> 800
+```
+_Prefix match score_
+
+---
+
+## `fuzzy_search`
+
+**Signature:** `array, string|object, string -> array`
+
+Search an array of objects by multiple fields, returning matches sorted by relevance score
+
+```
+fuzzy_search(tools, 'name,description', 'user') -> [{item: {...}, score: 100, match_type: 'exact', matched_field: 'name'}, ...]
+```
+_Search with comma-separated fields_
+
+```
+fuzzy_search(tools, `{"name": 10, "description": 5}`, 'cache') -> weighted search
+```
+_Search with weighted fields_
+
+---
+

--- a/skills/jpx-functions/references/duration-functions.md
+++ b/skills/jpx-functions/references/duration-functions.md
@@ -1,0 +1,146 @@
+# Duration Functions (8)
+
+## `duration_add`
+
+**Signature:** `string, string -> string`
+
+Add two duration strings
+
+```
+duration_add('1h', '30m') -> \"1h30m\"
+```
+_Add 1 hour and 30 minutes_
+
+```
+duration_add('1d', '12h') -> \"1d12h\"
+```
+_Add 1 day and 12 hours_
+
+---
+
+## `duration_days`
+
+**Signature:** `number -> number`
+
+Get days component from seconds
+
+```
+duration_days(`86400`) -> 1
+```
+_1 day_
+
+```
+duration_days(`90061`) -> 1
+```
+_1 day 1 hour 1 min 1 sec_
+
+---
+
+## `duration_hours`
+
+**Signature:** `number -> number`
+
+Convert seconds to hours
+
+```
+duration_hours(`7200`) -> 2
+```
+_2 hours_
+
+```
+duration_hours(`3600`) -> 1
+```
+_1 hour_
+
+---
+
+## `duration_minutes`
+
+**Signature:** `number -> number`
+
+Convert seconds to minutes
+
+```
+duration_minutes(`120`) -> 2
+```
+_2 minutes_
+
+```
+duration_minutes(`60`) -> 1
+```
+_1 minute_
+
+---
+
+## `duration_seconds`
+
+**Signature:** `number -> number`
+
+Get seconds component
+
+```
+duration_seconds(`65`) -> 5
+```
+_65 seconds mod 60_
+
+```
+duration_seconds(`120`) -> 0
+```
+_Exact minutes_
+
+---
+
+## `duration_subtract`
+
+**Signature:** `string, string -> string`
+
+Subtract second duration string from first
+
+```
+duration_subtract('2h', '30m') -> \"1h30m\"
+```
+_Subtract 30 minutes from 2 hours_
+
+```
+duration_subtract('1h', '1h') -> \"0s\"
+```
+_Equal durations_
+
+---
+
+## `format_duration`
+
+**Signature:** `number -> string`
+
+Format seconds as duration string
+
+```
+format_duration(`5400`) -> \"1h30m\"
+```
+_1.5 hours_
+
+```
+format_duration(`3661`) -> \"1h1m1s\"
+```
+_1 hour 1 min 1 sec_
+
+---
+
+## `parse_duration`
+
+**Signature:** `string -> number`
+
+Parse duration string to seconds
+
+```
+parse_duration('1h30m') -> 5400
+```
+_1.5 hours_
+
+```
+parse_duration('2h') -> 7200
+```
+_2 hours_
+
+---
+

--- a/skills/jpx-functions/references/encoding-functions.md
+++ b/skills/jpx-functions/references/encoding-functions.md
@@ -1,0 +1,182 @@
+# Encoding Functions (10)
+
+## `base64_decode`
+
+**Signature:** `string -> string`
+
+Decode base64 string
+
+```
+base64_decode('aGVsbG8=') -> \"hello\"
+```
+_Decode hello_
+
+```
+base64_decode('dGVzdA==') -> \"test\"
+```
+_Decode test_
+
+---
+
+## `base64_encode`
+
+**Signature:** `string -> string`
+
+Encode string to base64
+
+```
+base64_encode('hello') -> \"aGVsbG8=\"
+```
+_Encode hello_
+
+```
+base64_encode('test') -> \"dGVzdA==\"
+```
+_Encode test_
+
+---
+
+## `base64url_decode`
+
+**Signature:** `string -> string`
+
+Decode base64url (RFC 4648 §5) string
+
+```
+base64url_decode('aGVsbG8') -> \"hello\"
+```
+_Decode hello_
+
+```
+base64url_decode('dGVzdA') -> \"test\"
+```
+_Decode test_
+
+---
+
+## `base64url_encode`
+
+**Signature:** `string -> string`
+
+Encode string to base64url (RFC 4648 §5, no padding)
+
+```
+base64url_encode('hello') -> \"aGVsbG8\"
+```
+_Encode hello_
+
+```
+base64url_encode('test') -> \"dGVzdA\"
+```
+_Encode test_
+
+---
+
+## `hex_decode`
+
+**Signature:** `string -> string`
+
+Decode hex string
+
+```
+hex_decode('68656c6c6f') -> \"hello\"
+```
+_Decode hello_
+
+```
+hex_decode('74657374') -> \"test\"
+```
+_Decode test_
+
+---
+
+## `hex_encode`
+
+**Signature:** `string -> string`
+
+Encode string to hex
+
+```
+hex_encode('hello') -> \"68656c6c6f\"
+```
+_Encode hello_
+
+```
+hex_encode('test') -> \"74657374\"
+```
+_Encode test_
+
+---
+
+## `html_escape`
+
+**Signature:** `string -> string`
+
+Escape HTML special characters
+
+```
+html_escape('<div>') -> \"&lt;div&gt;\"
+```
+_Escape tags_
+
+```
+html_escape('a & b') -> \"a &amp; b\"
+```
+_Escape ampersand_
+
+---
+
+## `html_unescape`
+
+**Signature:** `string -> string`
+
+Unescape HTML entities
+
+```
+html_unescape('&lt;div&gt;') -> \"<div>\"
+```
+_Unescape tags_
+
+```
+html_unescape('a &amp; b') -> \"a & b\"
+```
+_Unescape ampersand_
+
+---
+
+## `jwt_decode`
+
+**Signature:** `string -> object`
+
+Decode JWT payload (claims) without verification
+
+```
+jwt_decode('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyXzEyMyJ9.sig').sub -> \"user_123\"
+```
+_Extract subject claim_
+
+```
+jwt_decode('eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiJ9.sig').name -> 'John'
+```
+_Extract name claim_
+
+---
+
+## `jwt_header`
+
+**Signature:** `string -> object`
+
+Decode JWT header without verification
+
+```
+jwt_header('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig').alg -> \"HS256\"
+```
+_Extract algorithm_
+
+```
+jwt_header('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig').typ -> \"JWT\"
+```
+_Extract type_
+
+---
+

--- a/skills/jpx-functions/references/expression-functions.md
+++ b/skills/jpx-functions/references/expression-functions.md
@@ -1,0 +1,735 @@
+# Expression Functions (41)
+
+## `all_expr`
+
+**Signature:** `array, expression -> boolean`
+
+Return true if every element satisfies the expression (short-circuits on false)
+
+```
+all_expr([1, 2, 3], &@ > `0`) -> true
+```
+_All positive_
+
+```
+all_expr([1, 2, 3], &@ > `2`) -> false
+```
+_Not all > 2_
+
+---
+
+## `any_expr`
+
+**Signature:** `array, expression -> boolean`
+
+Return true if any element satisfies the expression (short-circuits)
+
+```
+any_expr([1, 2, 3], &@ > `2`) -> true
+```
+_At least one > 2_
+
+```
+any_expr([1, 2, 3], &@ > `5`) -> false
+```
+_None > 5_
+
+---
+
+## `apply`
+
+**Signature:** `object|string, ...any -> any`
+
+Apply a partial function or invoke a function by name with arguments
+
+```
+apply(partial('join', `\"-\"`), `[\"a\", \"b\"]`) -> 'a-b' 
+```
+_Apply partial function_
+
+```
+apply('length', 'hello') -> 5
+```
+_Call function by name_
+
+---
+
+## `count_by`
+
+**Signature:** `expref, array -> object`
+
+Count occurrences grouped by expression result
+
+```
+count_by(&type, [{type: 'a'}, {type: 'b'}, {type: 'a'}]) -> {a: 2, b: 1}
+```
+_Count by field_
+
+```
+count_by(&status, orders) -> {pending: 5, shipped: 3}
+```
+_Count orders by status_
+
+---
+
+## `count_expr`
+
+**Signature:** `array, expression -> number`
+
+Count how many elements satisfy the expression
+
+```
+count_expr([1, 2, 3], &@ > `1`) -> 2
+```
+_Count > 1_
+
+```
+count_expr([1, 2, 3], &@ > `5`) -> 0
+```
+_None match_
+
+---
+
+## `dense_rank`
+
+**Signature:** `expref, array -> array`
+
+Assign ranks without gaps for ties (1, 2, 2, 3)
+
+```
+dense_rank(&score, [{"score":90},{"score":85},{"score":90}]) -> [1, 2, 1]
+```
+_Dense rank without gaps_
+
+```
+dense_rank(&@, [3, 1, 2, 1]) -> [1, 3, 2, 3]
+```
+_Dense rank numbers_
+
+---
+
+## `drop_while`
+
+**Signature:** `expref, array -> array`
+
+Drop elements from array while expression is truthy
+
+```
+drop_while(&@ < `4`, [1, 2, 3, 5, 1]) -> [5, 1]
+```
+_Drop while < 4_
+
+```
+drop_while(&@ < `0`, [1, 2, 3]) -> [1, 2, 3]
+```
+_None dropped_
+
+---
+
+## `every`
+
+**Signature:** `expref, array -> boolean`
+
+Check if all elements match (alias for all_expr)
+
+```
+every(&@ > `0`, [1, 2, 3]) -> true
+```
+_All positive_
+
+```
+every(&@ > `2`, [1, 2, 3]) -> false
+```
+_Not all > 2_
+
+---
+
+## `filter_expr`
+
+**Signature:** `array, expression -> array`
+
+Keep elements where JMESPath expression evaluates to truthy value
+
+```
+filter_expr([1, 2, 3], &@ > `1`) -> [2, 3]
+```
+_Filter numbers_
+
+```
+filter_expr(users, &age >= `18`) -> [adult users]
+```
+_Filter objects by field_
+
+---
+
+## `find_expr`
+
+**Signature:** `array, expression -> any`
+
+Return first element where expression is truthy, or null if none match
+
+```
+find_expr([1, 2, 3], &@ > `1`) -> 2
+```
+_First > 1_
+
+```
+find_expr([1, 2, 3], &@ > `5`) -> null
+```
+_None found_
+
+---
+
+## `find_index_expr`
+
+**Signature:** `array, expression -> number | null`
+
+Return zero-based index of first matching element, or -1 if none match
+
+```
+find_index_expr([1, 2, 3], &@ > `1`) -> 1
+```
+_Index of first > 1_
+
+```
+find_index_expr([1, 2, 3], &@ > `5`) -> -1
+```
+_Not found_
+
+---
+
+## `flat_map_expr`
+
+**Signature:** `array, expression -> array`
+
+Apply expression to each element and flatten all results into one array
+
+```
+flat_map_expr([[1], [2]], &@) -> [1, 2]
+```
+_Flatten nested arrays_
+
+```
+flat_map_expr([1, 2], &[@, @ * `2`]) -> [1, 2, 2, 4]
+```
+_Duplicate and transform_
+
+---
+
+## `fold`
+
+**Signature:** `expref, array, any -> any`
+
+Alias for reduce_expr - reduce array to single value using accumulator expression
+
+```
+fold(&add(accumulator, current), [1, 2, 3], `0`) -> 6
+```
+_Sum numbers_
+
+---
+
+## `group_by_expr`
+
+**Signature:** `expression, array -> object`
+
+Group elements into object keyed by expression result (legacy alias, prefer group_by(array, &expr))
+
+```
+group_by_expr(&t, [{t: 'a'}, {t: 'b'}]) -> {a: [...], b: [...]}
+```
+_Group by field_
+
+```
+group_by_expr(&@ > `2`, [1, 2, 3, 4]) -> {true: [3, 4], false: [1, 2]}
+```
+_Group by condition_
+
+---
+
+## `map_expr`
+
+**Signature:** `array, expression -> array`
+
+Apply a JMESPath expression to each element, returning transformed array
+
+```
+map_expr([1, 2], &@ * `2`) -> [2, 4]
+```
+_Double each number_
+
+```
+map_expr(users, &name) -> ['alice', 'bob']
+```
+_Extract field from objects_
+
+---
+
+## `map_keys`
+
+**Signature:** `expref, object -> object`
+
+Transform object keys using expression
+
+```
+map_keys(&upper(@), {a: 1}) -> {A: 1}
+```
+_Uppercase keys_
+
+```
+map_keys(&lower(@), {A: 1, B: 2}) -> {a: 1, b: 2}
+```
+_Lowercase keys_
+
+---
+
+## `map_values`
+
+**Signature:** `expref, object -> object`
+
+Transform object values using expression
+
+```
+map_values(&@ * `2`, {a: 1, b: 2}) -> {a: 2, b: 4}
+```
+_Double values_
+
+```
+map_values(&upper(@), {a: 'x', b: 'y'}) -> {a: 'X', b: 'Y'}
+```
+_Uppercase strings_
+
+---
+
+## `mapcat`
+
+**Signature:** `expref, array -> array`
+
+Apply expression to each element and concatenate all results (Clojure-style alias for flat_map_expr)
+
+```
+mapcat(&tags, [{tags: ['a', 'b']}, {tags: ['c']}]) -> ['a', 'b', 'c']
+```
+_Flatten tags from objects_
+
+```
+mapcat(&@, [[1, 2], [3, 4]]) -> [1, 2, 3, 4]
+```
+_Flatten nested arrays_
+
+---
+
+## `max_by_expr`
+
+**Signature:** `array, expression -> any`
+
+Return element with largest expression result, or null for empty array
+
+```
+max_by_expr([{a: 2}, {a: 1}], &a) -> {a: 2}
+```
+_Max by field_
+
+```
+max_by_expr(['a', 'abc', 'ab'], &length(@)) -> 'abc'
+```
+_Longest string_
+
+---
+
+## `min_by_expr`
+
+**Signature:** `array, expression -> any`
+
+Return element with smallest expression result, or null for empty array
+
+```
+min_by_expr([{a: 2}, {a: 1}], &a) -> {a: 1}
+```
+_Min by field_
+
+```
+min_by_expr(['a', 'abc', 'ab'], &length(@)) -> 'a'
+```
+_Shortest string_
+
+---
+
+## `none`
+
+**Signature:** `expref, array -> boolean`
+
+Return true if no elements satisfy the expression (opposite of any_expr/some)
+
+```
+none(&@ > `5`, [1, 2, 3]) -> true
+```
+_No elements > 5_
+
+```
+none(&@ > `5`, [1, 2, 10]) -> false
+```
+_10 is > 5_
+
+---
+
+## `order_by`
+
+**Signature:** `array, array[[string, string]] -> array`
+
+Sort array by multiple fields with ascending/descending control
+
+```
+order_by(items, [['name', 'asc'], ['price', 'desc']]) -> sorted
+```
+_Multi-field sort_
+
+```
+order_by(users, [['age', 'asc']]) -> youngest first
+```
+_Single field ascending_
+
+---
+
+## `partial`
+
+**Signature:** `string, ...any -> object`
+
+Create a partial function with some arguments pre-filled
+
+```
+partial('contains', `\"hello\"`) -> {__partial__: true, ...}
+```
+_Partial contains_
+
+```
+partial('add', `10`) -> partial add 10
+```
+_Partial addition_
+
+---
+
+## `partition_expr`
+
+**Signature:** `array, expression -> array`
+
+Split array into [matches, non-matches] based on expression
+
+```
+partition_expr([1, 2, 3], &@ > `1`) -> [[2, 3], [1]]
+```
+_Split by condition_
+
+```
+partition_expr([1, 2, 3, 4], &@ % `2` == `0`) -> [[2, 4], [1, 3]]
+```
+_Even vs odd_
+
+---
+
+## `pivot`
+
+**Signature:** `array, expression, expression -> object`
+
+Transform array of objects into object using key/value exprefs
+
+```
+pivot([{"name":"a","v":1},{"name":"b","v":2}], &name, &v) -> {"a": 1, "b": 2}
+```
+_Pivot by name_
+
+```
+pivot([{"k":"x","v":10},{"k":"y","v":20}], &k, &v) -> {"x": 10, "y": 20}
+```
+_Key-value pairs to object_
+
+---
+
+## `rank`
+
+**Signature:** `expref, array -> array`
+
+Assign ranks with gaps for ties (1, 2, 2, 4)
+
+```
+rank(&score, [{"score":90},{"score":85},{"score":90}]) -> [1, 3, 1]
+```
+_Rank with gaps_
+
+```
+rank(&@, [3, 1, 2, 1]) -> [1, 3, 2, 3]
+```
+_Rank numbers_
+
+---
+
+## `recurse`
+
+**Signature:** `any -> array`
+
+Collect all nested values recursively (jq parity)
+
+```
+recurse({a: {b: 1}}) -> [{a: {b: 1}}, {b: 1}, 1]
+```
+_Nested object_
+
+```
+recurse([1, [2, 3]]) -> [[1, [2, 3]], 1, [2, 3], 2, 3]
+```
+_Nested array_
+
+---
+
+## `recurse_with`
+
+**Signature:** `any, expression -> array`
+
+Recursive descent with expression filter (jq parity)
+
+```
+recurse_with({a: {a: 1}}, &a) -> [{a: 1}, 1]
+```
+_Follow 'a' key recursively_
+
+```
+recurse_with([1, [2, [3]]], &[1]) -> [[2, [3]], [3]]
+```
+_Follow index recursively_
+
+---
+
+## `reduce_expr`
+
+**Signature:** `expref, array, any -> any`
+
+Reduce array to single value using accumulator expression
+
+```
+reduce_expr(&add(accumulator, current), [1, 2, 3], `0`) -> 6
+```
+_Sum numbers_
+
+```
+reduce_expr(&multiply(accumulator, current), [2, 3, 4], `1`) -> 24
+```
+_Product_
+
+---
+
+## `reductions`
+
+**Signature:** `expref, array, any -> array`
+
+Return array of intermediate values from reduction (Clojure-style alias for scan_expr)
+
+```
+reductions(&sum([accumulator, current]), [1, 2, 3, 4], `0`) -> [1, 3, 6, 10]
+```
+_Running sum_
+
+```
+reductions(&max([accumulator, current]), [3, 1, 4, 1, 5], `0`) -> [3, 3, 4, 4, 5]
+```
+_Running max_
+
+---
+
+## `reject`
+
+**Signature:** `expref, array -> array`
+
+Keep elements where expression is falsy (inverse of filter_expr)
+
+```
+reject(&@ > `2`, [1, 2, 3, 4]) -> [1, 2]
+```
+_Reject > 2_
+
+```
+reject(&@ < `0`, [1, -1, 2, -2]) -> [1, 2]
+```
+_Reject negatives_
+
+---
+
+## `scan_expr`
+
+**Signature:** `expref, array, any -> array`
+
+Like reduce but returns array of intermediate accumulator values
+
+```
+scan_expr(&add(accumulator, current), [1, 2, 3], `0`) -> [1, 3, 6]
+```
+_Running sum_
+
+```
+scan_expr(&multiply(accumulator, current), [2, 3, 4], `1`) -> [2, 6, 24]
+```
+_Running product_
+
+---
+
+## `some`
+
+**Signature:** `expref, array -> boolean`
+
+Check if any element matches (alias for any_expr)
+
+```
+some(&@ > `2`, [1, 2, 3]) -> true
+```
+_Some > 2_
+
+```
+some(&@ > `5`, [1, 2, 3]) -> false
+```
+_None > 5_
+
+---
+
+## `sort_by_expr`
+
+**Signature:** `array, expression -> array`
+
+Sort array by expression result in ascending order
+
+```
+sort_by_expr([{a: 2}, {a: 1}], &a) -> [{a: 1}, {a: 2}]
+```
+_Sort by field_
+
+```
+sort_by_expr(['bb', 'a', 'ccc'], &length(@)) -> ['a', 'bb', 'ccc']
+```
+_Sort by length_
+
+---
+
+## `take_while`
+
+**Signature:** `expref, array -> array`
+
+Take elements from array while expression is truthy
+
+```
+take_while(&@ < `4`, [1, 2, 3, 5, 1]) -> [1, 2, 3]
+```
+_Take while < 4_
+
+```
+take_while(&@ > `0`, [3, 2, 1, 0, 5]) -> [3, 2, 1]
+```
+_Take while positive_
+
+---
+
+## `unique_by_expr`
+
+**Signature:** `array, expression -> array`
+
+Remove duplicates by expression result, keeping first occurrence
+
+```
+unique_by_expr([{a: 1}, {a: 1}], &a) -> [{a: 1}]
+```
+_Unique by field_
+
+```
+unique_by_expr([{id: 1, v: 'a'}, {id: 1, v: 'b'}], &id) -> [{id: 1, v: 'a'}]
+```
+_First wins_
+
+---
+
+## `unpivot`
+
+**Signature:** `object -> array`
+
+Transform object into array of {key, value} pairs (inverse of pivot)
+
+```
+unpivot({"a": 1, "b": 2}) -> [{"key": "a", "value": 1}, {"key": "b", "value": 2}]
+```
+_Unpivot object_
+
+```
+unpivot({"x": "hello"}) -> [{"key": "x", "value": "hello"}]
+```
+_Single entry_
+
+---
+
+## `until_expr`
+
+**Signature:** `any, expression, expression -> array`
+
+Loop until condition becomes true, collecting intermediate values (jq parity)
+
+```
+until_expr(`1`, &@ >= `5`, &add(@, `1`)) -> [1, 2, 3, 4, 5]
+```
+_Count until >= 5_
+
+```
+until_expr(`2`, &@ >= `100`, &multiply(@, `2`)) -> [2, 4, 8, 16, 32, 64, 128]
+```
+_Double until >= 100_
+
+---
+
+## `walk`
+
+**Signature:** `expref, any -> any`
+
+Recursively apply expression to all components of a value (bottom-up)
+
+```
+walk(&@, data) -> data unchanged
+```
+_Identity transform_
+
+```
+walk(&type(@), {a: 1}) -> 'object'
+```
+_Get type of result_
+
+---
+
+## `while_expr`
+
+**Signature:** `any, expression, expression -> array`
+
+Loop while condition is true, collecting intermediate values (jq parity)
+
+```
+while_expr(`1`, &@ < `5`, &add(@, `1`)) -> [1, 2, 3, 4]
+```
+_Count from 1 while < 5_
+
+```
+while_expr(`2`, &@ < `100`, &multiply(@, `2`)) -> [2, 4, 8, 16, 32, 64]
+```
+_Double while < 100_
+
+---
+
+## `zip_with`
+
+**Signature:** `expref, array, array -> array`
+
+Zip two arrays with a custom combiner expression
+
+```
+zip_with(&add([0], [1]), [1, 2], [10, 20]) -> [11, 22]
+```
+_Add pairs_
+
+```
+zip_with(&multiply([0], [1]), [2, 3], [4, 5]) -> [8, 15]
+```
+_Multiply pairs_
+
+---
+

--- a/skills/jpx-functions/references/format-functions.md
+++ b/skills/jpx-functions/references/format-functions.md
@@ -1,0 +1,110 @@
+# Format Functions (6)
+
+## `from_csv`
+
+**Signature:** `string -> array`
+
+Parse CSV string into array of arrays (jq parity)
+
+```
+from_csv("a,b,c\\n1,2,3") -> [["a", "b", "c"], ["1", "2", "3"]]
+```
+_Basic CSV parsing_
+
+```
+from_csv("\"hello, world\",test") -> [["hello, world", "test"]]
+```
+_Quoted fields with commas_
+
+---
+
+## `from_tsv`
+
+**Signature:** `string -> array`
+
+Parse TSV string into array of arrays (jq parity)
+
+```
+from_tsv("a\\tb\\tc\\n1\\t2\\t3") -> [["a", "b", "c"], ["1", "2", "3"]]
+```
+_Basic TSV parsing_
+
+```
+from_tsv("hello world\\ttest") -> [["hello world", "test"]]
+```
+_Spaces preserved in fields_
+
+---
+
+## `to_csv`
+
+**Signature:** `array -> string`
+
+Convert array to CSV row string (RFC 4180 compliant)
+
+```
+to_csv(['a', 'b', 'c']) -> "a,b,c"
+```
+_Simple strings_
+
+```
+to_csv(['hello', `42`, `true`, `null`]) -> "hello,42,true,"
+```
+_Mixed types_
+
+---
+
+## `to_csv_rows`
+
+**Signature:** `array -> string`
+
+Convert array of arrays to multi-line CSV string
+
+```
+to_csv_rows([[`1`, `2`, `3`], [`4`, `5`, `6`]]) -> "1,2,3\n4,5,6"
+```
+_Numeric rows_
+
+```
+to_csv_rows([['a', 'b'], ['c', 'd']]) -> "a,b\nc,d"
+```
+_String rows_
+
+---
+
+## `to_csv_table`
+
+**Signature:** `array, array? -> string`
+
+Convert array of objects to CSV with header row
+
+```
+to_csv_table([{name: 'alice', age: `30`}]) -> "age,name\n30,alice"
+```
+_Keys sorted alphabetically_
+
+```
+to_csv_table([{name: 'alice', age: `30`}], ['name', 'age']) -> "name,age\nalice,30"
+```
+_Explicit column order_
+
+---
+
+## `to_tsv`
+
+**Signature:** `array -> string`
+
+Convert array to TSV row string (tab-separated)
+
+```
+to_tsv(['a', 'b', 'c']) -> "a\tb\tc"
+```
+_Simple strings_
+
+```
+to_tsv(['hello', `42`, `true`]) -> "hello\t42\ttrue"
+```
+_Mixed types_
+
+---
+

--- a/skills/jpx-functions/references/fuzzy-functions.md
+++ b/skills/jpx-functions/references/fuzzy-functions.md
@@ -1,0 +1,164 @@
+# Fuzzy Functions (9)
+
+## `damerau_levenshtein`
+
+**Signature:** `string, string -> number`
+
+Damerau-Levenshtein distance
+
+```
+damerau_levenshtein('ab', 'ba') -> 1
+```
+_Single transposition_
+
+```
+damerau_levenshtein('hello', 'hello') -> 0
+```
+_Identical strings_
+
+---
+
+## `hamming`
+
+**Signature:** `string, string -> number|null`
+
+Hamming distance (number of differing positions). Returns null if strings have different lengths
+
+```
+hamming('karolin', 'kathrin') -> 3
+```
+_Three differing positions_
+
+```
+hamming('hello', 'hello') -> 0
+```
+_Identical strings_
+
+---
+
+## `jaro`
+
+**Signature:** `string, string -> number`
+
+Jaro similarity (0-1)
+
+```
+jaro('hello', 'hallo') -> 0.866...
+```
+_Similar words_
+
+```
+jaro('hello', 'hello') -> 1.0
+```
+_Identical strings_
+
+---
+
+## `jaro_winkler`
+
+**Signature:** `string, string -> number`
+
+Jaro-Winkler similarity (0-1)
+
+```
+jaro_winkler('hello', 'hallo') -> 0.88
+```
+_Similar words_
+
+```
+jaro_winkler('hello', 'hello') -> 1.0
+```
+_Identical strings_
+
+---
+
+## `levenshtein`
+
+**Signature:** `string, string -> number`
+
+Levenshtein edit distance
+
+```
+levenshtein('kitten', 'sitting') -> 3
+```
+_Classic example_
+
+```
+levenshtein('hello', 'hello') -> 0
+```
+_Identical strings_
+
+---
+
+## `normalized_damerau_levenshtein`
+
+**Signature:** `string, string -> number`
+
+Normalized Damerau-Levenshtein similarity (0-1)
+
+```
+normalized_damerau_levenshtein('hello', 'hello') -> 1.0
+```
+_Identical strings_
+
+```
+normalized_damerau_levenshtein('ab', 'ba') -> 0.5
+```
+_Transposition_
+
+---
+
+## `normalized_levenshtein`
+
+**Signature:** `string, string -> number`
+
+Normalized Levenshtein (0-1)
+
+```
+normalized_levenshtein('ab', 'abc') -> 0.666...
+```
+_One edit_
+
+```
+normalized_levenshtein('hello', 'hello') -> 0.0
+```
+_Identical_
+
+---
+
+## `osa_distance`
+
+**Signature:** `string, string -> number`
+
+Optimal String Alignment distance (like Levenshtein but allows adjacent transpositions)
+
+```
+osa_distance('ab', 'ba') -> 1
+```
+_Single transposition_
+
+```
+osa_distance('hello', 'hello') -> 0
+```
+_Identical strings_
+
+---
+
+## `sorensen_dice`
+
+**Signature:** `string, string -> number`
+
+Sorensen-Dice coefficient (0-1)
+
+```
+sorensen_dice('night', 'nacht') -> 0.25
+```
+_Similar words_
+
+```
+sorensen_dice('hello', 'hello') -> 1.0
+```
+_Identical strings_
+
+---
+

--- a/skills/jpx-functions/references/geo-functions.md
+++ b/skills/jpx-functions/references/geo-functions.md
@@ -1,0 +1,167 @@
+# Geo Functions (10)
+
+## `geo_bearing`
+
+**Signature:** `number, number, number, number -> number`
+
+Bearing between coordinates
+
+```
+geo_bearing(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`) -> 51.2
+```
+_NYC to London_
+
+```
+geo_bearing(`0`, `0`, `0`, `90`) -> 90.0
+```
+_Due east_
+
+---
+
+## `geo_bounding_box`
+
+**Signature:** `array -> object`
+
+Bounding box from an array of [lat, lon] points
+
+```
+geo_bounding_box(`[[40.7, -74.0], [34.0, -118.2]]`) -> {"max_lat": 40.7, "max_lon": -74.0, "min_lat": 34.0, "min_lon": -118.2}
+```
+_NYC and LA bounding box_
+
+---
+
+## `geo_distance`
+
+**Signature:** `number, number, number, number -> number`
+
+Haversine distance in meters
+
+```
+geo_distance(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`) -> 5570222
+```
+_NYC to London_
+
+```
+geo_distance(`34.0522`, `-118.2437`, `37.7749`, `-122.4194`) -> 559044
+```
+_LA to SF_
+
+---
+
+## `geo_distance_km`
+
+**Signature:** `number, number, number, number -> number`
+
+Haversine distance in kilometers
+
+```
+geo_distance_km(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`) -> 5570.2
+```
+_NYC to London_
+
+```
+geo_distance_km(`34.0522`, `-118.2437`, `37.7749`, `-122.4194`) -> 559.0
+```
+_LA to SF_
+
+---
+
+## `geo_distance_miles`
+
+**Signature:** `number, number, number, number -> number`
+
+Haversine distance in miles
+
+```
+geo_distance_miles(`40.7128`, `-74.0060`, `51.5074`, `-0.1278`) -> 3461.0
+```
+_NYC to London_
+
+```
+geo_distance_miles(`34.0522`, `-118.2437`, `37.7749`, `-122.4194`) -> 347.4
+```
+_LA to SF_
+
+---
+
+## `geo_in_bbox`
+
+**Signature:** `number, number, number, number, number, number -> boolean`
+
+Check if a point is inside a bounding box
+
+```
+geo_in_bbox(`40.0`, `-75.0`, `39.0`, `41.0`, `-76.0`, `-74.0`) -> true
+```
+_Point inside box_
+
+```
+geo_in_bbox(`42.0`, `-75.0`, `39.0`, `41.0`, `-76.0`, `-74.0`) -> false
+```
+_Point outside box_
+
+---
+
+## `geo_in_radius`
+
+**Signature:** `number, number, number, number, number -> boolean`
+
+Check if a point is within a radius (km) of a center point
+
+```
+geo_in_radius(`40.758`, `-73.985`, `40.748`, `-73.986`, `2`) -> true
+```
+_Times Square within 2km of Empire State_
+
+```
+geo_in_radius(`34.052`, `-118.244`, `40.713`, `-74.006`, `100`) -> false
+```
+_LA not within 100km of NYC_
+
+---
+
+## `geo_midpoint`
+
+**Signature:** `array -> array`
+
+Geographic midpoint of an array of [lat, lon] points
+
+```
+geo_midpoint(`[[0, 0], [0, 90]]`) -> [0.0, 45.0]
+```
+_Midpoint on equator_
+
+---
+
+## `geohash_decode`
+
+**Signature:** `string -> object`
+
+Decode a geohash string to {lat, lon}
+
+```
+geohash_decode('dr5ru7') -> {"lat": 40.71, "lon": -73.99}
+```
+_Decode NYC geohash_
+
+---
+
+## `geohash_encode`
+
+**Signature:** `number, number[, number] -> string`
+
+Encode lat/lon as a geohash string with optional precision (default 12)
+
+```
+geohash_encode(`40.7128`, `-74.0060`) -> "dr5ru6j1yz56"
+```
+_Encode NYC coordinates_
+
+```
+geohash_encode(`40.7128`, `-74.0060`, `5`) -> "dr5ru"
+```
+_Encode with precision 5_
+
+---
+

--- a/skills/jpx-functions/references/hash-functions.md
+++ b/skills/jpx-functions/references/hash-functions.md
@@ -1,0 +1,164 @@
+# Hash Functions (9)
+
+## `crc32`
+
+**Signature:** `string -> number`
+
+Calculate CRC32 checksum
+
+```
+crc32('hello') -> 907060870
+```
+_Simple string_
+
+```
+crc32('') -> 0
+```
+_Empty string_
+
+---
+
+## `hmac_md5`
+
+**Signature:** `string, string -> string`
+
+Calculate HMAC-MD5 signature
+
+```
+hmac_md5('hello', 'secret') -> \"e17e4e4a205c55782dce5b6ff41e6e19\"
+```
+_With secret key_
+
+```
+hmac_md5('message', 'key') -> \"a24c903c3a7e7b741ea77bd467b98bca\"
+```
+_Different message_
+
+---
+
+## `hmac_sha1`
+
+**Signature:** `string, string -> string`
+
+Calculate HMAC-SHA1 signature
+
+```
+hmac_sha1('hello', 'secret') -> \"5112055c36b16a6693045d75a054332e4555b52f\"
+```
+_With secret key_
+
+```
+hmac_sha1('data', 'key') -> \"104152c5bfdca07bc633eebd46199f0255c9f49d\"
+```
+_Different data_
+
+---
+
+## `hmac_sha256`
+
+**Signature:** `string, string -> string`
+
+Calculate HMAC-SHA256 signature
+
+```
+hmac_sha256('hello', 'secret') -> \"88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b\"
+```
+_With secret key_
+
+```
+hmac_sha256('data', 'key') -> \"5031fe3d989c6d1537a013fa6e739da23463fdaec3b70137d828e36ace221bd0\"
+```
+_Different data_
+
+---
+
+## `hmac_sha512`
+
+**Signature:** `string, string -> string`
+
+Calculate HMAC-SHA512 signature
+
+```
+hmac_sha512('hello', 'secret') -> \"d05888a20ae...\"
+```
+_With secret key_
+
+```
+hmac_sha512('data', 'key') -> \"3c5953a18...\"
+```
+_Different data_
+
+---
+
+## `md5`
+
+**Signature:** `string -> string`
+
+Calculate MD5 hash
+
+```
+md5('hello') -> \"5d41402abc4b2a76b9719d911017c592\"
+```
+_Simple string_
+
+```
+md5('') -> \"d41d8cd98f00b204e9800998ecf8427e\"
+```
+_Empty string_
+
+---
+
+## `sha1`
+
+**Signature:** `string -> string`
+
+Calculate SHA-1 hash
+
+```
+sha1('hello') -> \"aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d\"
+```
+_Simple string_
+
+```
+sha1('') -> \"da39a3ee5e6b4b0d3255bfef95601890afd80709\"
+```
+_Empty string_
+
+---
+
+## `sha256`
+
+**Signature:** `string -> string`
+
+Calculate SHA-256 hash
+
+```
+sha256('hello') -> \"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\"
+```
+_Simple string_
+
+```
+sha256('') -> \"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"
+```
+_Empty string_
+
+---
+
+## `sha512`
+
+**Signature:** `string -> string`
+
+Calculate SHA-512 hash
+
+```
+sha512('hello') -> \"9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043\"
+```
+_Simple string_
+
+```
+sha512('test') -> \"ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff\"
+```
+_Another string_
+
+---
+

--- a/skills/jpx-functions/references/ids-functions.md
+++ b/skills/jpx-functions/references/ids-functions.md
@@ -1,0 +1,56 @@
+# Ids Functions (3)
+
+## `nanoid`
+
+**Signature:** `number? -> string`
+
+Generate nanoid
+
+```
+nanoid() -> \"V1StGXR8_Z5jdHi6B-myT\"
+```
+_Default 21 chars_
+
+```
+nanoid(`10`) -> \"IRFa-VaY2b\"
+```
+_Custom length_
+
+---
+
+## `ulid`
+
+**Signature:** `-> string`
+
+Generate ULID
+
+```
+ulid() -> \"01ARZ3NDEKTSV4RRFFQ69G5FAV\"
+```
+_Generate ULID_
+
+```
+length(ulid()) -> 26
+```
+_Always 26 chars_
+
+---
+
+## `ulid_timestamp`
+
+**Signature:** `string -> number`
+
+Extract timestamp from ULID
+
+```
+ulid_timestamp('01ARZ3NDEKTSV4RRFFQ69G5FAV') -> 1469918176385
+```
+_Extract timestamp_
+
+```
+ulid_timestamp('01BX5ZZKBKACTAV9WEVGEMMVRY') -> 1484581420610
+```
+_Another ULID_
+
+---
+

--- a/skills/jpx-functions/references/jsonpatch-functions.md
+++ b/skills/jpx-functions/references/jsonpatch-functions.md
@@ -1,0 +1,56 @@
+# Jsonpatch Functions (3)
+
+## `json_diff`
+
+**Signature:** `object, object -> array`
+
+Generate JSON Patch (RFC 6902) that transforms first object into second
+
+```
+json_diff({a: 1}, {a: 2}) -> [{op: 'replace', path: '/a', value: 2}]
+```
+_Replace value_
+
+```
+json_diff({a: 1}, {a: 1, b: 2}) -> [{op: 'add', path: '/b', value: 2}]
+```
+_Add field_
+
+---
+
+## `json_merge_patch`
+
+**Signature:** `object, object -> object`
+
+Apply JSON Merge Patch (RFC 7396) to an object
+
+```
+json_merge_patch({a: 1, b: 2}, {b: 3, c: 4}) -> {a: 1, b: 3, c: 4}
+```
+_Merge objects_
+
+```
+json_merge_patch({a: 1}, {a: `null`}) -> {}
+```
+_Null removes field_
+
+---
+
+## `json_patch`
+
+**Signature:** `object, array -> object`
+
+Apply JSON Patch (RFC 6902) operations to an object
+
+```
+json_patch({a: 1}, [{op: 'add', path: '/b', value: 2}]) -> {a: 1, b: 2}
+```
+_Add operation_
+
+```
+json_patch({a: 1}, [{op: 'replace', path: '/a', value: 2}]) -> {a: 2}
+```
+_Replace operation_
+
+---
+

--- a/skills/jpx-functions/references/language-functions.md
+++ b/skills/jpx-functions/references/language-functions.md
@@ -1,0 +1,92 @@
+# Language Functions (5)
+
+## `detect_language`
+
+**Signature:** `string -> string | null`
+
+Detect the language of text, returning the native language name
+
+```
+detect_language('This is English text.') -> \"English\"
+```
+_Detect English_
+
+```
+detect_language('Esto es texto en español.') -> \"Español\"
+```
+_Detect Spanish (native name)_
+
+---
+
+## `detect_language_confidence`
+
+**Signature:** `string -> number | null`
+
+Detect language and return confidence score (0.0-1.0)
+
+```
+detect_language_confidence('This is definitely English text.') -> 0.95
+```
+_High confidence_
+
+```
+detect_language_confidence('Hi') -> 0.3
+```
+_Low confidence for short text_
+
+---
+
+## `detect_language_info`
+
+**Signature:** `string -> object | null`
+
+Detect language and return full detection info object
+
+```
+detect_language_info('This is a test.') -> {language: 'English', code: 'eng', script: 'Latin', confidence: 0.9, reliable: true}
+```
+_Full detection info_
+
+```
+detect_language_info('Bonjour').language -> 'French'
+```
+_Access language field_
+
+---
+
+## `detect_language_iso`
+
+**Signature:** `string -> string | null`
+
+Detect the language of text, returning the ISO 639-3 code
+
+```
+detect_language_iso('This is English text.') -> \"eng\"
+```
+_English ISO code_
+
+```
+detect_language_iso('Esto es texto en español.') -> \"spa\"
+```
+_Spanish ISO code_
+
+---
+
+## `detect_script`
+
+**Signature:** `string -> string | null`
+
+Detect the script (writing system) of text
+
+```
+detect_script('Hello world') -> \"Latin\"
+```
+_Latin script_
+
+```
+detect_script('Привет мир') -> \"Cyrillic\"
+```
+_Cyrillic script_
+
+---
+

--- a/skills/jpx-functions/references/math-functions.md
+++ b/skills/jpx-functions/references/math-functions.md
@@ -1,0 +1,758 @@
+# Math Functions (42)
+
+## `abs_fn`
+
+**Signature:** `number -> number`
+
+Absolute value
+
+```
+abs_fn(`-5`) -> 5
+```
+_Negative to positive_
+
+```
+abs_fn(`5`) -> 5
+```
+_Already positive_
+
+---
+
+## `add`
+
+**Signature:** `number, number -> number`
+
+Add two numbers
+
+```
+add(`2`, `3`) -> 5
+```
+_Add integers_
+
+```
+add(`1.5`, `2.5`) -> 4.0
+```
+_Add floats_
+
+---
+
+## `ceil_fn`
+
+**Signature:** `number -> number`
+
+Round up to nearest integer
+
+```
+ceil_fn(`3.2`) -> 4
+```
+_Round up fraction_
+
+```
+ceil_fn(`3.9`) -> 4
+```
+_Round up high fraction_
+
+---
+
+## `clamp`
+
+**Signature:** `number, number, number -> number`
+
+Clamp value to range
+
+```
+clamp(`15`, `0`, `10`) -> 10
+```
+_Above max_
+
+```
+clamp(`-5`, `0`, `10`) -> 0
+```
+_Below min_
+
+---
+
+## `correlation`
+
+**Signature:** `array, array -> number`
+
+Compute Pearson correlation coefficient between two arrays
+
+```
+correlation([1, 2, 3], [1, 2, 3]) -> 1.0
+```
+_Perfect positive_
+
+```
+correlation([1, 2, 3], [3, 2, 1]) -> -1.0
+```
+_Perfect negative_
+
+---
+
+## `cos`
+
+**Signature:** `number -> number`
+
+Cosine function
+
+```
+cos(`0`) -> 1
+```
+_Cos of 0_
+
+```
+cos(`3.14159`) -> -1
+```
+_Cos of pi_
+
+---
+
+## `covariance`
+
+**Signature:** `array, array -> number`
+
+Covariance between two arrays
+
+```
+covariance([1, 2, 3], [1, 2, 3]) -> 0.666...
+```
+_Perfect positive_
+
+```
+covariance([1, 2, 3], [3, 2, 1]) -> -0.666...
+```
+_Perfect negative_
+
+---
+
+## `cumulative_sum`
+
+**Signature:** `array -> array`
+
+Calculate running cumulative sum of a numeric array
+
+```
+cumulative_sum([1, 2, 3, 4]) -> [1, 3, 6, 10]
+```
+_Running total_
+
+```
+cumulative_sum([10, -5, 3]) -> [10, 5, 8]
+```
+_With negatives_
+
+---
+
+## `divide`
+
+**Signature:** `number, number -> number`
+
+Divide first number by second
+
+```
+divide(`10`, `2`) -> 5
+```
+_Integer division_
+
+```
+divide(`7`, `2`) -> 3.5
+```
+_Fractional result_
+
+---
+
+## `ewma`
+
+**Signature:** `array, number -> array`
+
+Exponential weighted moving average
+
+```
+ewma([1, 2, 3, 4, 5], `0.5`) -> [1, 1.5, 2.25, ...]
+```
+_Alpha 0.5_
+
+```
+ewma(prices, `0.3`) -> smoothed prices
+```
+_Smooth stock prices_
+
+---
+
+## `floor_fn`
+
+**Signature:** `number -> number`
+
+Round down to nearest integer
+
+```
+floor_fn(`3.7`) -> 3
+```
+_Round down high fraction_
+
+```
+floor_fn(`3.2`) -> 3
+```
+_Round down low fraction_
+
+---
+
+## `format_number`
+
+**Signature:** `number, number?, string? -> string`
+
+Format number with separators and optional suffix
+
+```
+format_number(`1234567`, `0`) -> \"1,234,567\"
+```
+_With commas_
+
+```
+format_number(`1234.56`, `2`) -> \"1,234.56\"
+```
+_With decimals_
+
+---
+
+## `histogram`
+
+**Signature:** `array, number -> array[object]`
+
+Compute histogram bins for an array of numbers
+
+```
+histogram([1, 2, 3, 4, 5], `3`) -> [{min: 1.0, max: 2.33, count: 2}, ...]
+```
+_3 bins_
+
+```
+histogram([10, 20, 30], `2`) -> [{min: 10.0, max: 20.0, count: 2}, {min: 20.0, max: 30.0, count: 1}]
+```
+_2 bins_
+
+---
+
+## `kurtosis`
+
+**Signature:** `array -> number`
+
+Excess kurtosis (measure of tailedness) of a numeric array (normal distribution = 0)
+
+```
+kurtosis([1, 2, 3, 4, 5]) -> -1.3
+```
+_Platykurtic (light tails)_
+
+```
+kurtosis([1, 1, 5, 5]) -> -2.0
+```
+_Uniform-like distribution_
+
+---
+
+## `log`
+
+**Signature:** `number -> number`
+
+Natural logarithm
+
+```
+log(`2.718`) -> ~1
+```
+_Log of e_
+
+```
+log(`1`) -> 0
+```
+_Log of 1_
+
+---
+
+## `mad`
+
+**Signature:** `array -> number`
+
+Median absolute deviation (robust measure of variability)
+
+```
+mad([1, 2, 3, 4, 5]) -> 1.0
+```
+_MAD of simple array_
+
+```
+mad([1, 1, 1, 100]) -> 0.0
+```
+_MAD with outlier_
+
+---
+
+## `median`
+
+**Signature:** `array -> number`
+
+Calculate median of array
+
+```
+median([1, 2, 3, 4, 5]) -> 3
+```
+_Odd count_
+
+```
+median([1, 2, 3, 4]) -> 2.5
+```
+_Even count_
+
+---
+
+## `mod_fn`
+
+**Signature:** `number, number -> number`
+
+Modulo operation
+
+```
+mod_fn(`10`, `3`) -> 1
+```
+_Remainder of 10/3_
+
+```
+mod_fn(`15`, `5`) -> 0
+```
+_Evenly divisible_
+
+---
+
+## `mode`
+
+**Signature:** `array -> any`
+
+Find the most common value in an array
+
+```
+mode([1, 2, 2, 3]) -> 2
+```
+_Most frequent_
+
+```
+mode(['a', 'b', 'a', 'a']) -> 'a'
+```
+_String mode_
+
+---
+
+## `moving_avg`
+
+**Signature:** `array, number -> array`
+
+Simple moving average with window size
+
+```
+moving_avg([1, 2, 3, 4, 5], `3`) -> [null, null, 2, 3, 4]
+```
+_Window of 3_
+
+```
+moving_avg([10, 20, 30, 40], `2`) -> [null, 15, 25, 35]
+```
+_Window of 2_
+
+---
+
+## `multiply`
+
+**Signature:** `number, number -> number`
+
+Multiply two numbers
+
+```
+multiply(`4`, `3`) -> 12
+```
+_Basic multiplication_
+
+```
+multiply(`2.5`, `4`) -> 10
+```
+_With decimals_
+
+---
+
+## `normalize`
+
+**Signature:** `array -> array`
+
+Min-max normalize an array of numbers to [0, 1] range
+
+```
+normalize([1, 3, 5]) -> [0.0, 0.5, 1.0]
+```
+_Basic normalization_
+
+```
+normalize([10, 10, 10]) -> [0, 0, 0]
+```
+_All same values_
+
+---
+
+## `outliers_iqr`
+
+**Signature:** `array, number? -> array`
+
+Find outliers using IQR method (values outside Q1-1.5*IQR to Q3+1.5*IQR)
+
+```
+outliers_iqr([1, 2, 3, 4, 100]) -> [100]
+```
+_Detect outlier_
+
+```
+outliers_iqr([1, 2, 3, 4, 5]) -> []
+```
+_No outliers_
+
+---
+
+## `outliers_zscore`
+
+**Signature:** `array, number? -> array`
+
+Find outliers using z-score method (values with |z-score| > threshold)
+
+```
+outliers_zscore([1, 2, 3, 4, 100]) -> [100]
+```
+_Detect outlier_
+
+```
+outliers_zscore([1, 2, 3, 4, 5]) -> []
+```
+_No outliers_
+
+---
+
+## `percentile`
+
+**Signature:** `array, number -> number`
+
+Calculate percentile of array
+
+```
+percentile([1, 2, 3, 4, 5], `50`) -> 3
+```
+_50th percentile (median)_
+
+```
+percentile([1, 2, 3, 4, 5], `25`) -> 2
+```
+_25th percentile_
+
+---
+
+## `pow`
+
+**Signature:** `number, number -> number`
+
+Raise to power
+
+```
+pow(`2`, `3`) -> 8
+```
+_2 cubed_
+
+```
+pow(`10`, `2`) -> 100
+```
+_10 squared_
+
+---
+
+## `quantile`
+
+**Signature:** `array, number -> number`
+
+Nth quantile (generalized percentile, q in [0,1])
+
+```
+quantile([1, 2, 3, 4, 5], `0.5`) -> 3
+```
+_Median (0.5)_
+
+```
+quantile([1, 2, 3, 4, 5], `0.25`) -> 2
+```
+_First quartile_
+
+---
+
+## `quartiles`
+
+**Signature:** `array -> object`
+
+Calculate quartiles (Q1, Q2, Q3) and IQR of array
+
+```
+quartiles([1, 2, 3, 4, 5]) -> {min: 1, q1: 2, q2: 3, q3: 4, max: 5, iqr: 2}
+```
+_Basic quartiles_
+
+```
+quartiles([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).iqr -> 4.5
+```
+_Get IQR_
+
+---
+
+## `rate_of_change`
+
+**Signature:** `array -> array`
+
+Calculate percentage change between consecutive values
+
+```
+rate_of_change([100, 110, 121]) -> [10.0, 10.0]
+```
+_10% growth_
+
+```
+rate_of_change([100, 50, 25]) -> [-50.0, -50.0]
+```
+_50% decline_
+
+---
+
+## `round`
+
+**Signature:** `number, number -> number`
+
+Round to specified decimal places
+
+```
+round(`3.14159`, `2`) -> 3.14
+```
+_Two decimals_
+
+```
+round(`3.5`, `0`) -> 4
+```
+_Round to integer_
+
+---
+
+## `sin`
+
+**Signature:** `number -> number`
+
+Sine function
+
+```
+sin(`0`) -> 0
+```
+_Sin of 0_
+
+```
+sin(`1.5708`) -> 1
+```
+_Sin of pi/2_
+
+---
+
+## `skew`
+
+**Signature:** `array -> number`
+
+Skewness (measure of asymmetry) of a numeric array using Fisher-Pearson coefficient
+
+```
+skew([1, 2, 3, 4, 5]) -> 0.0
+```
+_Symmetric distribution_
+
+```
+skew([1, 1, 1, 10]) -> 1.15...
+```
+_Right-skewed_
+
+---
+
+## `sqrt`
+
+**Signature:** `number -> number`
+
+Square root
+
+```
+sqrt(`16`) -> 4
+```
+_Perfect square_
+
+```
+sqrt(`2`) -> 1.414...
+```
+_Irrational result_
+
+---
+
+## `standardize`
+
+**Signature:** `array -> array`
+
+Standardize array to mean=0, std=1 (z-score normalization)
+
+```
+standardize([10, 20, 30]) -> [-1.22, 0, 1.22]
+```
+_Basic z-scores_
+
+```
+standardize([1, 2, 3, 4, 5]) -> normalized
+```
+_Normalize values_
+
+---
+
+## `stddev`
+
+**Signature:** `array -> number`
+
+Calculate standard deviation of array
+
+```
+stddev([1, 2, 3, 4, 5]) -> 1.414...
+```
+_Basic stddev_
+
+```
+stddev([10, 10, 10]) -> 0
+```
+_No variation_
+
+---
+
+## `subtract`
+
+**Signature:** `number, number -> number`
+
+Subtract second number from first
+
+```
+subtract(`5`, `3`) -> 2
+```
+_Basic subtraction_
+
+```
+subtract(`10`, `15`) -> -5
+```
+_Negative result_
+
+---
+
+## `tan`
+
+**Signature:** `number -> number`
+
+Tangent function
+
+```
+tan(`0`) -> 0
+```
+_Tan of 0_
+
+```
+tan(`0.7854`) -> ~1
+```
+_Tan of pi/4_
+
+---
+
+## `to_fixed`
+
+**Signature:** `number, number -> string`
+
+Format number with exact decimal places
+
+```
+to_fixed(`3.14159`, `2`) -> \"3.14\"
+```
+_Two decimals_
+
+```
+to_fixed(`5`, `2`) -> \"5.00\"
+```
+_Pad with zeros_
+
+---
+
+## `trend`
+
+**Signature:** `array -> string`
+
+Detect trend direction in a numeric array (increasing, decreasing, or stable)
+
+```
+trend([1, 2, 3, 4, 5]) -> "increasing"
+```
+_Upward trend_
+
+```
+trend([5, 4, 3, 2, 1]) -> "decreasing"
+```
+_Downward trend_
+
+---
+
+## `trend_slope`
+
+**Signature:** `array -> number`
+
+Calculate the linear regression slope of a numeric array
+
+```
+trend_slope([1, 2, 3, 4, 5]) -> 1.0
+```
+_Perfect linear increase_
+
+```
+trend_slope([5, 4, 3, 2, 1]) -> -1.0
+```
+_Perfect linear decrease_
+
+---
+
+## `variance`
+
+**Signature:** `array -> number`
+
+Calculate variance of array
+
+```
+variance([1, 2, 3, 4, 5]) -> 2
+```
+_Basic variance_
+
+```
+variance([10, 10, 10]) -> 0
+```
+_No variation_
+
+---
+
+## `z_score`
+
+**Signature:** `array -> array`
+
+Compute z-scores (standard scores) for an array of numbers
+
+```
+z_score([1, 3, 5]) -> [-1.22, 0.0, 1.22]
+```
+_Basic z-scores_
+
+```
+z_score([10, 20, 30])[1] -> 0.0
+```
+_Middle value is 0_
+
+---
+

--- a/skills/jpx-functions/references/multimatch-functions.md
+++ b/skills/jpx-functions/references/multimatch-functions.md
@@ -1,0 +1,182 @@
+# Multimatch Functions (10)
+
+## `extract_all`
+
+**Signature:** `string, array[string] -> array[object]`
+
+Extract all pattern matches with positions (Aho-Corasick)
+
+```
+extract_all('error warning', ['error', 'warning']) -> [{pattern: 'error', match: 'error', start: 0, end: 5}, ...]
+```
+_Multiple patterns_
+
+```
+extract_all('abab', ['a', 'b']) -> [{pattern: 'a', match: 'a', start: 0, end: 1}, ...]
+```
+_Overlapping matches_
+
+---
+
+## `extract_between`
+
+**Signature:** `string, string, string -> string|null`
+
+Extract text between two delimiters
+
+```
+extract_between('<title>Page</title>', '<title>', '</title>') -> \"Page\"
+```
+_HTML tag content_
+
+```
+extract_between('Hello [world]!', '[', ']') -> \"world\"
+```
+_Bracketed content_
+
+---
+
+## `match_all`
+
+**Signature:** `string, array[string] -> boolean`
+
+Check if string contains all of the patterns (Aho-Corasick)
+
+```
+match_all('hello world', ['hello', 'world']) -> true
+```
+_All patterns found_
+
+```
+match_all('hello world', ['hello', 'foo']) -> false
+```
+_Missing pattern_
+
+---
+
+## `match_any`
+
+**Signature:** `string, array[string] -> boolean`
+
+Check if string contains any of the patterns (Aho-Corasick)
+
+```
+match_any('hello world', ['world', 'foo']) -> true
+```
+_One pattern found_
+
+```
+match_any('hello world', ['foo', 'bar']) -> false
+```
+_No patterns found_
+
+---
+
+## `match_count`
+
+**Signature:** `string, array[string] -> number`
+
+Count total pattern matches in string (Aho-Corasick)
+
+```
+match_count('abcabc', ['a', 'b']) -> 4
+```
+_Count all matches_
+
+```
+match_count('hello', ['l']) -> 2
+```
+_Repeated pattern_
+
+---
+
+## `match_positions`
+
+**Signature:** `string, array[string] -> array[object]`
+
+Get start/end positions of all pattern matches (Aho-Corasick)
+
+```
+match_positions('The quick fox', ['quick', 'fox']) -> [{pattern: 'quick', start: 4, end: 9}, ...]
+```
+_Find positions_
+
+```
+match_positions('abab', ['ab']) -> [{pattern: 'ab', start: 0, end: 2}, {pattern: 'ab', start: 2, end: 4}]
+```
+_Multiple occurrences_
+
+---
+
+## `match_which`
+
+**Signature:** `string, array[string] -> array[string]`
+
+Return array of patterns that match the string (Aho-Corasick)
+
+```
+match_which('hello world', ['hello', 'foo', 'world']) -> [\"hello\", \"world\"]
+```
+_Find matching patterns_
+
+```
+match_which('abc', ['a', 'b', 'x']) -> [\"a\", \"b\"]
+```
+_Partial matches_
+
+---
+
+## `mm_tokenize`
+
+**Signature:** `string, object? -> array[string]`
+
+Smart word tokenization with optional lowercase and min_length
+
+```
+mm_tokenize('Hello, World!') -> [\"Hello\", \"World\"]
+```
+_Basic tokenization_
+
+```
+mm_tokenize('Hello, World!', {lowercase: `true`}) -> [\"hello\", \"world\"]
+```
+_Lowercase option_
+
+---
+
+## `replace_many`
+
+**Signature:** `string, object -> string`
+
+Replace multiple patterns simultaneously (Aho-Corasick)
+
+```
+replace_many('hello world', {hello: 'hi', world: 'earth'}) -> \"hi earth\"
+```
+_Multiple replacements_
+
+```
+replace_many('aaa', {a: 'b'}) -> \"bbb\"
+```
+_Repeated pattern_
+
+---
+
+## `split_keep`
+
+**Signature:** `string, string -> array[string]`
+
+Split string keeping delimiters in result
+
+```
+split_keep('a-b-c', '-') -> [\"a\", \"-\", \"b\", \"-\", \"c\"]
+```
+_Keep dashes_
+
+```
+split_keep('hello world', ' ') -> [\"hello\", \" \", \"world\"]
+```
+_Keep spaces_
+
+---
+

--- a/skills/jpx-functions/references/network-functions.md
+++ b/skills/jpx-functions/references/network-functions.md
@@ -1,0 +1,128 @@
+# Network Functions (7)
+
+## `cidr_broadcast`
+
+**Signature:** `string -> string`
+
+Get broadcast address from CIDR
+
+```
+cidr_broadcast('192.168.1.0/24') -> \"192.168.1.255\"
+```
+_/24 network_
+
+```
+cidr_broadcast('10.0.0.0/8') -> \"10.255.255.255\"
+```
+_/8 network_
+
+---
+
+## `cidr_contains`
+
+**Signature:** `string, string -> boolean`
+
+Check if IP is in CIDR range
+
+```
+cidr_contains('192.168.0.0/16', '192.168.1.1') -> true
+```
+_IP in range_
+
+```
+cidr_contains('10.0.0.0/8', '192.168.1.1') -> false
+```
+_IP not in range_
+
+---
+
+## `cidr_network`
+
+**Signature:** `string -> string`
+
+Get network address from CIDR
+
+```
+cidr_network('192.168.1.0/24') -> \"192.168.1.0\"
+```
+_/24 network_
+
+```
+cidr_network('10.0.0.0/8') -> \"10.0.0.0\"
+```
+_/8 network_
+
+---
+
+## `cidr_prefix`
+
+**Signature:** `string -> number`
+
+Get prefix length from CIDR
+
+```
+cidr_prefix('192.168.1.0/24') -> 24
+```
+_/24 prefix_
+
+```
+cidr_prefix('10.0.0.0/8') -> 8
+```
+_/8 prefix_
+
+---
+
+## `int_to_ip`
+
+**Signature:** `number -> string`
+
+Convert integer to IP address
+
+```
+int_to_ip(`3232235777`) -> \"192.168.1.1\"
+```
+_Private IP_
+
+```
+int_to_ip(`0`) -> \"0.0.0.0\"
+```
+_Zero_
+
+---
+
+## `ip_to_int`
+
+**Signature:** `string -> number`
+
+Convert IP address to integer
+
+```
+ip_to_int('192.168.1.1') -> 3232235777
+```
+_Private IP_
+
+```
+ip_to_int('0.0.0.0') -> 0
+```
+_Zero_
+
+---
+
+## `is_private_ip`
+
+**Signature:** `string -> boolean`
+
+Check if IP is in private range
+
+```
+is_private_ip('192.168.1.1') -> true
+```
+_Class C private_
+
+```
+is_private_ip('10.0.0.1') -> true
+```
+_Class A private_
+
+---
+

--- a/skills/jpx-functions/references/object-functions.md
+++ b/skills/jpx-functions/references/object-functions.md
@@ -1,0 +1,910 @@
+# Object Functions (51)
+
+## `camel_keys`
+
+**Signature:** `any -> any`
+
+Recursively convert all keys to camelCase
+
+```
+camel_keys({user_name: "alice"}) -> {userName: "alice"}
+```
+_Snake to camel_
+
+```
+camel_keys({"user-name": "bob"}) -> {userName: "bob"}
+```
+_Kebab to camel_
+
+---
+
+## `chunk_by_size`
+
+**Signature:** `array, number -> array`
+
+Split an array into chunks of approximately the specified byte size
+
+```
+chunk_by_size([{a:1}, {b:2}, {c:3}], `100`) -> [[{a:1}, {b:2}, {c:3}]]
+```
+_All fit in one chunk_
+
+```
+chunk_by_size([{a:1}, {b:2}], `10`) -> [[{a:1}], [{b:2}]]
+```
+_Split into chunks_
+
+---
+
+## `compact_deep`
+
+**Signature:** `array -> array`
+
+Recursively compact arrays, removing nulls at all levels
+
+```
+compact_deep([[1, null], [null, 2]]) -> [[1], [2]]
+```
+_Remove nulls from nested arrays_
+
+```
+compact_deep([[1, null], [null, [2, null]]]) -> [[1], [[2]]]
+```
+_Deep nesting_
+
+---
+
+## `completeness`
+
+**Signature:** `object -> number`
+
+Calculate percentage of non-null fields (0-100)
+
+```
+completeness({a: 1, b: 2, c: 3}) -> 100
+```
+_All fields filled_
+
+```
+completeness({a: 1, b: null, c: null}) -> 33.33
+```
+_One of three filled_
+
+---
+
+## `data_quality_score`
+
+**Signature:** `any -> object`
+
+Analyze data quality and return score with detailed issues
+
+```
+data_quality_score({a: 1, b: 'hello'}).score -> 100
+```
+_Perfect data_
+
+```
+data_quality_score({a: null, b: ''}).issues -> [{path: 'a', issue: 'null'}, ...]
+```
+_Issues detected_
+
+---
+
+## `deep_diff`
+
+**Signature:** `object, object -> object`
+
+Structural diff between two objects
+
+```
+deep_diff({a: 1}, {a: 2}) -> {added: {}, removed: {}, changed: {a: {from: 1, to: 2}}}
+```
+_Changed value_
+
+```
+deep_diff({a: 1}, {b: 2}) -> {added: {b: 2}, removed: {a: 1}, changed: {}}
+```
+_Added and removed_
+
+---
+
+## `deep_equals`
+
+**Signature:** `any, any -> boolean`
+
+Deep equality check for any two values
+
+```
+deep_equals({a: {b: 1}}, {a: {b: 1}}) -> true
+```
+_Equal nested objects_
+
+```
+deep_equals({a: 1}, {a: 2}) -> false
+```
+_Different values_
+
+---
+
+## `deep_merge`
+
+**Signature:** `object, object -> object`
+
+Recursively merge objects
+
+```
+deep_merge({a: {b: 1}}, {a: {c: 2}}) -> {a: {b: 1, c: 2}}
+```
+_Merge nested objects_
+
+```
+deep_merge({a: 1}, {b: 2}) -> {a: 1, b: 2}
+```
+_Merge flat objects_
+
+---
+
+## `defaults`
+
+**Signature:** `object, object -> object`
+
+Assign default values for missing keys (shallow)
+
+```
+defaults({a: 1}, {a: 2, b: 3}) -> {a: 1, b: 3}
+```
+_Keep existing, add missing_
+
+```
+defaults({}, {a: 1, b: 2}) -> {a: 1, b: 2}
+```
+_All defaults applied_
+
+---
+
+## `defaults_deep`
+
+**Signature:** `object, object -> object`
+
+Recursively assign default values for missing keys
+
+```
+defaults_deep({a: {b: 1}}, {a: {c: 2}}) -> {a: {b: 1, c: 2}}
+```
+_Merge nested defaults_
+
+```
+defaults_deep({a: {b: 1}}, {a: {b: 2}}) -> {a: {b: 1}}
+```
+_Keep existing nested_
+
+---
+
+## `delete_path`
+
+**Signature:** `any, string -> any`
+
+Delete value at JSON pointer path (immutable)
+
+```
+delete_path({a: 1, b: 2}, '/b') -> {a: 1}
+```
+_Delete top-level key_
+
+```
+delete_path({a: {b: 1, c: 2}}, '/a/b') -> {a: {c: 2}}
+```
+_Delete nested key_
+
+---
+
+## `estimate_size`
+
+**Signature:** `any -> number`
+
+Estimate the JSON serialization size in bytes
+
+```
+estimate_size(`"hello"`) -> 7
+```
+_String with quotes_
+
+```
+estimate_size({a: 1}) -> 7
+```
+_Simple object_
+
+---
+
+## `flatten`
+
+**Signature:** `object -> object`
+
+Alias for flatten_keys - flatten nested object with dot notation keys
+
+```
+flatten({a: {b: 1}}) -> {\"a.b\": 1}
+```
+_Simple nested_
+
+```
+flatten({a: {b: {c: 1}}}) -> {\"a.b.c\": 1}
+```
+_Deep nested_
+
+---
+
+## `flatten_array`
+
+**Signature:** `any, string? -> object`
+
+Flatten nested objects and arrays with dot notation keys (arrays use numeric indices)
+
+```
+flatten_array({a: [1, 2]}) -> {\"a.0\": 1, \"a.1\": 2}
+```
+_Array with indices_
+
+```
+flatten_array({a: {b: [1, 2]}}) -> {\"a.b.0\": 1, \"a.b.1\": 2}
+```
+_Nested object with array_
+
+---
+
+## `flatten_keys`
+
+**Signature:** `object -> object`
+
+Flatten nested object with dot notation keys
+
+```
+flatten_keys({a: {b: 1}}) -> {\"a.b\": 1}
+```
+_Simple nested_
+
+```
+flatten_keys({a: {b: {c: 1}}}) -> {\"a.b.c\": 1}
+```
+_Deep nested_
+
+---
+
+## `from_entries`
+
+**Signature:** `array -> object`
+
+Alias for from_items. Convert array of [key, value] pairs to object. Familiar to jq/lodash users.
+
+```
+from_entries([['a', 1], ['b', 2]]) -> {a: 1, b: 2}
+```
+_Multiple pairs_
+
+```
+items({a: 1, b: 2}) | from_entries(@) -> {a: 1, b: 2}
+```
+_Round-trip with items_
+
+---
+
+## `from_items`
+
+**Signature:** `array -> object`
+
+Convert array of [key, value] pairs to object
+
+```
+from_items([['a', 1]]) -> {a: 1}
+```
+_Single pair_
+
+```
+from_items([['a', 1], ['b', 2]]) -> {a: 1, b: 2}
+```
+_Multiple pairs_
+
+---
+
+## `get`
+
+**Signature:** `any, string, any? -> any`
+
+Get value at dot-separated path with optional default
+
+```
+get({a: {b: 1}}, 'a.b') -> 1
+```
+_Nested path_
+
+```
+get({a: 1}, 'a') -> 1
+```
+_Top-level key_
+
+---
+
+## `get_path`
+
+**Signature:** `any, string, any? -> any`
+
+Get value at dot-separated path with optional default
+
+```
+get_path({a: {b: 1}}, 'a.b') -> 1
+```
+_Nested path_
+
+---
+
+## `has`
+
+**Signature:** `any, string -> boolean`
+
+Check if dot-separated path exists
+
+```
+has({a: {b: 1}}, 'a.b') -> true
+```
+_Nested path exists_
+
+```
+has({a: 1}, 'a') -> true
+```
+_Top-level exists_
+
+---
+
+## `has_path`
+
+**Signature:** `any, string -> boolean`
+
+Check if dot-separated path exists
+
+```
+has_path({a: {b: 1}}, 'a.b') -> true
+```
+_Nested path exists_
+
+---
+
+## `has_same_shape`
+
+**Signature:** `any, any -> boolean`
+
+Check if two values have the same structure (ignoring actual values)
+
+```
+has_same_shape({a: 1, b: 2}, {a: 99, b: 100}) -> true
+```
+_Same keys, different values_
+
+```
+has_same_shape({a: 1}, {a: 1, b: 2}) -> false
+```
+_Different keys_
+
+---
+
+## `infer_schema`
+
+**Signature:** `any -> object`
+
+Infer a JSON Schema-like type description from a value
+
+```
+infer_schema(`42`) -> {type: "number"}
+```
+_Number type_
+
+```
+infer_schema({name: "alice", age: 30}) -> {type: "object", properties: {name: {type: "string"}, age: {type: "number"}}}
+```
+_Object schema_
+
+---
+
+## `invert`
+
+**Signature:** `object -> object`
+
+Swap keys and values
+
+```
+invert({a: 'x'}) -> {x: 'a'}
+```
+_Swap key and value_
+
+```
+invert({a: 'b', c: 'd'}) -> {b: 'a', d: 'c'}
+```
+_Multiple pairs_
+
+---
+
+## `items`
+
+**Signature:** `object -> array`
+
+Convert object to array of [key, value] pairs
+
+```
+items({a: 1}) -> [[\"a\", 1]]
+```
+_Single key_
+
+```
+items({a: 1, b: 2}) -> [[\"a\", 1], [\"b\", 2]]
+```
+_Multiple keys_
+
+---
+
+## `kebab_keys`
+
+**Signature:** `any -> any`
+
+Recursively convert all keys to kebab-case
+
+```
+kebab_keys({userName: "alice"}) -> {"user-name": "alice"}
+```
+_Camel to kebab_
+
+```
+kebab_keys({user_name: "bob"}) -> {"user-name": "bob"}
+```
+_Snake to kebab_
+
+---
+
+## `leaves`
+
+**Signature:** `any -> array`
+
+Get all leaf values (non-object, non-array)
+
+```
+leaves({a: 1, b: [2, 3]}) -> [1, 2, 3]
+```
+_Mixed structure_
+
+```
+leaves({a: {b: 1}}) -> [1]
+```
+_Nested object_
+
+---
+
+## `leaves_with_paths`
+
+**Signature:** `any -> array`
+
+Get all leaf values with their JSON pointer paths
+
+```
+leaves_with_paths({a: 1}) -> [{path: \"/a\", value: 1}]
+```
+_Single leaf_
+
+```
+leaves_with_paths({a: {b: 1}}) -> [{path: \"/a/b\", value: 1}]
+```
+_Nested path_
+
+---
+
+## `mask`
+
+**Signature:** `string, number? -> string`
+
+Mask a string, showing only the last N characters
+
+```
+mask("4111111111111111") -> "************1111"
+```
+_Credit card default_
+
+```
+mask("555-123-4567", `3`) -> "*********567"
+```
+_Phone with 3 visible_
+
+---
+
+## `omit`
+
+**Signature:** `object, array -> object`
+
+Remove specific keys from object
+
+```
+omit({a: 1, b: 2}, ['a']) -> {b: 2}
+```
+_Remove one key_
+
+```
+omit({a: 1, b: 2, c: 3}, ['a', 'c']) -> {b: 2}
+```
+_Remove multiple keys_
+
+---
+
+## `paginate`
+
+**Signature:** `array, number, number -> object`
+
+Get a page of items from an array with metadata
+
+```
+paginate([1,2,3,4,5], `2`, `1`) -> {items: [1,2], page: 1, page_size: 2, total_items: 5, total_pages: 3, has_next: true, has_prev: false}
+```
+_First page_
+
+```
+paginate([1,2,3,4,5], `2`, `3`) -> {items: [5], page: 3, page_size: 2, total_items: 5, total_pages: 3, has_next: false, has_prev: true}
+```
+_Last page_
+
+---
+
+## `paths`
+
+**Signature:** `any -> array`
+
+List all JSON pointer paths in value
+
+```
+paths({a: {b: 1}}) -> [\"/a\", \"/a/b\"]
+```
+_Nested object_
+
+```
+paths({a: 1, b: 2}) -> [\"/a\", \"/b\"]
+```
+_Flat object_
+
+---
+
+## `paths_to`
+
+**Signature:** `any, string -> array`
+
+Find all dot-notation paths to a key anywhere in structure
+
+```
+paths_to({a: {id: 1}, b: {id: 2}}, "id") -> ["a.id", "b.id"]
+```
+_Find paths to id_
+
+```
+paths_to({users: [{id: 1}]}, "id") -> ["users.0.id"]
+```
+_Array paths_
+
+---
+
+## `pick`
+
+**Signature:** `object, array -> object`
+
+Select specific keys from object
+
+```
+pick({a: 1, b: 2}, ['a']) -> {a: 1}
+```
+_Pick one key_
+
+```
+pick({a: 1, b: 2, c: 3}, ['a', 'c']) -> {a: 1, c: 3}
+```
+_Pick multiple keys_
+
+---
+
+## `pluck_deep`
+
+**Signature:** `any, string -> array`
+
+Find all values for a key anywhere in nested structure
+
+```
+pluck_deep({users: [{id: 1}, {id: 2}], meta: {id: 99}}, "id") -> [1, 2, 99]
+```
+_Find all ids_
+
+```
+pluck_deep({a: {b: {c: 1}}, d: {c: 2}}, "c") -> [1, 2]
+```
+_Nested values_
+
+---
+
+## `redact`
+
+**Signature:** `any, array -> any`
+
+Recursively replace values at specified keys with [REDACTED]
+
+```
+redact({name: "alice", password: "secret"}, ["password"]) -> {name: "alice", password: "[REDACTED]"}
+```
+_Redact password_
+
+```
+redact({user: {name: "bob", ssn: "123"}}, ["ssn"]) -> {user: {name: "bob", ssn: "[REDACTED]"}}
+```
+_Nested redact_
+
+---
+
+## `redact_keys`
+
+**Signature:** `any, string -> any`
+
+Recursively redact keys matching a regex pattern
+
+```
+redact_keys({password: "x", api_key: "y"}, "password|api_key") -> {password: "[REDACTED]", api_key: "[REDACTED]"}
+```
+_Multiple patterns_
+
+```
+redact_keys({secret_key: "a", secret_token: "b"}, "secret.*") -> {secret_key: "[REDACTED]", secret_token: "[REDACTED]"}
+```
+_Wildcard pattern_
+
+---
+
+## `remove_empty`
+
+**Signature:** `any -> any`
+
+Recursively remove nulls, empty strings, empty arrays, and empty objects
+
+```
+remove_empty({a: \"\", b: [], c: {}, d: null, e: \"hello\"}) -> {e: \"hello\"}
+```
+_Remove all empty values_
+
+```
+remove_empty({a: {b: \"\", c: 1}}) -> {a: {c: 1}}
+```
+_Nested cleanup_
+
+---
+
+## `remove_empty_strings`
+
+**Signature:** `any -> any`
+
+Recursively remove empty string values
+
+```
+remove_empty_strings({name: \"alice\", bio: \"\"}) -> {name: \"alice\"}
+```
+_Remove empty strings_
+
+```
+remove_empty_strings([\"hello\", \"\", \"world\"]) -> [\"hello\", \"world\"]
+```
+_From arrays_
+
+---
+
+## `remove_nulls`
+
+**Signature:** `any -> any`
+
+Recursively remove null values
+
+```
+remove_nulls({a: 1, b: null, c: 2}) -> {a: 1, c: 2}
+```
+_Remove nulls from object_
+
+```
+remove_nulls({a: {b: null, c: 1}}) -> {a: {c: 1}}
+```
+_Nested nulls_
+
+---
+
+## `rename_keys`
+
+**Signature:** `object, object -> object`
+
+Rename object keys
+
+```
+rename_keys({a: 1}, {a: 'b'}) -> {b: 1}
+```
+_Rename one key_
+
+```
+rename_keys({a: 1, b: 2}, {a: 'x', b: 'y'}) -> {x: 1, y: 2}
+```
+_Rename multiple_
+
+---
+
+## `set_path`
+
+**Signature:** `any, string, any -> any`
+
+Set value at JSON pointer path (immutable)
+
+```
+set_path({a: 1}, '/b', `2`) -> {a: 1, b: 2}
+```
+_Add new key_
+
+```
+set_path({a: 1}, '/a', `2`) -> {a: 2}
+```
+_Update existing_
+
+---
+
+## `snake_keys`
+
+**Signature:** `any -> any`
+
+Recursively convert all keys to snake_case
+
+```
+snake_keys({userName: "alice"}) -> {user_name: "alice"}
+```
+_Camel to snake_
+
+```
+snake_keys({"user-name": "bob"}) -> {user_name: "bob"}
+```
+_Kebab to snake_
+
+---
+
+## `structural_diff`
+
+**Signature:** `any, any -> object`
+
+Compare two values and return their structural differences
+
+```
+structural_diff({a: 1}, {a: 2}) -> {changed: [{path: "a", from: 1, to: 2}], added: [], removed: []}
+```
+_Changed value_
+
+```
+structural_diff({a: 1}, {a: 1, b: 2}) -> {changed: [], added: [{path: "b", value: 2}], removed: []}
+```
+_Added key_
+
+---
+
+## `template`
+
+**Signature:** `object, string -> string`
+
+Expand a template string with values from an object using {{key}} syntax
+
+```
+template({name: "Alice"}, `"Hello, {{name}}!"`) -> "Hello, Alice!"
+```
+_Simple substitution_
+
+```
+template({user: {name: "Bob"}}, `"Hi {{user.name}}"`) -> "Hi Bob"
+```
+_Nested access_
+
+---
+
+## `template_strict`
+
+**Signature:** `object, string -> string | null`
+
+Expand a template string, returning null if any variable is missing
+
+```
+template_strict({name: "Alice"}, `"Hello, {{name}}!"`) -> "Hello, Alice!"
+```
+_All vars present_
+
+```
+template_strict({}, `"Hello, {{name}}!"`) -> null
+```
+_Missing variable_
+
+---
+
+## `truncate_to_size`
+
+**Signature:** `array, number -> array`
+
+Truncate an array to fit within approximately the specified byte size
+
+```
+truncate_to_size([{a:1}, {b:2}, {c:3}], `100`) -> [{a:1}, {b:2}, {c:3}]
+```
+_All fit_
+
+```
+truncate_to_size([{a:1}, {b:2}, {c:3}], `15`) -> [{a:1}, {b:2}]
+```
+_Truncated_
+
+---
+
+## `type_consistency`
+
+**Signature:** `array -> object`
+
+Check if array elements have consistent types
+
+```
+type_consistency([1, 2, 3]).consistent -> true
+```
+_Consistent numbers_
+
+```
+type_consistency([1, 'two', 3]).consistent -> false
+```
+_Mixed types_
+
+---
+
+## `unflatten`
+
+**Signature:** `object -> object`
+
+Alias for unflatten_keys - restore nested object from dot notation keys
+
+```
+unflatten({\"a.b\": 1}) -> {a: {b: 1}}
+```
+_Simple nested_
+
+```
+unflatten({\"a.b.c\": 1}) -> {a: {b: {c: 1}}}
+```
+_Deep nested_
+
+---
+
+## `unflatten_keys`
+
+**Signature:** `object -> object`
+
+Restore nested object from dot notation keys
+
+```
+unflatten_keys({\"a.b\": 1}) -> {a: {b: 1}}
+```
+_Simple nested_
+
+```
+unflatten_keys({\"a.b.c\": 1}) -> {a: {b: {c: 1}}}
+```
+_Deep nested_
+
+---
+
+## `with_entries`
+
+**Signature:** `object, string -> object`
+
+Transform object entries using an expression (jq parity)
+
+```
+with_entries({a: 1, b: 2}, '[upper(@[0]), multiply(@[1], `2`)]') -> {A: 2, B: 4}
+```
+_Transform keys and values_
+
+```
+with_entries({a: 1, b: 2}, '[@[0], add(@[1], `10`)]') -> {a: 11, b: 12}
+```
+_Transform values only_
+
+---
+

--- a/skills/jpx-functions/references/path-functions.md
+++ b/skills/jpx-functions/references/path-functions.md
@@ -1,0 +1,128 @@
+# Path Functions (7)
+
+## `path_basename`
+
+**Signature:** `string -> string`
+
+Get filename from path
+
+```
+path_basename('/foo/bar.txt') -> \"bar.txt\"
+```
+_Unix path_
+
+```
+path_basename('/foo/bar/') -> \"bar\"
+```
+_Directory path_
+
+---
+
+## `path_dirname`
+
+**Signature:** `string -> string`
+
+Get directory from path
+
+```
+path_dirname('/foo/bar.txt') -> \"/foo\"
+```
+_Unix path_
+
+```
+path_dirname('/foo/bar/baz') -> \"/foo/bar\"
+```
+_Nested path_
+
+---
+
+## `path_ext`
+
+**Signature:** `string -> string`
+
+Get file extension
+
+```
+path_ext('/foo/bar.txt') -> \"txt\"
+```
+_Text file_
+
+```
+path_ext('image.png') -> \"png\"
+```
+_Image file_
+
+---
+
+## `path_is_absolute`
+
+**Signature:** `string -> boolean`
+
+Check if path is absolute
+
+```
+path_is_absolute('/foo/bar') -> true
+```
+_Absolute path_
+
+```
+path_is_absolute('foo/bar') -> false
+```
+_Relative path_
+
+---
+
+## `path_is_relative`
+
+**Signature:** `string -> boolean`
+
+Check if path is relative
+
+```
+path_is_relative('foo/bar') -> true
+```
+_Relative path_
+
+```
+path_is_relative('file.txt') -> true
+```
+_Filename only_
+
+---
+
+## `path_join`
+
+**Signature:** `string... -> string`
+
+Join path segments
+
+```
+path_join('/foo', 'bar', 'baz') -> \"/foo/bar/baz\"
+```
+_Multiple segments_
+
+```
+path_join('/home', 'user', 'file.txt') -> \"/home/user/file.txt\"
+```
+_Full path_
+
+---
+
+## `path_stem`
+
+**Signature:** `string -> string`
+
+Get filename without extension
+
+```
+path_stem('file.txt') -> \"file\"
+```
+_Simple file_
+
+```
+path_stem('/foo/bar.tar.gz') -> \"bar.tar\"
+```
+_Double extension_
+
+---
+

--- a/skills/jpx-functions/references/phonetic-functions.md
+++ b/skills/jpx-functions/references/phonetic-functions.md
@@ -1,0 +1,164 @@
+# Phonetic Functions (9)
+
+## `caverphone`
+
+**Signature:** `string -> string`
+
+Caverphone code
+
+```
+caverphone('Smith') -> \"SMT1111111\"
+```
+_Common name_
+
+```
+caverphone('Thompson') -> \"TMPSN11111\"
+```
+_Another name_
+
+---
+
+## `caverphone2`
+
+**Signature:** `string -> string`
+
+Caverphone 2 code
+
+```
+caverphone2('Smith') -> \"SMT1111111\"
+```
+_Common name_
+
+```
+caverphone2('Thompson') -> \"TMPSN11111\"
+```
+_Another name_
+
+---
+
+## `double_metaphone`
+
+**Signature:** `string -> object`
+
+Double Metaphone codes
+
+```
+double_metaphone('Smith') -> {primary: 'SM0', secondary: 'XMT'}
+```
+_Common name_
+
+```
+double_metaphone('Schmidt') -> {primary: 'XMT', secondary: 'SMT'}
+```
+_German variant_
+
+---
+
+## `match_rating_codex`
+
+**Signature:** `string -> string`
+
+Match Rating codex
+
+```
+match_rating_codex('Smith') -> \"SMTH\"
+```
+_Common name_
+
+```
+match_rating_codex('Johnson') -> \"JHNSN\"
+```
+_Another name_
+
+---
+
+## `metaphone`
+
+**Signature:** `string -> string`
+
+Metaphone phonetic code
+
+```
+metaphone('Smith') -> \"SM0\"
+```
+_Common name_
+
+```
+metaphone('phone') -> \"FN\"
+```
+_Ph sound_
+
+---
+
+## `nysiis`
+
+**Signature:** `string -> string`
+
+NYSIIS phonetic code
+
+```
+nysiis('Smith') -> \"SNAT\"
+```
+_Common name_
+
+```
+nysiis('Johnson') -> \"JANSAN\"
+```
+_Another name_
+
+---
+
+## `phonetic_match`
+
+**Signature:** `string, string, string -> boolean`
+
+Check phonetic match with algorithm
+
+```
+phonetic_match('Smith', 'Smyth', 'soundex') -> true
+```
+_Soundex match_
+
+```
+phonetic_match('Robert', 'Rupert', 'metaphone') -> true
+```
+_Metaphone match_
+
+---
+
+## `soundex`
+
+**Signature:** `string -> string`
+
+Soundex phonetic code
+
+```
+soundex('Robert') -> \"R163\"
+```
+_Common name_
+
+```
+soundex('Rupert') -> \"R163\"
+```
+_Same code as Robert_
+
+---
+
+## `sounds_like`
+
+**Signature:** `string, string -> boolean`
+
+Check if strings sound similar
+
+```
+sounds_like('Robert', 'Rupert') -> true
+```
+_Similar sounding_
+
+```
+sounds_like('Smith', 'Smyth') -> true
+```
+_Spelling variants_
+
+---
+

--- a/skills/jpx-functions/references/rand-functions.md
+++ b/skills/jpx-functions/references/rand-functions.md
@@ -1,0 +1,92 @@
+# Rand Functions (5)
+
+## `random`
+
+**Signature:** `-> number`
+
+Generate random number between 0 and 1
+
+```
+random() -> 0.123456...
+```
+_Random float_
+
+```
+floor(multiply(random(), `100`)) -> 42
+```
+_Random 0-99_
+
+---
+
+## `random_choice`
+
+**Signature:** `array -> any`
+
+Pick a random element from an array
+
+```
+random_choice(['a', 'b', 'c']) -> 'b'
+```
+_Random element_
+
+```
+random_choice([]) -> null
+```
+_Empty array returns null_
+
+---
+
+## `random_int`
+
+**Signature:** `number, number -> number`
+
+Generate a random integer in an inclusive range [min, max]
+
+```
+random_int(`1`, `10`) -> 7
+```
+_Random integer 1-10_
+
+```
+random_int(`0`, `1`) -> 0
+```
+_Coin flip_
+
+---
+
+## `sample`
+
+**Signature:** `array, number -> array`
+
+Random sample from array
+
+```
+sample([1, 2, 3, 4], `2`) -> [3, 1]
+```
+_Sample 2 items_
+
+```
+sample(['a', 'b', 'c'], `1`) -> ['b']
+```
+_Sample 1 item_
+
+---
+
+## `shuffle`
+
+**Signature:** `array -> array`
+
+Randomly shuffle array
+
+```
+shuffle([1, 2, 3]) -> [2, 3, 1]
+```
+_Shuffle numbers_
+
+```
+length(shuffle([1, 2, 3])) -> 3
+```
+_Preserves length_
+
+---
+

--- a/skills/jpx-functions/references/regex-functions.md
+++ b/skills/jpx-functions/references/regex-functions.md
@@ -1,0 +1,92 @@
+# Regex Functions (5)
+
+## `regex_count`
+
+**Signature:** `string, string -> number`
+
+Count the number of regex matches. Use backtick-JSON syntax: regex_count(text, `"\\d+"`)
+
+```
+regex_count(`"a1b2c3"`, `"\\\\d+"`) -> 3
+```
+_Count numbers_
+
+```
+regex_count(`"hello world"`, `"[aeiou]"`) -> 3
+```
+_Count vowels_
+
+---
+
+## `regex_extract`
+
+**Signature:** `string, string -> array`
+
+Extract regex matches. Use backtick-JSON syntax: regex_extract(text, `"\\w+"`)
+
+```
+regex_extract(`"a1b2"`, `"\\\\d+"`) -> [\"1\", \"2\"]
+```
+_Extract numbers_
+
+```
+regex_extract(`"hello world"`, `"\\\\w+"`) -> [\"hello\", \"world\"]
+```
+_Extract words_
+
+---
+
+## `regex_match`
+
+**Signature:** `string, string -> boolean`
+
+Test if string matches regex. Use backtick-JSON syntax: regex_match(text, `"^\\d+$"`)
+
+```
+regex_match(`"hello"`, `"^h.*o$"`) -> true
+```
+_Full match_
+
+```
+regex_match(`"test123"`, `"\\\\d+"`) -> true
+```
+_Contains digits_
+
+---
+
+## `regex_replace`
+
+**Signature:** `string, string, string -> string`
+
+Replace regex matches. Use backtick-JSON syntax: regex_replace(text, `"\\d+"`, `"X"`)
+
+```
+regex_replace(`"a1b2"`, `"\\\\d+"`, `"X"`) -> \"aXbX\"
+```
+_Replace digits_
+
+```
+regex_replace(`"hello world"`, `"\\\\s+"`, `"-"`) -> \"hello-world\"
+```
+_Replace spaces_
+
+---
+
+## `regex_split`
+
+**Signature:** `string, string -> array`
+
+Split a string by a regex pattern. Use backtick-JSON syntax: regex_split(text, `"\\s+"`)
+
+```
+regex_split(`"a,b,c"`, `","`) -> [\"a\", \"b\", \"c\"]
+```
+_Split by comma_
+
+```
+regex_split(`"hello   world"`, `"\\\\s+"`) -> [\"hello\", \"world\"]
+```
+_Split by whitespace_
+
+---
+

--- a/skills/jpx-functions/references/semver-functions.md
+++ b/skills/jpx-functions/references/semver-functions.md
@@ -1,0 +1,128 @@
+# Semver Functions (7)
+
+## `semver_compare`
+
+**Signature:** `string, string -> number`
+
+Compare versions (-1, 0, 1)
+
+```
+semver_compare('1.0.0', '2.0.0') -> -1
+```
+_Less than_
+
+```
+semver_compare('2.0.0', '1.0.0') -> 1
+```
+_Greater than_
+
+---
+
+## `semver_is_valid`
+
+**Signature:** `string -> boolean`
+
+Check if string is valid semver
+
+```
+semver_is_valid('1.2.3') -> true
+```
+_Valid semver_
+
+```
+semver_is_valid('1.2.3-alpha') -> true
+```
+_With prerelease_
+
+---
+
+## `semver_major`
+
+**Signature:** `string -> number`
+
+Get major version
+
+```
+semver_major('1.2.3') -> 1
+```
+_Major version_
+
+```
+semver_major('10.0.0') -> 10
+```
+_Double digit_
+
+---
+
+## `semver_minor`
+
+**Signature:** `string -> number`
+
+Get minor version
+
+```
+semver_minor('1.2.3') -> 2
+```
+_Minor version_
+
+```
+semver_minor('1.10.0') -> 10
+```
+_Double digit_
+
+---
+
+## `semver_parse`
+
+**Signature:** `string -> object`
+
+Parse semantic version
+
+```
+semver_parse('1.2.3') -> {major: 1, minor: 2, patch: 3}
+```
+_Basic version_
+
+```
+semver_parse('1.2.3-alpha').pre -> 'alpha'
+```
+_With prerelease_
+
+---
+
+## `semver_patch`
+
+**Signature:** `string -> number`
+
+Get patch version
+
+```
+semver_patch('1.2.3') -> 3
+```
+_Patch version_
+
+```
+semver_patch('1.2.10') -> 10
+```
+_Double digit_
+
+---
+
+## `semver_satisfies`
+
+**Signature:** `string, string -> boolean`
+
+Check if version matches constraint
+
+```
+semver_satisfies('1.2.3', '^1.0.0') -> true
+```
+_Caret range_
+
+```
+semver_satisfies('2.0.0', '^1.0.0') -> false
+```
+_Outside range_
+
+---
+

--- a/skills/jpx-functions/references/standard-functions.md
+++ b/skills/jpx-functions/references/standard-functions.md
@@ -1,0 +1,470 @@
+# Standard Functions (26)
+
+## `abs`
+
+**Signature:** `number -> number`
+
+Returns the absolute value of a number
+
+```
+abs(`-5`) -> 5
+```
+_Negative number_
+
+```
+abs(`5`) -> 5
+```
+_Positive number_
+
+---
+
+## `avg`
+
+**Signature:** `array[number] -> number`
+
+Returns the average of an array of numbers
+
+```
+avg([1, 2, 3]) -> 2
+```
+_Simple average_
+
+```
+avg([10, 20, 30, 40]) -> 25
+```
+_Four numbers_
+
+---
+
+## `ceil`
+
+**Signature:** `number -> number`
+
+Returns the smallest integer greater than or equal to the number
+
+```
+ceil(`1.5`) -> 2
+```
+_Round up decimal_
+
+```
+ceil(`-1.5`) -> -1
+```
+_Negative rounds toward zero_
+
+---
+
+## `contains`
+
+**Signature:** `array|string, any -> boolean`
+
+Returns true if the subject contains the search value
+
+```
+contains([1, 2, 3], `2`) -> true
+```
+_Array contains number_
+
+```
+contains('hello', 'ell') -> true
+```
+_String contains substring_
+
+---
+
+## `ends_with`
+
+**Signature:** `string, string -> boolean`
+
+Returns true if the subject ends with the suffix
+
+```
+ends_with('hello', 'lo') -> true
+```
+_Ends with suffix_
+
+```
+ends_with('hello', 'he') -> false
+```
+_Does not end with_
+
+---
+
+## `floor`
+
+**Signature:** `number -> number`
+
+Returns the largest integer less than or equal to the number
+
+```
+floor(`1.9`) -> 1
+```
+_Round down decimal_
+
+```
+floor(`-1.5`) -> -2
+```
+_Negative rounds away from zero_
+
+---
+
+## `join`
+
+**Signature:** `string, array[string] -> string`
+
+Returns array elements joined into a string with a separator
+
+```
+join(', ', ['a', 'b', 'c']) -> \"a, b, c\"
+```
+_Join with comma_
+
+```
+join('-', ['2024', '01', '15']) -> \"2024-01-15\"
+```
+_Join date parts_
+
+---
+
+## `keys`
+
+**Signature:** `object -> array[string]`
+
+Returns an array of keys from an object
+
+```
+keys({a: 1, b: 2}) -> [\"a\", \"b\"]
+```
+_Get object keys_
+
+```
+keys({name: \"John\", age: 30}) -> [\"age\", \"name\"]
+```
+_Keys sorted alphabetically_
+
+---
+
+## `length`
+
+**Signature:** `array|object|string -> number`
+
+Returns the length of an array, object, or string
+
+```
+length([1, 2, 3]) -> 3
+```
+_Array length_
+
+```
+length('hello') -> 5
+```
+_String length_
+
+---
+
+## `map`
+
+**Signature:** `expression, array -> array`
+
+Applies an expression to each element of an array
+
+```
+map(&a, [{a: 1}, {a: 2}]) -> [1, 2]
+```
+_Extract field from objects_
+
+```
+map(&length(@), ['a', 'bb', 'ccc']) -> [1, 2, 3]
+```
+_Apply function_
+
+---
+
+## `max`
+
+**Signature:** `array[number]|array[string] -> number|string`
+
+Returns the maximum value in an array
+
+```
+max([1, 3, 2]) -> 3
+```
+_Max of numbers_
+
+```
+max(['a', 'c', 'b']) -> 'c'
+```
+_Max of strings_
+
+---
+
+## `max_by`
+
+**Signature:** `array, expression -> any`
+
+Returns the element with maximum value by expression
+
+```
+max_by([{a: 1}, {a: 2}], &a) -> {a: 2}
+```
+_Max by field_
+
+```
+max_by([{name: 'a', age: 30}, {name: 'b', age: 25}], &age) -> {name: 'a', age: 30}
+```
+_Max by age_
+
+---
+
+## `merge`
+
+**Signature:** `object... -> object`
+
+Merges objects into a single object
+
+```
+merge({a: 1}, {b: 2}) -> {a: 1, b: 2}
+```
+_Merge two objects_
+
+```
+merge({a: 1}, {a: 2}) -> {a: 2}
+```
+_Later values override_
+
+---
+
+## `min`
+
+**Signature:** `array[number]|array[string] -> number|string`
+
+Returns the minimum value in an array
+
+```
+min([1, 3, 2]) -> 1
+```
+_Min of numbers_
+
+```
+min(['a', 'c', 'b']) -> 'a'
+```
+_Min of strings_
+
+---
+
+## `min_by`
+
+**Signature:** `array, expression -> any`
+
+Returns the element with minimum value by expression
+
+```
+min_by([{a: 1}, {a: 2}], &a) -> {a: 1}
+```
+_Min by field_
+
+```
+min_by([{name: 'a', age: 30}, {name: 'b', age: 25}], &age) -> {name: 'b', age: 25}
+```
+_Min by age_
+
+---
+
+## `not_null`
+
+**Signature:** `any... -> any`
+
+Returns the first non-null argument
+
+```
+not_null(`null`, 'a', 'b') -> \"a\"
+```
+_Skip nulls_
+
+```
+not_null('first', 'second') -> \"first\"
+```
+_First non-null_
+
+---
+
+## `reverse`
+
+**Signature:** `array|string -> array|string`
+
+Reverses an array or string
+
+```
+reverse([1, 2, 3]) -> [3, 2, 1]
+```
+_Reverse array_
+
+```
+reverse('hello') -> 'olleh'
+```
+_Reverse string_
+
+---
+
+## `sort`
+
+**Signature:** `array[number]|array[string] -> array`
+
+Sorts an array of numbers or strings
+
+```
+sort([3, 1, 2]) -> [1, 2, 3]
+```
+_Sort numbers_
+
+```
+sort(['c', 'a', 'b']) -> ['a', 'b', 'c']
+```
+_Sort strings_
+
+---
+
+## `sort_by`
+
+**Signature:** `array, expression -> array`
+
+Sorts an array by expression result
+
+```
+sort_by([{a: 2}, {a: 1}], &a) -> [{a: 1}, {a: 2}]
+```
+_Sort by field_
+
+```
+sort_by(['bb', 'a', 'ccc'], &length(@)) -> ['a', 'bb', 'ccc']
+```
+_Sort by length_
+
+---
+
+## `starts_with`
+
+**Signature:** `string, string -> boolean`
+
+Returns true if the subject starts with the prefix
+
+```
+starts_with('hello', 'he') -> true
+```
+_Starts with prefix_
+
+```
+starts_with('hello', 'lo') -> false
+```
+_Does not start with_
+
+---
+
+## `sum`
+
+**Signature:** `array[number] -> number`
+
+Returns the sum of an array of numbers
+
+```
+sum([1, 2, 3]) -> 6
+```
+_Sum of numbers_
+
+```
+sum([10, -5, 3]) -> 8
+```
+_With negative_
+
+---
+
+## `to_array`
+
+**Signature:** `any -> array`
+
+Converts a value to an array
+
+```
+to_array('hello') -> [\"hello\"]
+```
+_String to array_
+
+```
+to_array([1, 2]) -> [1, 2]
+```
+_Array unchanged_
+
+---
+
+## `to_number`
+
+**Signature:** `any -> number`
+
+Converts a value to a number
+
+```
+to_number('42') -> 42
+```
+_String to number_
+
+```
+to_number('3.14') -> 3.14
+```
+_String to float_
+
+---
+
+## `to_string`
+
+**Signature:** `any -> string`
+
+Converts a value to a string
+
+```
+to_string(`42`) -> \"42\"
+```
+_Number to string_
+
+```
+to_string(`true`) -> \"true\"
+```
+_Boolean to string_
+
+---
+
+## `type`
+
+**Signature:** `any -> string`
+
+Returns the type of a value as a string
+
+```
+type('hello') -> \"string\"
+```
+_String type_
+
+```
+type(`42`) -> \"number\"
+```
+_Number type_
+
+---
+
+## `values`
+
+**Signature:** `object -> array`
+
+Returns an array of values from an object
+
+```
+values({a: 1, b: 2}) -> [1, 2]
+```
+_Get object values_
+
+```
+values({x: 'hello', y: 'world'}) -> ['hello', 'world']
+```
+_String values_
+
+---
+

--- a/skills/jpx-functions/references/string-functions.md
+++ b/skills/jpx-functions/references/string-functions.md
@@ -1,0 +1,650 @@
+# String Functions (36)
+
+## `abbreviate`
+
+**Signature:** `string, number, string? -> string`
+
+Truncate string with ellipsis suffix
+
+```
+abbreviate('hello world', `8`) -> \"hello...\"
+```
+_Default ellipsis_
+
+```
+abbreviate('hello', `10`) -> \"hello\"
+```
+_No truncation needed_
+
+---
+
+## `camel_case`
+
+**Signature:** `string -> string`
+
+Convert to camelCase
+
+```
+camel_case('hello_world') -> \"helloWorld\"
+```
+_From snake_case_
+
+```
+camel_case('hello-world') -> \"helloWorld\"
+```
+_From kebab-case_
+
+---
+
+## `capitalize`
+
+**Signature:** `string -> string`
+
+Capitalize the first character
+
+```
+capitalize('hello') -> \"Hello\"
+```
+_Basic capitalize_
+
+```
+capitalize('HELLO') -> \"HELLO\"
+```
+_Already uppercase_
+
+---
+
+## `center`
+
+**Signature:** `string, number, string? -> string`
+
+Center-pad string to given width
+
+```
+center('hi', `6`) -> \"  hi  \"
+```
+_Center with spaces_
+
+```
+center('hi', `6`, '-') -> \"--hi--\"
+```
+_Center with dashes_
+
+---
+
+## `concat`
+
+**Signature:** `string... -> string`
+
+Concatenate strings
+
+```
+concat('hello', ' ', 'world') -> \"hello world\"
+```
+_Multiple strings_
+
+```
+concat('a', 'b') -> \"ab\"
+```
+_Two strings_
+
+---
+
+## `explode`
+
+**Signature:** `string -> array`
+
+Convert a string to an array of Unicode codepoints
+
+```
+explode('abc') -> [97, 98, 99]
+```
+_ASCII characters_
+
+```
+explode('A☺') -> [65, 9786]
+```
+_Unicode characters_
+
+---
+
+## `find_first`
+
+**Signature:** `string, string -> number | null`
+
+Find first occurrence of substring
+
+```
+find_first('hello', 'l') -> 2
+```
+_Find character_
+
+```
+find_first('hello world', 'world') -> 6
+```
+_Find substring_
+
+---
+
+## `find_last`
+
+**Signature:** `string, string -> number | null`
+
+Find last occurrence of substring
+
+```
+find_last('hello', 'l') -> 3
+```
+_Find last character_
+
+```
+find_last('foo bar foo', 'foo') -> 8
+```
+_Find last substring_
+
+---
+
+## `implode`
+
+**Signature:** `array -> string`
+
+Convert an array of Unicode codepoints to a string
+
+```
+implode([97, 98, 99]) -> \"abc\"
+```
+_ASCII codepoints_
+
+```
+implode([65, 9786]) -> \"A☺\"
+```
+_Unicode codepoints_
+
+---
+
+## `indices`
+
+**Signature:** `string, string -> array`
+
+Find all indices of substring occurrences
+
+```
+indices('hello', 'l') -> [2, 3]
+```
+_Multiple occurrences_
+
+```
+indices('ababa', 'aba') -> [0, 2]
+```
+_Overlapping matches_
+
+---
+
+## `inside`
+
+**Signature:** `string, string -> boolean`
+
+Check if search string is contained in string
+
+```
+inside('world', 'hello world') -> true
+```
+_Found_
+
+```
+inside('foo', 'hello world') -> false
+```
+_Not found_
+
+---
+
+## `is_blank`
+
+**Signature:** `string -> boolean`
+
+Check if string is empty or whitespace-only
+
+```
+is_blank('   ') -> true
+```
+_Whitespace only_
+
+```
+is_blank('') -> true
+```
+_Empty string_
+
+---
+
+## `kebab_case`
+
+**Signature:** `string -> string`
+
+Convert to kebab-case
+
+```
+kebab_case('helloWorld') -> \"hello-world\"
+```
+_From camelCase_
+
+```
+kebab_case('hello_world') -> \"hello-world\"
+```
+_From snake_case_
+
+---
+
+## `lower`
+
+**Signature:** `string -> string`
+
+Convert string to lowercase
+
+```
+lower('HELLO') -> \"hello\"
+```
+_All uppercase_
+
+```
+lower('Hello World') -> \"hello world\"
+```
+_Mixed case_
+
+---
+
+## `ltrimstr`
+
+**Signature:** `string, string -> string`
+
+Remove prefix from string if present
+
+```
+ltrimstr('foobar', 'foo') -> \"bar\"
+```
+_Remove prefix_
+
+```
+ltrimstr('foobar', 'bar') -> \"foobar\"
+```
+_Prefix not found_
+
+---
+
+## `mask`
+
+**Signature:** `string, number?, string? -> string`
+
+Mask string, keeping last N characters visible
+
+```
+mask('4111111111111111', `4`) -> \"************1111\"
+```
+_Credit card_
+
+```
+mask('secret', `0`) -> \"******\"
+```
+_Mask all_
+
+---
+
+## `normalize_whitespace`
+
+**Signature:** `string -> string`
+
+Collapse multiple whitespace to single space
+
+```
+normalize_whitespace('a  b  c') -> \"a b c\"
+```
+_Multiple spaces_
+
+```
+normalize_whitespace('a\\n\\nb') -> \"a b\"
+```
+_Newlines to space_
+
+---
+
+## `pad_left`
+
+**Signature:** `string, number, string -> string`
+
+Pad string on the left to reach target length
+
+```
+pad_left('5', `3`, '0') -> \"005\"
+```
+_Zero-pad number_
+
+```
+pad_left('hi', `5`, ' ') -> \"   hi\"
+```
+_Right-align text_
+
+---
+
+## `pad_right`
+
+**Signature:** `string, number, string -> string`
+
+Pad string on the right to reach target length
+
+```
+pad_right('5', `3`, '0') -> \"500\"
+```
+_Pad with zeros_
+
+```
+pad_right('hi', `5`, ' ') -> \"hi   \"
+```
+_Left-align text_
+
+---
+
+## `redact`
+
+**Signature:** `string, string, string? -> string`
+
+Redact regex pattern matches with replacement
+
+```
+redact('email: test@example.com', '\\S+@\\S+', '[EMAIL]') -> \"email: [EMAIL]\"
+```
+_Redact email_
+
+```
+redact('call 555-1234', '\\d{3}-\\d{4}', '[PHONE]') -> \"call [PHONE]\"
+```
+_Redact phone_
+
+---
+
+## `repeat`
+
+**Signature:** `string, number -> string`
+
+Repeat a string n times
+
+```
+repeat('ab', `3`) -> \"ababab\"
+```
+_Repeat 3 times_
+
+```
+repeat('-', `5`) -> \"-----\"
+```
+_Create separator_
+
+---
+
+## `replace`
+
+**Signature:** `string, string, string -> string`
+
+Replace occurrences of a substring. Use backtick-JSON syntax: replace(text, `"\n"`, `" "`)
+
+```
+replace(`"hello"`, `"l"`, `"L"`) -> \"heLLo\"
+```
+_Replace all occurrences_
+
+```
+replace(`"line1\\nline2"`, `"\\n"`, `" "`) -> \"line1 line2\"
+```
+_Replace newlines_
+
+---
+
+## `reverse_string`
+
+**Signature:** `string -> string`
+
+Reverse a string
+
+```
+reverse_string('hello') -> \"olleh\"
+```
+_Reverse word_
+
+```
+reverse_string('ab') -> \"ba\"
+```
+_Two chars_
+
+---
+
+## `rtrimstr`
+
+**Signature:** `string, string -> string`
+
+Remove suffix from string if present
+
+```
+rtrimstr('foobar', 'bar') -> \"foo\"
+```
+_Remove suffix_
+
+```
+rtrimstr('hello.txt', '.txt') -> \"hello\"
+```
+_Remove file extension_
+
+---
+
+## `shell_escape`
+
+**Signature:** `string -> string`
+
+Escape a string for safe use in shell commands (POSIX sh compatible, jq parity)
+
+```
+shell_escape('hello') -> \"hello\"
+```
+_Simple string unchanged_
+
+```
+shell_escape('hello world') -> \"'hello world'\"
+```
+_Spaces get quoted_
+
+---
+
+## `slice`
+
+**Signature:** `string, number, number -> string`
+
+Extract substring by start and end index
+
+```
+slice('hello', `1`, `4`) -> \"ell\"
+```
+_Middle slice_
+
+```
+slice('hello', `0`, `2`) -> \"he\"
+```
+_From start_
+
+---
+
+## `snake_case`
+
+**Signature:** `string -> string`
+
+Convert to snake_case
+
+```
+snake_case('helloWorld') -> \"hello_world\"
+```
+_From camelCase_
+
+```
+snake_case('HelloWorld') -> \"hello_world\"
+```
+_From PascalCase_
+
+---
+
+## `split`
+
+**Signature:** `string, string -> array`
+
+Split string by delimiter. Use backtick-JSON syntax for literals: split(text, `"\n"`) to split on newlines
+
+```
+split(`"a,b,c"`, `","`) -> [\"a\", \"b\", \"c\"]
+```
+_Basic split_
+
+```
+split(`"hello world"`, `" "`) -> [\"hello\", \"world\"]
+```
+_Split by space_
+
+---
+
+## `sprintf`
+
+**Signature:** `string, any... -> string`
+
+Printf-style string formatting
+
+```
+sprintf('Pi is %.2f', `3.14159`) -> \"Pi is 3.14\"
+```
+_Float formatting_
+
+```
+sprintf('Hello %s', 'world') -> \"Hello world\"
+```
+_String interpolation_
+
+---
+
+## `substr`
+
+**Signature:** `string, number, number -> string`
+
+Extract substring by start index and length
+
+```
+substr('hello', `1`, `3`) -> \"ell\"
+```
+_From index 1, length 3_
+
+```
+substr('hello', `0`, `2`) -> \"he\"
+```
+_From start_
+
+---
+
+## `title`
+
+**Signature:** `string -> string`
+
+Convert to title case
+
+```
+title('hello world') -> \"Hello World\"
+```
+_Basic title case_
+
+```
+title('HELLO WORLD') -> \"Hello World\"
+```
+_From uppercase_
+
+---
+
+## `trim`
+
+**Signature:** `string -> string`
+
+Remove leading and trailing whitespace
+
+```
+trim('  hello  ') -> \"hello\"
+```
+_Remove both sides_
+
+```
+trim('hello') -> \"hello\"
+```
+_No whitespace_
+
+---
+
+## `trim_left`
+
+**Signature:** `string -> string`
+
+Remove leading whitespace
+
+```
+trim_left('  hello') -> \"hello\"
+```
+_Remove leading spaces_
+
+```
+trim_left('hello  ') -> \"hello  \"
+```
+_Trailing preserved_
+
+---
+
+## `trim_right`
+
+**Signature:** `string -> string`
+
+Remove trailing whitespace
+
+```
+trim_right('hello  ') -> \"hello\"
+```
+_Remove trailing spaces_
+
+```
+trim_right('  hello') -> \"  hello\"
+```
+_Leading preserved_
+
+---
+
+## `upper`
+
+**Signature:** `string -> string`
+
+Convert string to uppercase
+
+```
+upper('hello') -> \"HELLO\"
+```
+_Basic uppercase_
+
+```
+upper('Hello World') -> \"HELLO WORLD\"
+```
+_Mixed case_
+
+---
+
+## `wrap`
+
+**Signature:** `string, number -> string`
+
+Wrap text to specified width
+
+```
+wrap('hello world', `5`) -> \"hello\\nworld\"
+```
+_Wrap at word boundary_
+
+```
+wrap('a b c d e', `3`) -> \"a b\\nc d\\ne\"
+```
+_Multiple wraps_
+
+---
+

--- a/skills/jpx-functions/references/text-functions.md
+++ b/skills/jpx-functions/references/text-functions.md
@@ -1,0 +1,380 @@
+# Text Functions (21)
+
+## `bigrams`
+
+**Signature:** `string -> array`
+
+Generate word bigrams (2-grams)
+
+```
+bigrams('a b c') -> \[\['a', 'b'\], \['b', 'c'\]\]
+```
+_Basic bigrams_
+
+```
+bigrams('the quick brown fox') -> \[\['the', 'quick'\], \['quick', 'brown'\], \['brown', 'fox'\]\]
+```
+_Sentence bigrams_
+
+---
+
+## `char_count`
+
+**Signature:** `string -> number`
+
+Count characters in text
+
+```
+char_count('hello') -> 5
+```
+_Simple word_
+
+```
+char_count('hello world') -> 11
+```
+_With space_
+
+---
+
+## `char_frequencies`
+
+**Signature:** `string -> object`
+
+Count character frequencies
+
+```
+char_frequencies('aab') -> {a: 2, b: 1}
+```
+_Count repeated chars_
+
+```
+char_frequencies('hello') -> {e: 1, h: 1, l: 2, o: 1}
+```
+_Word frequencies_
+
+---
+
+## `collapse_whitespace`
+
+**Signature:** `string -> string`
+
+Normalize whitespace (multiple spaces to single, trim)
+
+```
+collapse_whitespace('  hello   world  ') -> 'hello world'
+```
+_Collapse spaces_
+
+```
+collapse_whitespace('hello\t\nworld') -> 'hello world'
+```
+_Collapse tabs and newlines_
+
+---
+
+## `is_stopword`
+
+**Signature:** `string, string? -> boolean`
+
+Check if word is a stopword
+
+```
+is_stopword('the') -> true
+```
+_Common stopword_
+
+```
+is_stopword('elephant') -> false
+```
+_Not a stopword_
+
+---
+
+## `ngrams`
+
+**Signature:** `string, number, string? -> array`
+
+Generate n-grams from text (word or character)
+
+```
+ngrams('hello', `3`, 'char') -> \['hel', 'ell', 'llo'\]
+```
+_Character trigrams_
+
+```
+ngrams('a b c d', `2`, 'word') -> \[\['a', 'b'\], \['b', 'c'\], \['c', 'd'\]\]
+```
+_Word bigrams_
+
+---
+
+## `normalize_unicode`
+
+**Signature:** `string, string? -> string`
+
+Unicode normalization (NFC, NFD, NFKC, NFKD)
+
+```
+normalize_unicode('café') -> 'café'
+```
+_NFC normalization (default)_
+
+```
+normalize_unicode('ﬁ', 'NFKC') -> 'fi'
+```
+_Compatibility decomposition_
+
+---
+
+## `paragraph_count`
+
+**Signature:** `string -> number`
+
+Count paragraphs in text
+
+```
+paragraph_count('A\\n\\nB') -> 2
+```
+_Two paragraphs_
+
+```
+paragraph_count('Single paragraph') -> 1
+```
+_Single paragraph_
+
+---
+
+## `reading_time`
+
+**Signature:** `string -> string`
+
+Estimate reading time
+
+```
+reading_time('The quick brown fox') -> \"1 min read\"
+```
+_Short text_
+
+```
+reading_time('') -> \"1 min read\"
+```
+_Empty text minimum_
+
+---
+
+## `reading_time_seconds`
+
+**Signature:** `string -> number`
+
+Estimate reading time in seconds
+
+```
+reading_time_seconds('The quick brown fox jumps over the lazy dog') -> 2
+```
+_Short sentence_
+
+```
+reading_time_seconds('') -> 0
+```
+_Empty text_
+
+---
+
+## `remove_accents`
+
+**Signature:** `string -> string`
+
+Strip diacritics/accents from text
+
+```
+remove_accents('café') -> 'cafe'
+```
+_Remove accent_
+
+```
+remove_accents('naïve résumé') -> 'naive resume'
+```
+_Multiple accents_
+
+---
+
+## `remove_stopwords`
+
+**Signature:** `array, string? -> array`
+
+Remove stopwords from token array
+
+```
+remove_stopwords(\['the', 'quick', 'fox'\]) -> \['quick', 'fox'\]
+```
+_Remove English stopwords_
+
+```
+tokens('The quick brown fox') | remove_stopwords(@) -> \['quick', 'brown', 'fox'\]
+```
+_Pipeline_
+
+---
+
+## `sentence_count`
+
+**Signature:** `string -> number`
+
+Count sentences in text
+
+```
+sentence_count('Hello. World!') -> 2
+```
+_Two sentences_
+
+```
+sentence_count('One sentence') -> 1
+```
+_Single sentence_
+
+---
+
+## `stem`
+
+**Signature:** `string, string? -> string`
+
+Stem a word using Snowball stemmer (Porter algorithm)
+
+```
+stem('running') -> 'run'
+```
+_Basic stemming_
+
+```
+stem('cats') -> 'cat'
+```
+_Plural stemming_
+
+---
+
+## `stems`
+
+**Signature:** `array, string? -> array`
+
+Stem an array of tokens
+
+```
+stems(\['running', 'cats'\]) -> \['run', 'cat'\]
+```
+_Stem multiple words_
+
+```
+tokens('The cats are running') | stems(@) -> \['the', 'cat', 'are', 'run'\]
+```
+_Pipeline with tokens_
+
+---
+
+## `stopwords`
+
+**Signature:** `string? -> array`
+
+Get stopwords list for a language (default: English)
+
+```
+stopwords() | length(@) > `100` -> true
+```
+_English has many stopwords_
+
+```
+stopwords('es') | contains(@, 'el') -> true
+```
+_Spanish stopwords_
+
+---
+
+## `tokenize`
+
+**Signature:** `string, object? -> array`
+
+Configurable tokenization with options for case and punctuation handling
+
+```
+tokenize('Hello, World!') -> \['hello', 'world'\]
+```
+_Default (lowercase, strip punctuation)_
+
+```
+tokenize('Hello, World!', `{"case": "preserve"}`) -> \['Hello', 'World'\]
+```
+_Preserve case_
+
+---
+
+## `tokens`
+
+**Signature:** `string -> array`
+
+Simple word tokenization with normalization (lowercase, strip punctuation)
+
+```
+tokens('Hello, World!') -> \['hello', 'world'\]
+```
+_Basic tokenization_
+
+```
+tokens('The quick, brown fox!') -> \['the', 'quick', 'brown', 'fox'\]
+```
+_Strip punctuation_
+
+---
+
+## `trigrams`
+
+**Signature:** `string -> array`
+
+Generate word trigrams (3-grams)
+
+```
+trigrams('a b c d') -> \[\['a', 'b', 'c'\], \['b', 'c', 'd'\]\]
+```
+_Basic trigrams_
+
+```
+trigrams('the quick brown fox jumps') -> \[\['the', 'quick', 'brown'\], \['quick', 'brown', 'fox'\], \['brown', 'fox', 'jumps'\]\]
+```
+_Sentence trigrams_
+
+---
+
+## `word_count`
+
+**Signature:** `string -> number`
+
+Count words in text
+
+```
+word_count('hello world') -> 2
+```
+_Two words_
+
+```
+word_count('one') -> 1
+```
+_Single word_
+
+---
+
+## `word_frequencies`
+
+**Signature:** `string -> object`
+
+Count word frequencies
+
+```
+word_frequencies('a a b') -> {a: 2, b: 1}
+```
+_Count repeated words_
+
+```
+word_frequencies('the quick brown fox') -> {brown: 1, fox: 1, quick: 1, the: 1}
+```
+_Unique words_
+
+---
+

--- a/skills/jpx-functions/references/type-functions.md
+++ b/skills/jpx-functions/references/type-functions.md
@@ -1,0 +1,236 @@
+# Type Functions (13)
+
+## `auto_parse`
+
+**Signature:** `any -> any`
+
+Intelligently parse strings to numbers, booleans, and nulls
+
+```
+auto_parse({num: \"42\", bool: \"true\", nil: \"null\"}) -> {num: 42, bool: true, nil: null}
+```
+_Parse mixed types_
+
+```
+auto_parse([\"42\", \"true\", \"hello\"]) -> [42, true, \"hello\"]
+```
+_Parse array_
+
+---
+
+## `is_array`
+
+**Signature:** `any -> boolean`
+
+Check if value is an array
+
+```
+is_array([1, 2]) -> true
+```
+_Array returns true_
+
+```
+is_array('hello') -> false
+```
+_String returns false_
+
+---
+
+## `is_boolean`
+
+**Signature:** `any -> boolean`
+
+Check if value is a boolean
+
+```
+is_boolean(`true`) -> true
+```
+_True is boolean_
+
+```
+is_boolean(`false`) -> true
+```
+_False is boolean_
+
+---
+
+## `is_empty`
+
+**Signature:** `any -> boolean`
+
+Check if value is empty
+
+```
+is_empty([]) -> true
+```
+_Empty array_
+
+```
+is_empty('') -> true
+```
+_Empty string_
+
+---
+
+## `is_null`
+
+**Signature:** `any -> boolean`
+
+Check if value is null
+
+```
+is_null(`null`) -> true
+```
+_Null returns true_
+
+```
+is_null('') -> false
+```
+_Empty string is not null_
+
+---
+
+## `is_number`
+
+**Signature:** `any -> boolean`
+
+Check if value is a number
+
+```
+is_number(`42`) -> true
+```
+_Integer is number_
+
+```
+is_number(`3.14`) -> true
+```
+_Float is number_
+
+---
+
+## `is_object`
+
+**Signature:** `any -> boolean`
+
+Check if value is an object
+
+```
+is_object({a: 1}) -> true
+```
+_Object returns true_
+
+```
+is_object({}) -> true
+```
+_Empty object is object_
+
+---
+
+## `is_string`
+
+**Signature:** `any -> boolean`
+
+Check if value is a string
+
+```
+is_string('hello') -> true
+```
+_String returns true_
+
+```
+is_string('') -> true
+```
+_Empty string is string_
+
+---
+
+## `parse_booleans`
+
+**Signature:** `any -> any`
+
+Recursively convert boolean strings to booleans
+
+```
+parse_booleans({active: "true"}) -> {active: true}
+```
+_Parse true_
+
+```
+parse_booleans({flag: "YES"}) -> {flag: true}
+```
+_Parse yes_
+
+---
+
+## `parse_nulls`
+
+**Signature:** `any -> any`
+
+Recursively convert null-like strings to null
+
+```
+parse_nulls({a: "null"}) -> {a: null}
+```
+_Parse null_
+
+```
+parse_nulls({a: "None"}) -> {a: null}
+```
+_Parse None_
+
+---
+
+## `parse_numbers`
+
+**Signature:** `any -> any`
+
+Recursively convert numeric strings to numbers
+
+```
+parse_numbers({count: "42"}) -> {count: 42}
+```
+_Parse integer_
+
+```
+parse_numbers({price: "19.99"}) -> {price: 19.99}
+```
+_Parse float_
+
+---
+
+## `to_boolean`
+
+**Signature:** `any -> boolean`
+
+Convert value to boolean
+
+```
+to_boolean('true') -> true
+```
+_String 'true'_
+
+```
+to_boolean('false') -> false
+```
+_String 'false'_
+
+---
+
+## `type_of`
+
+**Signature:** `any -> string`
+
+Get the type of a value
+
+```
+type_of(`42`) -> \"number\"
+```
+_Number type_
+
+```
+type_of('hello') -> \"string\"
+```
+_String type_
+
+---
+

--- a/skills/jpx-functions/references/units-functions.md
+++ b/skills/jpx-functions/references/units-functions.md
@@ -1,0 +1,74 @@
+# Units Functions (4)
+
+## `convert_length`
+
+**Signature:** `number, string, string -> number`
+
+Convert a length value between meters, kilometers, miles, feet, inches, centimeters, millimeters, yards, and nautical miles
+
+```
+convert_length(`1`, 'km', 'mi') -> 0.621371
+```
+_Kilometers to miles_
+
+```
+convert_length(`1`, 'ft', 'm') -> 0.3048
+```
+_Feet to meters_
+
+---
+
+## `convert_mass`
+
+**Signature:** `number, string, string -> number`
+
+Convert a mass value between kilograms, grams, milligrams, pounds, ounces, tonnes, and stones
+
+```
+convert_mass(`1`, 'kg', 'lbs') -> 2.20462
+```
+_Kilograms to pounds_
+
+```
+convert_mass(`1`, 'lbs', 'kg') -> 0.453592
+```
+_Pounds to kilograms_
+
+---
+
+## `convert_temperature`
+
+**Signature:** `number, string, string -> number`
+
+Convert a temperature value between Celsius, Fahrenheit, and Kelvin
+
+```
+convert_temperature(`100`, 'C', 'F') -> 212
+```
+_Boiling point of water in Fahrenheit_
+
+```
+convert_temperature(`32`, 'F', 'C') -> 0
+```
+_Freezing point in Celsius_
+
+---
+
+## `convert_volume`
+
+**Signature:** `number, string, string -> number`
+
+Convert a volume value between liters, milliliters, gallons, quarts, pints, cups, fluid ounces, tablespoons, and teaspoons
+
+```
+convert_volume(`1`, 'gal', 'l') -> 3.78541
+```
+_Gallons to liters_
+
+```
+convert_volume(`1`, 'l', 'ml') -> 1000
+```
+_Liters to milliliters_
+
+---
+

--- a/skills/jpx-functions/references/url-functions.md
+++ b/skills/jpx-functions/references/url-functions.md
@@ -1,0 +1,110 @@
+# Url Functions (6)
+
+## `query_string_build`
+
+**Signature:** `object -> string`
+
+Build a URL query string from an object
+
+```
+query_string_build({foo: 'bar', baz: 'qux'}) -> "foo=bar&baz=qux"
+```
+_Basic query string_
+
+```
+query_string_build({q: 'hello world'}) -> "q=hello+world"
+```
+_With special characters_
+
+---
+
+## `query_string_parse`
+
+**Signature:** `string -> object`
+
+Parse a URL query string into an object
+
+```
+query_string_parse('foo=bar&baz=qux') -> {foo: 'bar', baz: 'qux'}
+```
+_Basic parsing_
+
+```
+query_string_parse('greeting=hello%20world') -> {greeting: 'hello world'}
+```
+_Encoded values_
+
+---
+
+## `url_build`
+
+**Signature:** `object -> string`
+
+Build a URL from component parts
+
+```
+url_build({scheme: 'https', host: 'example.com'}) -> "https://example.com/"
+```
+_Minimal URL_
+
+```
+url_build({scheme: 'https', host: 'example.com', port: 8080, path: '/api'}) -> full URL
+```
+_With port and path_
+
+---
+
+## `url_decode`
+
+**Signature:** `string -> string`
+
+URL decode a string
+
+```
+url_decode('hello%20world') -> \"hello world\"
+```
+_Decode space_
+
+```
+url_decode('a%2Bb') -> \"a+b\"
+```
+_Decode plus sign_
+
+---
+
+## `url_encode`
+
+**Signature:** `string -> string`
+
+URL encode a string
+
+```
+url_encode('hello world') -> \"hello%20world\"
+```
+_Encode space_
+
+```
+url_encode('a+b') -> \"a%2Bb\"
+```
+_Encode plus_
+
+---
+
+## `url_parse`
+
+**Signature:** `string -> object`
+
+Parse URL into components
+
+```
+url_parse('https://example.com/path') -> {scheme: 'https', ...}
+```
+_Parse full URL_
+
+```
+url_parse('http://user:pass@host:8080') -> components
+```
+_With auth and port_
+
+---
+

--- a/skills/jpx-functions/references/utility-functions.md
+++ b/skills/jpx-functions/references/utility-functions.md
@@ -1,0 +1,200 @@
+# Utility Functions (11)
+
+## `coalesce`
+
+**Signature:** `any... -> any`
+
+Return first non-null value
+
+```
+coalesce(`null`, `null`, 'value') -> \"value\"
+```
+_Skip nulls_
+
+```
+coalesce(field1, field2, 'default') -> first non-null
+```
+_Field fallback_
+
+---
+
+## `default`
+
+**Signature:** `any, any -> any`
+
+Return default value if null
+
+```
+default(`null`, 'fallback') -> \"fallback\"
+```
+_Null uses default_
+
+```
+default('value', 'fallback') -> 'value'
+```
+_Non-null keeps value_
+
+---
+
+## `env`
+
+**Signature:** `-> object`
+
+Get all environment variables as an object
+
+```
+env() -> {HOME: '/Users/...', PATH: '...', ...}
+```
+_All env vars_
+
+```
+env().HOME -> home directory
+```
+_Access specific var_
+
+---
+
+## `get_env`
+
+**Signature:** `string -> string | null`
+
+Get a single environment variable by name
+
+```
+get_env('HOME') -> \"/Users/josh\"
+```
+_Get home directory_
+
+```
+get_env('PATH') -> system PATH
+```
+_Get PATH_
+
+---
+
+## `if`
+
+**Signature:** `boolean, any, any -> any`
+
+Conditional expression
+
+```
+if(`true`, 'yes', 'no') -> \"yes\"
+```
+_True branch_
+
+```
+if(`false`, 'yes', 'no') -> \"no\"
+```
+_False branch_
+
+---
+
+## `json_decode`
+
+**Signature:** `string -> any`
+
+Parse JSON string
+
+```
+json_decode('{\"a\": 1}') -> {a: 1}
+```
+_Parse object_
+
+```
+json_decode('[1, 2, 3]') -> [1, 2, 3]
+```
+_Parse array_
+
+---
+
+## `json_encode`
+
+**Signature:** `any -> string`
+
+Serialize value to JSON string
+
+```
+json_encode({a: 1}) -> \"{\\\"a\\\":1}\"
+```
+_Encode object_
+
+```
+json_encode([1, 2, 3]) -> \"[1,2,3]\"
+```
+_Encode array_
+
+---
+
+## `json_pointer`
+
+**Signature:** `any, string -> any`
+
+Access value using JSON Pointer (RFC 6901)
+
+```
+json_pointer({foo: {bar: 1}}, '/foo/bar') -> 1
+```
+_Nested access_
+
+```
+json_pointer(data, '/0/name') -> first item name
+```
+_Array access_
+
+---
+
+## `now`
+
+**Signature:** `-> number`
+
+Current Unix timestamp in seconds
+
+```
+now() -> 1699900000
+```
+_Current timestamp_
+
+```
+now() - 3600 -> one hour ago
+```
+_Subtract seconds_
+
+---
+
+## `now_ms`
+
+**Signature:** `-> number`
+
+Current Unix timestamp in milliseconds
+
+```
+now_ms() -> 1699900000000
+```
+_Current time in ms_
+
+```
+now_ms() - start_ms -> elapsed ms
+```
+_Calculate duration_
+
+---
+
+## `pretty`
+
+**Signature:** `any, number? -> string`
+
+Pretty-print value as formatted JSON string
+
+```
+pretty({a: 1}) -> \"{\n  \\\"a\\\": 1\n}\"
+```
+_Default 2-space indent_
+
+```
+pretty({a: 1}, `4`) -> 4-space indent
+```
+_Custom indent_
+
+---
+

--- a/skills/jpx-functions/references/uuid-functions.md
+++ b/skills/jpx-functions/references/uuid-functions.md
@@ -1,0 +1,20 @@
+# Uuid Functions (1)
+
+## `uuid`
+
+**Signature:** `-> string`
+
+Generate a UUID v4
+
+```
+uuid() -> \"550e8400-e29b-41d4-a716-446655440000\"
+```
+_Generate UUID_
+
+```
+uuid() -> random unique ID
+```
+_Each call is unique_
+
+---
+

--- a/skills/jpx-functions/references/validation-functions.md
+++ b/skills/jpx-functions/references/validation-functions.md
@@ -1,0 +1,236 @@
+# Validation Functions (13)
+
+## `is_base64`
+
+**Signature:** `string -> boolean`
+
+Check if valid Base64 encoding
+
+```
+is_base64('SGVsbG8=') -> true
+```
+_Valid base64_
+
+```
+is_base64('not valid!') -> false
+```
+_Invalid chars_
+
+---
+
+## `is_credit_card`
+
+**Signature:** `string -> boolean`
+
+Validate credit card number (Luhn check + length)
+
+```
+is_credit_card('4111111111111111') -> true
+```
+_Valid Visa test number_
+
+```
+is_credit_card('1234567890123456') -> false
+```
+_Invalid number_
+
+---
+
+## `is_email`
+
+**Signature:** `string -> boolean`
+
+Validate email address format
+
+```
+is_email('user@example.com') -> true
+```
+_Valid email_
+
+```
+is_email('invalid-email') -> false
+```
+_Missing @_
+
+---
+
+## `is_hex`
+
+**Signature:** `string -> boolean`
+
+Check if valid hexadecimal string
+
+```
+is_hex('deadbeef') -> true
+```
+_Valid hex_
+
+```
+is_hex('ABCDEF') -> true
+```
+_Uppercase hex_
+
+---
+
+## `is_ipv4`
+
+**Signature:** `string -> boolean`
+
+Validate IPv4 address format
+
+```
+is_ipv4('192.168.1.1') -> true
+```
+_Valid IPv4_
+
+```
+is_ipv4('256.1.1.1') -> false
+```
+_Out of range_
+
+---
+
+## `is_ipv6`
+
+**Signature:** `string -> boolean`
+
+Validate IPv6 address format
+
+```
+is_ipv6('::1') -> true
+```
+_Loopback_
+
+```
+is_ipv6('2001:db8::1') -> true
+```
+_Full IPv6_
+
+---
+
+## `is_iso_date`
+
+**Signature:** `string -> boolean`
+
+Validate ISO 8601 date format
+
+```
+is_iso_date('2023-12-13T15:30:00Z') -> true
+```
+_Full ISO format_
+
+```
+is_iso_date('2023-12-13') -> true
+```
+_Date only_
+
+---
+
+## `is_json`
+
+**Signature:** `string -> boolean`
+
+Check if string is valid JSON
+
+```
+is_json('{\"a\": 1}') -> true
+```
+_Valid JSON object_
+
+```
+is_json('[1, 2, 3]') -> true
+```
+_Valid JSON array_
+
+---
+
+## `is_jwt`
+
+**Signature:** `string -> boolean`
+
+Check if valid JWT structure (3 base64url parts)
+
+```
+is_jwt('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U') -> true
+```
+_Valid JWT_
+
+```
+is_jwt('eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiJ9.signature') -> true
+```
+_Three parts with dots_
+
+---
+
+## `is_phone`
+
+**Signature:** `string -> boolean`
+
+Validate phone number format
+
+```
+is_phone('+1-555-123-4567') -> true
+```
+_US format with country code_
+
+```
+is_phone('555-123-4567') -> true
+```
+_US format without country code_
+
+---
+
+## `is_url`
+
+**Signature:** `string -> boolean`
+
+Validate URL format
+
+```
+is_url('https://example.com') -> true
+```
+_Simple HTTPS URL_
+
+```
+is_url('http://localhost:8080/path') -> true
+```
+_URL with port and path_
+
+---
+
+## `is_uuid`
+
+**Signature:** `string -> boolean`
+
+Validate UUID format
+
+```
+is_uuid('550e8400-e29b-41d4-a716-446655440000') -> true
+```
+_Valid UUID v4_
+
+```
+is_uuid('6ba7b810-9dad-11d1-80b4-00c04fd430c8') -> true
+```
+_Valid UUID v1_
+
+---
+
+## `luhn_check`
+
+**Signature:** `string -> boolean`
+
+Generic Luhn algorithm check
+
+```
+luhn_check('79927398713') -> true
+```
+_Valid Luhn number_
+
+```
+luhn_check('4532015112830366') -> true
+```
+_Valid credit card number_
+
+---
+

--- a/skills/jpx-mcp/SKILL.md
+++ b/skills/jpx-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jpx-mcp
-description: "Use the jpx MCP server and its 32 tools for JMESPath evaluation, function discovery, JSON utilities, and cross-server tool discovery. Use when evaluating JMESPath expressions via MCP, exploring available functions, analyzing JSON structure, managing named queries, or registering tools for discovery across MCP servers."
+description: "Invoke jpx MCP server tools for JMESPath evaluation, function discovery, JSON utilities, and cross-server tool discovery. Use when evaluating expressions via MCP, exploring functions, analyzing JSON structure, or managing named queries."
 license: MIT OR Apache-2.0
 metadata:
   author: joshrotenberg

--- a/skills/jpx-mcp/SKILL.md
+++ b/skills/jpx-mcp/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: jpx-mcp
+description: "Use the jpx MCP server and its 32 tools for JMESPath evaluation, function discovery, JSON utilities, and cross-server tool discovery. Use when evaluating JMESPath expressions via MCP, exploring available functions, analyzing JSON structure, managing named queries, or registering tools for discovery across MCP servers."
+license: MIT OR Apache-2.0
+metadata:
+  author: joshrotenberg
+  version: "1.0"
+compatibility: Requires jpx-mcp server (stdio or HTTP transport)
+---
+
+# jpx MCP Server Guide
+
+The jpx MCP server exposes 32 tools for JMESPath evaluation, function discovery, JSON utilities, and more. It supports 400+ extended functions beyond the JMESPath specification.
+
+## Tool Groups
+
+### Evaluation (5 tools)
+
+| Tool | Use when... |
+|------|-------------|
+| `evaluate` | Running a JMESPath expression against inline JSON data |
+| `evaluate_file` | Querying a JSON file on disk (avoids passing large data through protocol) |
+| `batch_evaluate` | Running multiple expressions against the same input (parses once) |
+| `validate` | Checking if an expression is syntactically valid before running it |
+| `explain` | Understanding what an expression does step by step |
+
+**`evaluate` example:**
+```json
+{"expression": "users[?age > `30`].name", "input": "{\"users\":[{\"name\":\"alice\",\"age\":35}]}"}
+```
+
+**`batch_evaluate`** is more efficient than calling `evaluate` multiple times when you need several values from the same data -- it parses the input JSON once.
+
+**`explain`** returns a structured breakdown with node types, functions used, and complexity rating. Works on invalid expressions too (returns parse error details).
+
+### Function Discovery (6 tools)
+
+| Tool | Use when... |
+|------|-------------|
+| `functions` | Listing available functions, optionally filtered by category |
+| `describe` | Getting detailed info on a specific function (signature, examples) |
+| `categories` | Listing all function categories |
+| `search` | Finding functions by keyword (fuzzy matching across names, descriptions) |
+| `similar` | Finding functions related to a known function |
+| `suggest_function` | Describing what you want in natural language |
+
+**Discovery workflow:**
+1. `search` with a keyword to find relevant functions
+2. `describe` to get the full signature and examples
+3. `evaluate` to try it out
+
+**`suggest_function`** accepts plain English: "remove duplicates from an array" returns ranked suggestions with relevance explanations.
+
+### JSON Utilities (7 tools)
+
+| Tool | Use when... |
+|------|-------------|
+| `format` | Pretty-printing or compacting JSON (with configurable indent) |
+| `diff` | Generating RFC 6902 JSON Patch between two documents |
+| `patch` | Applying RFC 6902 JSON Patch operations |
+| `merge` | Applying RFC 7396 JSON Merge Patch |
+| `keys` | Extracting object keys (optionally recursive with dot notation) |
+| `stats` | Analyzing JSON structure (type, size, depth, field analysis) |
+| `paths` | Listing all paths in dot notation (optionally with types/values) |
+
+**Data exploration workflow:**
+1. `stats` to understand overall structure
+2. `paths` to see all available fields
+3. `keys` with `recursive: true` for nested structure
+4. `evaluate` with expressions informed by the structure
+
+### Query Store (5 tools)
+
+| Tool | Use when... |
+|------|-------------|
+| `define_query` | Saving a named query for reuse in the current session |
+| `get_query` | Retrieving a stored query's expression |
+| `delete_query` | Removing a stored query |
+| `list_queries` | Showing all stored queries |
+| `run_query` | Executing a stored query against new input |
+
+**Iterative query building:**
+1. `define_query` with an initial expression
+2. `run_query` to test against data
+3. Refine and `define_query` again (updates existing)
+4. `run_query` with different inputs
+
+Queries are validated on definition -- invalid expressions are rejected.
+
+### Cross-Server Discovery (6 tools)
+
+| Tool | Use when... |
+|------|-------------|
+| `register_tools` | Registering another MCP server's tools for searchable discovery |
+| `query_tools` | Searching across all registered tools (BM25 full-text search) |
+| `similar_tools` | Finding tools similar to a given tool |
+| `unregister_discovery` | Removing a server from the discovery index |
+| `list_discovery_servers` | Listing registered servers |
+| `list_discovery_categories` | Listing tool categories across servers |
+
+**Registration** supports two formats:
+- **Full spec:** Detailed `DiscoverySpec` with params, examples, categories, tags
+- **Simplified:** Just `server_name` + array of `{name, description, tags}`
+
+**Search** uses BM25 indexing across tool names, descriptions, tags, categories, and parameters.
+
+### Engine Info (1 tool)
+
+| Tool | Use when... |
+|------|-------------|
+| `engine_info` | Checking server version, mode, function count, session state |
+
+Optionally include the discovery JSON schema (`include_schema: true`) or index statistics (`include_index_stats: true`).
+
+## Common Workflows
+
+### Explore unfamiliar JSON
+```
+stats(input) -> paths(input) -> evaluate(expression, input)
+```
+
+### Find the right function
+```
+search("group elements") -> describe("group_by") -> evaluate(...)
+```
+
+### Build complex queries iteratively
+```
+define_query("v1", "users[*].name") -> run_query("v1", data) ->
+define_query("v1", "users[?active].name | sort(@)") -> run_query("v1", data)
+```
+
+### Compare JSON documents
+```
+diff(source, target) -> review patch ops -> patch(document, ops)
+```
+
+## Configuration
+
+### Transport modes
+- **stdio** (default): For local MCP client integration
+- **HTTP**: For remote access (`--transport http --host 0.0.0.0 --port 3000`)
+
+### Strict mode
+`--strict` disables all extension functions, limiting to the 26 standard JMESPath functions.
+
+### Config file
+The server discovers `jpx.toml` configuration (cwd -> home -> XDG) for function filtering, query libraries, and other engine settings.
+
+## Related Skills
+
+- [jmespath-query](../jmespath-query/SKILL.md) -- JMESPath expression syntax
+- [jpx-functions](../jpx-functions/SKILL.md) -- 400+ extension functions
+- [jpx-cli](../jpx-cli/SKILL.md) -- Command-line usage

--- a/skills/jpx-mcp/references/discovery.md
+++ b/skills/jpx-mcp/references/discovery.md
@@ -1,0 +1,86 @@
+# Cross-Server Tool Discovery
+
+jpx-mcp includes a tool discovery registry that lets you search across tools from multiple MCP servers.
+
+## Registering Tools
+
+### Simplified Registration
+
+For quick registration with minimal metadata:
+
+```json
+{
+  "server_name": "my-server",
+  "version": "1.0",
+  "tools": [
+    {"name": "search_docs", "description": "Search documentation", "tags": ["search", "docs"]},
+    {"name": "create_issue", "description": "Create a GitHub issue", "tags": ["github", "issues"]}
+  ]
+}
+```
+
+### Full Spec Registration
+
+For detailed registration with parameters, examples, and categories:
+
+```json
+{
+  "spec": {
+    "server": {"name": "my-server", "version": "1.0", "description": "My MCP server"},
+    "tools": [
+      {
+        "name": "search_docs",
+        "description": "Full-text search across documentation",
+        "category": "search",
+        "tags": ["search", "docs", "full-text"],
+        "params": [
+          {"name": "query", "description": "Search query", "required": true},
+          {"name": "limit", "description": "Max results", "required": false}
+        ],
+        "examples": [{"description": "Search for auth docs", "input": {"query": "authentication"}}]
+      }
+    ],
+    "categories": {
+      "search": {"description": "Search and discovery tools"}
+    }
+  }
+}
+```
+
+### Replacing Registrations
+
+By default, `replace: true` overwrites existing registrations for the same server. Set `replace: false` to error if already registered.
+
+## Searching Tools
+
+### query_tools
+
+BM25 full-text search across all registered tools:
+
+```json
+{"query": "search documentation", "top_k": 5}
+```
+
+Searches across tool names, descriptions, tags, categories, and parameter descriptions. Returns ranked results with match scores.
+
+### similar_tools
+
+Find tools related to a known tool:
+
+```json
+{"tool_id": "my-server:search_docs", "top_k": 5}
+```
+
+Uses the tool's indexed content to find related tools across all servers.
+
+## Managing the Registry
+
+- `list_discovery_servers` -- see all registered servers with tool counts
+- `list_discovery_categories` -- see categories across all servers
+- `unregister_discovery` -- remove a server (e.g., before re-registering with updated tools)
+
+## Use Cases
+
+- **Multi-server environments:** Register tools from several MCP servers, then search across all of them to find the right tool for a task
+- **Tool recommendations:** Use `similar_tools` to discover alternative tools you might not know about
+- **Inventory:** `list_discovery_servers` gives a quick overview of all available capabilities

--- a/skills/jpx-mcp/references/query-store.md
+++ b/skills/jpx-mcp/references/query-store.md
@@ -1,0 +1,40 @@
+# Query Store
+
+The query store lets you save, retrieve, and execute named JMESPath queries within a session.
+
+## Workflow
+
+### Define and iterate
+```
+define_query("users-by-role", "group_by(@, &role)")
+run_query("users-by-role", <user data>)
+# Refine...
+define_query("users-by-role", "group_by([?active], &role)")
+run_query("users-by-role", <user data>)
+```
+
+### Build a library of queries
+```
+define_query("active-users", "[?status == 'active']", "Filter to active users only")
+define_query("top-scores", "sort_by(@, &score) | reverse(@) | [:10]", "Top 10 by score")
+define_query("error-rate", "length([?level == 'error']) / length(@)", "Error rate")
+```
+
+### Review stored queries
+```
+list_queries -> shows all names, expressions, and descriptions
+get_query("active-users") -> returns expression and description
+```
+
+### Clean up
+```
+delete_query("old-query")
+```
+
+## Notes
+
+- Queries are session-scoped -- they don't persist across server restarts
+- Expressions are validated on `define_query` -- invalid syntax is rejected
+- `define_query` with an existing name overwrites the previous query
+- `run_query` parses the input JSON and applies the stored expression
+- Descriptions are optional but help when reviewing stored queries with `list_queries`

--- a/skills/jpx-mcp/references/tool-reference.md
+++ b/skills/jpx-mcp/references/tool-reference.md
@@ -1,0 +1,182 @@
+# jpx MCP Tool Reference
+
+Complete parameter reference for all 32 tools.
+
+## Evaluation Tools
+
+### evaluate
+Evaluate a JMESPath expression against JSON input.
+- `expression` (string, required): JMESPath expression
+- `input` (string, required): JSON input as string
+
+### evaluate_file
+Evaluate a JMESPath expression against a JSON file on disk.
+- `expression` (string, required): JMESPath expression
+- `file_path` (string, required): Absolute path to JSON file (max 50MB)
+
+### batch_evaluate
+Evaluate multiple expressions against the same JSON input.
+- `expressions` (array of strings, required): List of JMESPath expressions
+- `input` (string, required): JSON input as string
+
+Returns an array of results, one per expression.
+
+### validate
+Check if a JMESPath expression is syntactically valid.
+- `expression` (string, required): JMESPath expression to validate
+
+Returns `{valid: true}` or `{valid: false, error: "..."}`.
+
+### explain
+Break down a JMESPath expression into steps.
+- `expression` (string, required): JMESPath expression to explain
+
+Returns structured breakdown: node types, descriptions, functions used, depth, complexity rating. Works on invalid expressions (returns parse error).
+
+## Function Discovery Tools
+
+### functions
+List available JMESPath functions.
+- `category` (string, optional): Filter by category name (e.g., "String", "Math", "Array")
+
+Returns array of `{name, signature, description}`.
+
+### describe
+Get detailed information about a specific function.
+- `name` (string, required): Function name or alias
+
+Returns `{name, signature, description, category, examples, aliases}` or error if unknown.
+
+### categories
+List all function categories. No parameters.
+
+Returns array of category name strings.
+
+### search
+Search for functions using fuzzy matching.
+- `query` (string, required): Search query
+- `limit` (number, optional, default 20): Max results
+
+Searches across names, descriptions, categories, signatures, and aliases. Returns ranked results with match type and score.
+
+### similar
+Find functions similar to a specified function.
+- `function` (string, required): Function name
+
+Returns functions in the same category, with similar signatures, or related by description keywords.
+
+### suggest_function
+Suggest functions for a natural-language task description.
+- `task` (string, required): Plain-English description (e.g., "remove duplicates")
+- `limit` (number, optional, default 5): Max suggestions
+
+Strips filler words and searches. Returns ranked suggestions with relevance explanations.
+
+## JSON Utility Tools
+
+### format
+Pretty-print or compact JSON.
+- `input` (string, required): JSON string
+- `indent` (number, optional, default 2): Spaces for indentation (0 for compact)
+
+### diff
+Generate RFC 6902 JSON Patch between two documents.
+- `source` (string, required): Source JSON document
+- `target` (string, required): Target JSON document
+
+Returns array of patch operations (add, remove, replace, move, copy, test).
+
+### patch
+Apply RFC 6902 JSON Patch to a document.
+- `input` (string, required): JSON document
+- `patch` (string, required): JSON Patch operations array
+
+### merge
+Apply RFC 7396 JSON Merge Patch to a document.
+- `input` (string, required): JSON document
+- `patch` (string, required): JSON Merge Patch document
+
+### keys
+Extract keys from a JSON object.
+- `input` (string, required): JSON document
+- `recursive` (boolean, optional, default false): If true, returns all nested keys in dot notation
+
+### stats
+Analyze JSON structure.
+- `input` (string, required): JSON to analyze
+
+Returns type, size, depth, field analysis (for arrays of objects), and type distribution.
+
+### paths
+Extract all paths from JSON in dot notation.
+- `input` (string, required): JSON to extract paths from
+- `include_types` (boolean, optional, default true): Include type for each path
+- `include_values` (boolean, optional, default false): Include values for leaf paths
+
+## Query Store Tools
+
+### define_query
+Store a named query for the session.
+- `name` (string, required): Unique query name
+- `expression` (string, required): JMESPath expression
+- `description` (string, optional): What the query does
+
+Expression is validated before storing. Overwrites existing query with same name.
+
+### get_query
+Retrieve a stored query.
+- `name` (string, required): Query name
+
+### delete_query
+Delete a stored query.
+- `name` (string, required): Query name
+
+### list_queries
+List all stored queries. No parameters.
+
+### run_query
+Execute a stored query against input.
+- `name` (string, required): Query name
+- `input` (string, required): JSON input as string
+
+## Discovery Tools
+
+### register_tools
+Register an MCP server's tools for cross-server discovery.
+
+**Full spec format:**
+- `spec` (object): Complete DiscoverySpec with `server`, `tools`, `categories`
+- `replace` (boolean, optional, default true): Replace existing registration
+
+**Simplified format:**
+- `server_name` (string): Server name
+- `version` (string, optional): Server version
+- `tools` (array): List of `{name, description, tags}`
+- `replace` (boolean, optional, default true)
+
+### query_tools
+Search across all registered tools.
+- `query` (string, required): Search query
+- `top_k` (number, optional, default 10): Max results
+
+### similar_tools
+Find tools similar to a specified tool.
+- `tool_id` (string, required): Tool ID in "server:tool_name" format
+- `top_k` (number, optional, default 5): Max results
+
+### unregister_discovery
+Remove a server from the discovery index.
+- `server_name` (string, required): Server name to remove
+
+### list_discovery_servers
+List all registered servers. No parameters.
+
+### list_discovery_categories
+List tool categories from registered servers. No parameters.
+
+## Engine Info
+
+### engine_info
+Get engine information.
+- `include_schema` (boolean, optional, default false): Include discovery JSON schema
+- `include_index_stats` (boolean, optional, default false): Include BM25 index statistics


### PR DESCRIPTION
## Summary

Add a `skills/` directory with four [Agent Skills](https://agentskills.io/) for AI agent integration. Skills are supported by Claude Code, Cursor, VS Code Copilot, Gemini CLI, OpenAI Codex, and 25+ other agent products.

### Skills

| Skill | Lines | References | Audience |
|-------|-------|------------|----------|
| `jmespath-query` | 278 | 3 files | Any agent working with JSON (tool-agnostic) |
| `jpx-cli` | 235 | 3 files | jpx CLI users |
| `jpx-functions` | 169 | 33 files | Users of jpx extension functions |
| `jpx-mcp` | 154 | 3 files | jpx MCP server users |

**46 files total**, all SKILL.md files under the 500-line recommendation.

### Design

- **Progressive disclosure**: SKILL.md has the overview, references/ has the deep-dive docs
- **`jmespath-query` is standalone** -- useful with AWS CLI, Azure CLI, Boto3, any JMESPath implementation
- **`jpx-functions` references are generated** from `functions.toml` (33 per-category files covering all 400+ functions)
- **Skills cross-reference each other** where relevant
- **`jpx-cli` includes `allowed-tools: Bash(jpx:*)`** for agents that support tool pre-approval

### Structure

```
skills/
├── jmespath-query/     # JMESPath syntax, patterns, built-in functions
│   ├── SKILL.md
│   └── references/     # syntax-reference, filter-patterns, let-expressions
├── jpx-cli/            # CLI usage, output formats, streaming, pipelines
│   ├── SKILL.md
│   └── references/     # output-formats, streaming, query-files
├── jpx-functions/      # 400+ extension functions
│   ├── SKILL.md
│   └── references/     # 33 per-category function reference files
└── jpx-mcp/            # MCP server tools and configuration
    ├── SKILL.md
    └── references/     # tool-reference, discovery, query-store
```

## Test plan

- [x] All SKILL.md frontmatter valid (name matches directory, description present)
- [x] All SKILL.md under 500 lines
- [x] Function reference files generated from functions.toml (33 categories, 459 functions)
- [x] Internal cross-references between skills are consistent
- [ ] Manual review of content accuracy

Closes #177, closes #178, closes #179, closes #180, closes #181