### PR TITLE
chore: fix stale counts across docs and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,15 +9,15 @@ This project includes [Agent Skills](https://agentskills.io/) in the `skills/` d
 | Skill | When to use |
 |-------|-------------|
 | [`jmespath-query`](skills/jmespath-query/SKILL.md) | Writing JMESPath expressions (syntax, patterns, built-in functions) |
-| [`jpx-functions`](skills/jpx-functions/SKILL.md) | Using the 400+ extension functions (signatures, categories, examples) |
+| [`jpx-functions`](skills/jpx-functions/SKILL.md) | Using the 460+ extension functions (signatures, categories, examples) |
 | [`jpx-cli`](skills/jpx-cli/SKILL.md) | Using the jpx CLI (output formats, streaming, pipelines, REPL) |
-| [`jpx-mcp`](skills/jpx-mcp/SKILL.md) | Using the jpx MCP server (32 tools, discovery, query store) |
+| [`jpx-mcp`](skills/jpx-mcp/SKILL.md) | Using the jpx MCP server (30 tools, discovery, query store) |
 
 Each skill has a SKILL.md overview and a `references/` directory with detailed docs loaded on demand.
 
 ## Project overview
 
-jpx is a JMESPath CLI and toolchain with 400+ extension functions — a `jq` alternative.
+jpx is a JMESPath CLI and toolchain with 460+ extension functions — a `jq` alternative.
 Written in Rust (edition 2024, rust-version 1.90), dual-licensed MIT/Apache-2.0.
 
 ### Workspace crates
@@ -25,9 +25,9 @@ Written in Rust (edition 2024, rust-version 1.90), dual-licensed MIT/Apache-2.0.
 | Crate | Path | Description |
 |---|---|---|
 | `jpx` | `crates/jpx/` | CLI with REPL, streaming, multiple output formats (JSON, YAML, CSV, TSV, table) |
-| `jpx-core` | `crates/jpx-core/` | From-scratch JMESPath parser and interpreter, 425 functions across 32 categories |
+| `jpx-core` | `crates/jpx-core/` | From-scratch JMESPath parser and interpreter, 462 functions across 33 categories |
 | `jpx-engine` | `crates/jpx-engine/` | Query engine, introspection, BM25 discovery index, config |
-| `jpx-mcp` | `crates/jpx-mcp/` | MCP server (32 tools) built on `tower-mcp` |
+| `jpx-mcp` | `crates/jpx-mcp/` | MCP server (30 tools) built on `tower-mcp` |
 | `python` | `python/` | Python bindings via PyO3 (`jmespath-extensions` on PyPI) |
 
 ## Build and test
@@ -50,7 +50,7 @@ cargo build -p jpx --features parquet
 ### Feature flags
 
 - `let-expr` — JEP-18 let expressions (`let $var = expr in body`)
-- `extensions` — all 400+ extension functions (default on for jpx-core)
+- `extensions` — all 460+ extension functions (default on for jpx-core)
 - `parquet` — Parquet file input support (CLI only)
 - `arrow` — Arrow array support (jpx-engine)
 - `schema` — JSON Schema generation via schemars (jpx-engine, for MCP)
@@ -143,7 +143,7 @@ group_by(arr, 'region') | items(@) | [*].{region: [0], count: length([1])}
 
 ## Function discovery
 
-jpx has 400+ functions across 32 categories. Never guess function names — discover them:
+jpx has 460+ functions across 33 categories. Never guess function names -- discover them:
 
 ```bash
 # Search by keyword (BM25 full-text search)
@@ -175,7 +175,7 @@ Always use `describe` to check a function's exact signature before using it.
 
 ## MCP server tools
 
-The MCP server exposes 32 tools. Key patterns:
+The MCP server exposes 30 tools. Key patterns:
 
 - **`evaluate`** / **`evaluate_file`** — run a JMESPath expression against JSON input or a file
 - **`batch_evaluate`** — run multiple expressions against the same input

--- a/skills/jmespath-query/SKILL.md
+++ b/skills/jmespath-query/SKILL.md
@@ -275,4 +275,4 @@ length([?status != 'ok']) == `0`        -- all ok?
 
 ## Extended Functions
 
-jpx extends JMESPath with 400+ additional functions for strings, math, dates, hashing, encoding, regex, and more. See the [jpx-functions skill](../jpx-functions/SKILL.md) for details.
+jpx extends JMESPath with 460+ additional functions for strings, math, dates, hashing, encoding, regex, and more. See the [jpx-functions skill](../jpx-functions/SKILL.md) for details.

--- a/skills/jpx-cli/SKILL.md
+++ b/skills/jpx-cli/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(jpx:*)
 
 # jpx CLI Usage Guide
 
-jpx is a JMESPath CLI with 400+ extended functions. It reads JSON, applies expressions, and outputs results in multiple formats.
+jpx is a JMESPath CLI with 460+ extended functions. It reads JSON, applies expressions, and outputs results in multiple formats.
 
 ## Basic Usage
 
@@ -166,7 +166,7 @@ See [references/query-files.md](references/query-files.md) for the `.jpx` file f
 ## Function Discovery
 
 ```bash
-jpx --list-functions                     # all 400+ functions
+jpx --list-functions                     # all 460+ functions
 jpx --list-category String              # functions in a category
 jpx --describe format_date              # detailed function info
 jpx --search "date format"             # fuzzy search
@@ -231,5 +231,5 @@ jpx 'dependencies | keys(@) | sort(@)' package.json
 ## Related Skills
 
 - [jmespath-query](../jmespath-query/SKILL.md) -- JMESPath expression syntax
-- [jpx-functions](../jpx-functions/SKILL.md) -- 400+ extension functions
+- [jpx-functions](../jpx-functions/SKILL.md) -- 460+ extension functions
 - [jpx-mcp](../jpx-mcp/SKILL.md) -- MCP server for AI agent integration

--- a/skills/jpx-functions/SKILL.md
+++ b/skills/jpx-functions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jpx-functions
-description: "Look up and call the 400+ extension functions in jpx beyond standard JMESPath. Covers array, string, math, datetime, hash, encoding, regex, object, expression (higher-order), geo, text, validation, and 20+ more categories. Use when a task needs functions beyond the 26 standard JMESPath built-ins."
+description: "Look up and call the 460+ extension functions in jpx beyond standard JMESPath. Covers array, string, math, datetime, hash, encoding, regex, object, expression (higher-order), geo, text, validation, and 20+ more categories. Use when a task needs functions beyond the 26 standard JMESPath built-ins."
 license: MIT OR Apache-2.0
 metadata:
   author: joshrotenberg
@@ -10,7 +10,7 @@ compatibility: Requires jpx, jpx-core, jpx-engine, or jpx-python
 
 # jpx Extension Functions
 
-jpx extends JMESPath with 400+ functions across 33 categories. This skill covers function discovery, the most commonly used functions, and key conventions.
+jpx extends JMESPath with 460+ functions across 33 categories. This skill covers function discovery, the most commonly used functions, and key conventions.
 
 ## Discovering Functions
 

--- a/skills/jpx-mcp/SKILL.md
+++ b/skills/jpx-mcp/SKILL.md
@@ -10,7 +10,7 @@ compatibility: Requires jpx-mcp server (stdio or HTTP transport)
 
 # jpx MCP Server Guide
 
-The jpx MCP server exposes 32 tools for JMESPath evaluation, function discovery, JSON utilities, and more. It supports 400+ extended functions beyond the JMESPath specification.
+The jpx MCP server exposes 30 tools for JMESPath evaluation, function discovery, JSON utilities, and more. It supports 460+ extended functions beyond the JMESPath specification.
 
 ## Tool Groups
 
@@ -150,5 +150,5 @@ The server discovers `jpx.toml` configuration (cwd -> home -> XDG) for function 
 ## Related Skills
 
 - [jmespath-query](../jmespath-query/SKILL.md) -- JMESPath expression syntax
-- [jpx-functions](../jpx-functions/SKILL.md) -- 400+ extension functions
+- [jpx-functions](../jpx-functions/SKILL.md) -- 460+ extension functions
 - [jpx-cli](../jpx-cli/SKILL.md) -- Command-line usage

--- a/skills/jpx-mcp/references/tool-reference.md
+++ b/skills/jpx-mcp/references/tool-reference.md
@@ -1,6 +1,6 @@
 # jpx MCP Tool Reference
 
-Complete parameter reference for all 32 tools.
+Complete parameter reference for all 30 tools.
 
 ## Evaluation Tools
 


### PR DESCRIPTION
## Summary

Fix stale numbers that accumulated across docs and skills:

| Item | Was | Actual |
|------|-----|--------|
| MCP tools | 32 | **30** (verified via `ToolBuilder::new` count and test assertion) |
| Extension functions | 400+ | **460+** (462 in functions.toml) |
| Function categories | 31/32 | **33** |
| jpx-core description | 425 functions, 32 categories | **462 functions, 33 categories** |

### Files updated
- `AGENTS.md` -- tool counts, function counts, category counts
- `skills/jmespath-query/SKILL.md` -- function count
- `skills/jpx-cli/SKILL.md` -- function count references
- `skills/jpx-functions/SKILL.md` -- description and body count
- `skills/jpx-mcp/SKILL.md` -- tool count and function count
- `skills/jpx-mcp/references/tool-reference.md` -- tool count
- GitHub repo description updated to "460+ extended functions"
- `CLAUDE.md` updated locally (gitignored)
- Memory file updated

## Test plan

- [x] Grep confirms no remaining "400+", "32 tool", or "31 categor" references in tracked files
- [ ] CI passes