### PR TITLE
Prepare jpx Python package for first PyPI release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -2295,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2954,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/crates/jpx-core/src/extensions/discovery.rs
+++ b/crates/jpx-core/src/extensions/discovery.rs
@@ -167,7 +167,7 @@ impl Function for FuzzySearchFn {
         }
 
         // Sort by score descending
-        results.sort_by(|a, b| b.0.cmp(&a.0));
+        results.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         let result_array: Vec<Value> = results.into_iter().map(|(_, item)| item).collect();
         Ok(Value::Array(result_array))

--- a/crates/jpx-engine/src/bm25.rs
+++ b/crates/jpx-engine/src/bm25.rs
@@ -549,7 +549,7 @@ impl Bm25Index {
             .iter()
             .map(|(t, info)| (t.clone(), info.df))
             .collect();
-        terms.sort_by(|a, b| b.1.cmp(&a.1)); // Sort by df descending
+        terms.sort_by_key(|b| std::cmp::Reverse(b.1)); // Sort by df descending
         terms
     }
 

--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -372,7 +372,7 @@ impl JpxEngine {
             .filter(|(_, score)| *score > 0)
             .collect();
 
-        concept_scores.sort_by(|a, b| b.1.cmp(&a.1));
+        concept_scores.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         let related_concepts: Vec<FunctionDetail> = concept_scores
             .into_iter()

--- a/crates/jpx/src/discovery.rs
+++ b/crates/jpx/src/discovery.rs
@@ -148,7 +148,7 @@ pub(crate) fn search_functions(registry: &FunctionRegistry, query: &str) {
     }
 
     // Sort by score descending
-    results.sort_by(|a, b| b.score.cmp(&a.score));
+    results.sort_by_key(|b| std::cmp::Reverse(b.score));
 
     if results.is_empty() {
         println!(
@@ -260,7 +260,7 @@ pub(crate) fn suggest_for_unknown_function(
         })
         .collect();
 
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     if scored.is_empty() {
         return None;
@@ -443,7 +443,7 @@ pub(crate) fn find_similar_functions(registry: &FunctionRegistry, func_name: &st
         })
         .collect();
 
-    related.sort_by(|a, b| b.1.cmp(&a.1));
+    related.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     if !related.is_empty() {
         println!("  {} {}:", "▸".dimmed(), "Related concepts".bold());

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -19,5 +19,5 @@ crate-type = ["cdylib"]
 [dependencies]
 jpx-core = { workspace = true, features = ["extensions"] }
 jpx-engine = { workspace = true, features = ["let-expr"] }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module"] }
 serde_json = { workspace = true }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -19,5 +19,5 @@ crate-type = ["cdylib"]
 [dependencies]
 jpx-core = { workspace = true, features = ["extensions"] }
 jpx-engine = { workspace = true, features = ["let-expr"] }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module", "abi3-py39"] }
 serde_json = { workspace = true }

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,66 @@
+# jpx
+
+Python bindings for [jpx](https://github.com/joshrotenberg/jpx), a JMESPath query
+engine with 460+ extended functions on top of the standard JMESPath specification.
+
+The bindings are built in Rust with [PyO3](https://pyo3.rs) and ship as
+abi3 wheels, so a single wheel per platform works on CPython 3.9 and newer.
+
+## Install
+
+```bash
+pip install jpx
+```
+
+## Quick start
+
+```python
+import jpx
+
+data = {"people": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]}
+
+# Run a query
+jpx.search("people[?age > `28`].name", data)
+# ['Alice']
+
+# Compile once, reuse many times
+expr = jpx.compile("people[*].name")
+expr.search(data)
+# ['Alice', 'Bob']
+
+# Validate an expression without running it
+jpx.validate("people[*].name")
+# {'valid': True, ...}
+```
+
+## Discovering functions
+
+```python
+jpx.list_categories()           # extension categories
+jpx.list_functions("string")    # functions in a category
+jpx.describe("group_by")        # metadata for a single function
+```
+
+## Full engine
+
+`JpxEngine` exposes the complete engine: batch evaluation, function
+introspection, JSON utilities (diff, patch, merge, stats, paths), and a
+session-scoped named query store.
+
+```python
+from jpx import JpxEngine
+
+engine = JpxEngine()
+engine.evaluate("a.b", {"a": {"b": 1}})
+engine.diff({"a": 1}, {"a": 2})        # RFC 6902 patch
+engine.stats({"a": [1, 2, 3]})          # structural stats
+```
+
+## Links
+
+- Documentation: https://joshrotenberg.github.io/jpx/
+- Source and issues: https://github.com/joshrotenberg/jpx
+
+## License
+
+MIT OR Apache-2.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,9 +5,10 @@ build-backend = "maturin"
 [project]
 name = "jpx"
 version = "0.1.0"
-description = "JMESPath query engine with 400+ functions - Python bindings for jpx-core and jpx-engine"
+description = "JMESPath query engine with 460+ functions - Python bindings for jpx-core and jpx-engine"
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Josh Rotenberg", email = "joshrotenberg@gmail.com" }]
+readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR makes the first **jpx Python package** publish to PyPI clean and broadly installable, and clears the security + CI blockers in the way.

## 1. Security (RUSTSEC)

| Crate | Advisory | Issue | Fix |
|-------|----------|-------|-----|
| pyo3 0.23.5 | [RUSTSEC-2025-0020](https://rustsec.org/advisories/RUSTSEC-2025-0020) | Buffer overflow in `PyString::from_object` | → 0.24.2 |
| bytes 1.11.0 | [RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007) | Integer overflow in `BytesMut::reserve` | → 1.11.1 |

`cargo audit` goes from 2 vulnerabilities to **0**. The pyo3 bump needs no binding code changes (the bindings already use the non-deprecated `into_pyobject`).

## 2. abi3 wheels + PyPI page

Without this, the first publish would build a **CPython 3.12-only** wheel (despite `requires-python = ">=3.9"`), leaving 3.9/3.10/3.11/3.13 users with no installable wheel, and the PyPI page would be blank.

- pyo3 now enables `abi3-py39` -> one `cp39-abi3` wheel per platform, installs on CPython 3.9+. Verified: `jpx-0.1.0-cp39-abi3-macosx_11_0_arm64.whl`.
- Added `python/README.md` + `readme = "README.md"`.
- Corrected the stale "400+" count to "460+" in the package description.

## 3. CI unblock

CI pins a floating `stable` toolchain; clippy 1.96 promoted `clippy::unnecessary_sort_by`, which was failing `clippy --workspace -- -D warnings` on every PR. Six descending sorts (jpx-core, jpx-engine, jpx CLI) now use `sort_by_key(std::cmp::Reverse(..))` -- identical behavior, all tests pass.

## Verification

- `cargo audit` -> 0 vulnerabilities
- `cargo clippy --all-features --workspace -- -D warnings` clean; `cargo fmt --check` clean
- `maturin build` produces a `cp39-abi3` wheel; all **72 Python tests pass**
- Full workspace builds on Linux/CI

Once merged, pushing the `py-v0.1.0` tag triggers the first PyPI publish for the package requested in #184.
