### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aho-corasick",
  "base64",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "dirs",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.2.2" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.3.5" }
+jpx-core = { path = "crates/jpx-core", version = "0.3.0" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.4.0" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.2...jpx-core-v0.3.0) - 2026-06-11
+
+### Added
+
+- register 37 implemented-but-unlisted extension functions ([#190](https://github.com/joshrotenberg/jpx/pull/190)) ([#201](https://github.com/joshrotenberg/jpx/pull/201))
+
+### Fixed
+
+- resolve jpx-core name collisions and from_epoch_ms pre-epoch handling ([#189](https://github.com/joshrotenberg/jpx/pull/189)) ([#211](https://github.com/joshrotenberg/jpx/pull/211))
+- report error column in characters and bound slice length cast ([#210](https://github.com/joshrotenberg/jpx/pull/210))
+- stop datetime panics and bound allocation in extensions ([#208](https://github.com/joshrotenberg/jpx/pull/208))
+- deduplicate flatten/mask name collisions ([#209](https://github.com/joshrotenberg/jpx/pull/209))
+- prevent user data from colliding with expref sentinels ([#207](https://github.com/joshrotenberg/jpx/pull/207))
+- eliminate UTF-8 byte-slice panics in CLI and extensions ([#198](https://github.com/joshrotenberg/jpx/pull/198))
+- bound parser and interpreter recursion depth (stack-overflow DoS) ([#197](https://github.com/joshrotenberg/jpx/pull/197))
+
+### Other
+
+- release-readiness audit -- refresh stale counts, add crate READMEs, fix doc warnings ([#216](https://github.com/joshrotenberg/jpx/pull/216))
+- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
+- mark extensible public enums non_exhaustive; thiserror for ErrorReason ([#214](https://github.com/joshrotenberg/jpx/pull/214))
+- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
+- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
+
 ## [0.2.2](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.1...jpx-core-v0.2.2) - 2026-03-16
 
 ### Added

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.5...jpx-engine-v0.4.0) - 2026-06-11
+
+### Added
+
+- add batch introspection (describe_functions + batch_describe MCP tool) ([#213](https://github.com/joshrotenberg/jpx/pull/213))
+
+### Fixed
+
+- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))
+
+### Other
+
+- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
+- mark extensible public enums non_exhaustive; thiserror for ErrorReason ([#214](https://github.com/joshrotenberg/jpx/pull/214))
+- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
+- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
+
 ## [0.3.5](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.4...jpx-engine-v0.3.5) - 2026-03-16
 
 ### Other

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.3.5"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.4...jpx-mcp-v0.5.0) - 2026-06-11
+
+### Added
+
+- add batch introspection (describe_functions + batch_describe MCP tool) ([#213](https://github.com/joshrotenberg/jpx/pull/213))
+
+### Fixed
+
+- bound MCP resource usage on untrusted input ([#204](https://github.com/joshrotenberg/jpx/pull/204))
+- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))
+
+### Other
+
+- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
+- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
+
 ## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.3...jpx-mcp-v0.4.4) - 2026-03-16
 
 ### Added

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.4...jpx-v0.5.0) - 2026-06-11
+
+### Added
+
+- add --cheatsheet flag for a one-page quick reference ([#212](https://github.com/joshrotenberg/jpx/pull/212))
+- register 37 implemented-but-unlisted extension functions ([#190](https://github.com/joshrotenberg/jpx/pull/190)) ([#201](https://github.com/joshrotenberg/jpx/pull/201))
+
+### Fixed
+
+- deduplicate flatten/mask name collisions ([#209](https://github.com/joshrotenberg/jpx/pull/209))
+- replace unmaintained atty with std::io::IsTerminal ([#205](https://github.com/joshrotenberg/jpx/pull/205))
+- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))
+- correct streaming pipeline error handling and CLI cleanups ([#200](https://github.com/joshrotenberg/jpx/pull/200))
+- terminate cleanly on a broken pipe (SIGPIPE) ([#199](https://github.com/joshrotenberg/jpx/pull/199))
+- eliminate UTF-8 byte-slice panics in CLI and extensions ([#198](https://github.com/joshrotenberg/jpx/pull/198))
+
+### Other
+
+- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
+- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
+- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
+
 ## [0.4.4](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.3...jpx-v0.4.4) - 2026-03-16
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.2.2 -> 0.3.0 (⚠ API breaking changes)
* `jpx-engine`: 0.3.5 -> 0.4.0 (⚠ API breaking changes)
* `jpx`: 0.4.4 -> 0.5.0 (✓ API compatible changes)
* `jpx-mcp`: 0.4.4 -> 0.5.0 (✓ API compatible changes)

### ⚠ `jpx-core` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Category in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/registry.rs:21
  enum Category in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/registry.rs:21
  enum RuntimeError in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/error.rs:95
  enum Feature in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/registry.rs:155
  enum Feature in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/registry.rs:155
  enum ErrorReason in /tmp/.tmpH9fWLU/jpx/crates/jpx-core/src/error.rs:80

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct jpx_core::extensions::datetime::NowFn, previously in file /tmp/.tmpafPNUo/jpx-core/src/extensions/datetime.rs:120
  struct jpx_core::extensions::array::ModeFn, previously in file /tmp/.tmpafPNUo/jpx-core/src/extensions/array.rs:936
  struct jpx_core::extensions::string::RedactFn, previously in file /tmp/.tmpafPNUo/jpx-core/src/extensions/string.rs:1475
  struct jpx_core::extensions::type_conv::IsBlankFn, previously in file /tmp/.tmpafPNUo/jpx-core/src/extensions/type_conv.rs:207
  struct jpx_core::extensions::type_conv::IsJsonFn, previously in file /tmp/.tmpafPNUo/jpx-core/src/extensions/type_conv.rs:226
```

### ⚠ `jpx-engine` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum EngineError in /tmp/.tmpH9fWLU/jpx/crates/jpx-engine/src/error.rs:151
  enum EvaluationErrorKind in /tmp/.tmpH9fWLU/jpx/crates/jpx-engine/src/error.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.2...jpx-core-v0.3.0) - 2026-06-11

### Added

- register 37 implemented-but-unlisted extension functions ([#190](https://github.com/joshrotenberg/jpx/pull/190)) ([#201](https://github.com/joshrotenberg/jpx/pull/201))

### Fixed

- resolve jpx-core name collisions and from_epoch_ms pre-epoch handling ([#189](https://github.com/joshrotenberg/jpx/pull/189)) ([#211](https://github.com/joshrotenberg/jpx/pull/211))
- report error column in characters and bound slice length cast ([#210](https://github.com/joshrotenberg/jpx/pull/210))
- stop datetime panics and bound allocation in extensions ([#208](https://github.com/joshrotenberg/jpx/pull/208))
- deduplicate flatten/mask name collisions ([#209](https://github.com/joshrotenberg/jpx/pull/209))
- prevent user data from colliding with expref sentinels ([#207](https://github.com/joshrotenberg/jpx/pull/207))
- eliminate UTF-8 byte-slice panics in CLI and extensions ([#198](https://github.com/joshrotenberg/jpx/pull/198))
- bound parser and interpreter recursion depth (stack-overflow DoS) ([#197](https://github.com/joshrotenberg/jpx/pull/197))

### Other

- release-readiness audit -- refresh stale counts, add crate READMEs, fix doc warnings ([#216](https://github.com/joshrotenberg/jpx/pull/216))
- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
- mark extensible public enums non_exhaustive; thiserror for ErrorReason ([#214](https://github.com/joshrotenberg/jpx/pull/214))
- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.5...jpx-engine-v0.4.0) - 2026-06-11

### Added

- add batch introspection (describe_functions + batch_describe MCP tool) ([#213](https://github.com/joshrotenberg/jpx/pull/213))

### Fixed

- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))

### Other

- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
- mark extensible public enums non_exhaustive; thiserror for ErrorReason ([#214](https://github.com/joshrotenberg/jpx/pull/214))
- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
</blockquote>

## `jpx`

<blockquote>

## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.4...jpx-v0.5.0) - 2026-06-11

### Added

- add --cheatsheet flag for a one-page quick reference ([#212](https://github.com/joshrotenberg/jpx/pull/212))
- register 37 implemented-but-unlisted extension functions ([#190](https://github.com/joshrotenberg/jpx/pull/190)) ([#201](https://github.com/joshrotenberg/jpx/pull/201))

### Fixed

- deduplicate flatten/mask name collisions ([#209](https://github.com/joshrotenberg/jpx/pull/209))
- replace unmaintained atty with std::io::IsTerminal ([#205](https://github.com/joshrotenberg/jpx/pull/205))
- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))
- correct streaming pipeline error handling and CLI cleanups ([#200](https://github.com/joshrotenberg/jpx/pull/200))
- terminate cleanly on a broken pipe (SIGPIPE) ([#199](https://github.com/joshrotenberg/jpx/pull/199))
- eliminate UTF-8 byte-slice panics in CLI and extensions ([#198](https://github.com/joshrotenberg/jpx/pull/198))

### Other

- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
- Prepare jpx Python package for first PyPI release ([#185](https://github.com/joshrotenberg/jpx/pull/185))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.4...jpx-mcp-v0.5.0) - 2026-06-11

### Added

- add batch introspection (describe_functions + batch_describe MCP tool) ([#213](https://github.com/joshrotenberg/jpx/pull/213))

### Fixed

- bound MCP resource usage on untrusted input ([#204](https://github.com/joshrotenberg/jpx/pull/204))
- [**breaking**] config strict-merge now honors later layers in both directions ([#202](https://github.com/joshrotenberg/jpx/pull/202))

### Other

- release prep -- refresh counts, fix Python module, add library crate READMEs ([#215](https://github.com/joshrotenberg/jpx/pull/215))
- refresh stale function counts, wire config color, drop dead code ([#206](https://github.com/joshrotenberg/jpx/pull/206))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).