### PR TITLE
fix: bound parser and interpreter recursion depth (stack-overflow DoS)

### DIFF
--- a/crates/jpx-core/src/error.rs
+++ b/crates/jpx-core/src/error.rs
@@ -117,6 +117,12 @@ pub enum RuntimeError {
         position: usize,
         invocation: usize,
     },
+    /// Expression nesting exceeded the maximum evaluation depth.
+    #[error("Recursion limit exceeded: maximum expression nesting depth is {limit}")]
+    RecursionLimitExceeded {
+        /// The maximum allowed nesting depth.
+        limit: usize,
+    },
 }
 
 #[cfg(test)]

--- a/crates/jpx-core/src/interpreter.rs
+++ b/crates/jpx-core/src/interpreter.rs
@@ -13,8 +13,37 @@ use crate::{ErrorReason, JmespathError, RuntimeError, make_expref_sentinel};
 /// Result of searching data using a JMESPath Expression.
 pub type SearchResult = Result<Value, JmespathError>;
 
+/// Maximum interpreter recursion depth.
+///
+/// Bounds evaluation nesting so that a deeply nested AST (e.g. a long
+/// left-associative `a.a.a...` chain, which the parser builds without deep
+/// recursion of its own) cannot overflow the stack and abort the process.
+///
+/// Chosen to stay safe even when the interpreter runs on a ~2 MiB stack (the
+/// default for tokio worker threads and the Rust test harness), where each
+/// recursive frame is large in debug builds. Still far above any realistic
+/// expression, whose AST nesting is in the low tens.
+const MAX_EVAL_DEPTH: usize = 128;
+
 /// Interprets the given data using an AST node.
+///
+/// Thin wrapper that bounds recursion depth via [`Context::eval_depth`];
+/// the actual interpretation happens in [`interpret_inner`].
 pub fn interpret(data: &Value, node: &Ast, ctx: &mut Context<'_>) -> SearchResult {
+    ctx.eval_depth += 1;
+    if ctx.eval_depth > MAX_EVAL_DEPTH {
+        ctx.eval_depth -= 1;
+        let reason = ErrorReason::Runtime(RuntimeError::RecursionLimitExceeded {
+            limit: MAX_EVAL_DEPTH,
+        });
+        return Err(JmespathError::from_ctx(ctx, reason));
+    }
+    let result = interpret_inner(data, node, ctx);
+    ctx.eval_depth -= 1;
+    result
+}
+
+fn interpret_inner(data: &Value, node: &Ast, ctx: &mut Context<'_>) -> SearchResult {
     match node {
         Ast::Field { name, .. } => Ok(data.get_field(name)),
         Ast::Subexpr { lhs, rhs, .. } => {
@@ -394,5 +423,43 @@ mod tests {
     #[test]
     fn builtin_function_sort() {
         assert_eq!(search("sort(@)", &json!([3, 1, 2])), json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn deep_ast_eval_errors_gracefully() {
+        // The parser rejects deeply nested input, so build a deep AST directly
+        // to exercise the interpreter's own defense-in-depth guard (which also
+        // protects API callers that construct an AST themselves). Run on a
+        // 2 MiB stack (a typical async worker-thread size): if the guard were
+        // too lax this thread would abort the whole test process instead of
+        // returning an error.
+        use crate::Runtime;
+        use crate::ast::Ast;
+        let msg = std::thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let mut ast = Ast::Identity { offset: 0 };
+                for _ in 0..400 {
+                    ast = Ast::Subexpr {
+                        offset: 0,
+                        lhs: Box::new(ast),
+                        rhs: Box::new(Ast::Identity { offset: 0 }),
+                    };
+                }
+                let rt = Runtime::strict();
+                let expr = crate::Expression::new("<deep>", ast, &rt);
+                format!("{}", expr.search(&json!({})).unwrap_err())
+            })
+            .unwrap()
+            .join()
+            .expect("deep evaluation must not overflow the stack");
+        assert!(msg.contains("Recursion limit"), "unexpected message: {msg}");
+    }
+
+    #[test]
+    fn moderate_ast_eval_ok() {
+        // Well within the depth limit: evaluates normally (null on empty object).
+        let expr = format!("a{}", ".a".repeat(50));
+        assert_eq!(search(&expr, &json!({})), json!(null));
     }
 }

--- a/crates/jpx-core/src/lib.rs
+++ b/crates/jpx-core/src/lib.rs
@@ -139,6 +139,9 @@ pub struct Context<'a> {
     /// Side-channel table for expression references.
     /// Exprefs are stored here and referenced by index in sentinel values.
     pub(crate) expref_table: Vec<Ast>,
+    /// Current interpreter recursion depth, used to bound evaluation nesting
+    /// and prevent stack overflow on deeply nested ASTs.
+    pub(crate) eval_depth: usize,
     /// Variable scopes for let expressions (JEP-18).
     #[cfg(feature = "let-expr")]
     scopes: Vec<HashMap<String, Value>>,
@@ -153,6 +156,7 @@ impl<'a> Context<'a> {
             runtime,
             offset: 0,
             expref_table: Vec::new(),
+            eval_depth: 0,
             #[cfg(feature = "let-expr")]
             scopes: Vec::new(),
         }

--- a/crates/jpx-core/src/parser.rs
+++ b/crates/jpx-core/src/parser.rs
@@ -19,11 +19,21 @@ pub fn parse(expr: &str) -> ParseResult {
 /// The maximum binding power for a token that can stop a projection.
 const PROJECTION_STOP: usize = 10;
 
+/// Maximum expression nesting depth accepted by the parser.
+///
+/// Every nested sub-expression enters through [`Parser::nud`] exactly once, so
+/// bounding `nud` recursion here prevents deeply nested input (e.g. `!!!...`,
+/// `(((...)))`, nested filters or function arguments) from overflowing the
+/// stack and aborting the process. Kept in step with the interpreter's
+/// `MAX_EVAL_DEPTH`; far above any realistic expression.
+const MAX_PARSE_DEPTH: usize = 128;
+
 struct Parser<'a> {
     tokens: Vec<TokenTuple<'a>>,
     cursor: usize,
     expr: &'a str,
     offset: usize,
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -33,6 +43,7 @@ impl<'a> Parser<'a> {
             cursor: 0,
             expr,
             offset: 0,
+            depth: 0,
         }
     }
 
@@ -83,13 +94,43 @@ impl<'a> Parser<'a> {
 
     fn expr(&mut self, rbp: usize) -> ParseResult {
         let mut left = self.nud();
+        // Bound the left-associative chain length (e.g. `a.a.a...`, `a|a|a...`).
+        // Such chains are built iteratively here without deep recursion, so
+        // `nud`'s depth guard does not catch them, yet they produce a deeply
+        // nested AST that would overflow any recursive AST walker (the
+        // interpreter, `explain`, drop). Rejecting them here keeps every
+        // downstream consumer safe.
+        let mut chain = 0usize;
         while rbp < self.peek(0).lbp() {
+            chain += 1;
+            if chain > MAX_PARSE_DEPTH {
+                return Err(self.err(
+                    self.peek(0),
+                    &format!("Expression nesting exceeds maximum depth of {MAX_PARSE_DEPTH}"),
+                    true,
+                ));
+            }
             left = self.led(Box::new(left?));
         }
         left
     }
 
     fn nud(&mut self) -> ParseResult {
+        self.depth += 1;
+        if self.depth > MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            return Err(self.err(
+                self.peek(0),
+                &format!("Expression nesting exceeds maximum depth of {MAX_PARSE_DEPTH}"),
+                true,
+            ));
+        }
+        let result = self.nud_inner();
+        self.depth -= 1;
+        result
+    }
+
+    fn nud_inner(&mut self) -> ParseResult {
         let (offset, token) = self.advance_with_pos();
         match token {
             Token::At => Ok(Ast::Identity { offset }),
@@ -304,6 +345,7 @@ impl<'a> Parser<'a> {
     #[cfg(feature = "let-expr")]
     fn parse_let_binding_expr_bp(&mut self, rbp: usize) -> ParseResult {
         let mut left = self.nud();
+        let mut chain = 0usize;
         loop {
             match self.peek(0) {
                 Token::Comma => break,
@@ -312,6 +354,14 @@ impl<'a> Parser<'a> {
             }
             if rbp >= self.peek(0).lbp() {
                 break;
+            }
+            chain += 1;
+            if chain > MAX_PARSE_DEPTH {
+                return Err(self.err(
+                    self.peek(0),
+                    &format!("Expression nesting exceeds maximum depth of {MAX_PARSE_DEPTH}"),
+                    true,
+                ));
             }
             left = self.led(Box::new(left?));
         }
@@ -800,6 +850,44 @@ mod tests {
     fn error_trailing_comma_in_list() {
         let result = parse("[a, b,]");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_on_excessive_not_nesting() {
+        // Deeply nested prefix operators (recursive descent) must return a
+        // parse error, not overflow the stack.
+        let expr = format!("{}a", "!".repeat(300));
+        let result = parse(&expr);
+        assert!(result.is_err(), "deep nesting should error, not abort");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("nesting"), "unexpected message: {msg}");
+    }
+
+    #[test]
+    fn error_on_excessive_paren_nesting() {
+        let expr = format!("{}a{}", "(".repeat(500), ")".repeat(500));
+        assert!(parse(&expr).is_err());
+    }
+
+    #[test]
+    fn error_on_excessive_subexpr_chain() {
+        // A long left-associative chain is rejected at parse time so it can
+        // never build an AST deep enough to overflow a downstream walker
+        // (interpreter, explain, drop).
+        let expr = format!("a{}", ".a".repeat(300));
+        let result = parse(&expr);
+        assert!(
+            result.is_err(),
+            "deep chain should error, not build a deep AST"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("nesting"), "unexpected message: {msg}");
+    }
+
+    #[test]
+    fn parse_nesting_within_limit_ok() {
+        assert!(parse(&format!("{}a", "!".repeat(100))).is_ok());
+        assert!(parse(&format!("a{}", ".a".repeat(100))).is_ok());
     }
 
     #[cfg(feature = "let-expr")]


### PR DESCRIPTION
## Summary

Fixes the recursion-depth stack-overflow DoS in jpx-core (the p0 from #186). Deeply nested but well-formed input could overflow the stack and **abort the process** (`SIGABRT`, not catchable). It is reachable from the public API on attacker-controlled **expressions or data**, so it crashes any embedder: the MCP server (dropping every session), the Python bindings, and the CLI.

Before this PR (confirmed against the built CLI):

```
$ echo '{}' | jpx "$(python3 -c "print('a'+'.a'*5000)")"
fatal runtime error: stack overflow, aborting        # exit 134

$ echo '{}' | jpx --explain "$(python3 -c "print('a'+'.a'*5000)")"
fatal runtime error: stack overflow, aborting        # exit 134
```

After:

```
$ echo '{}' | jpx "$(python3 -c "print('a'+'.a'*5000)")"
jpx: Parse error: Expression nesting exceeds maximum depth of 128 ...   # exit 1

$ echo '{}' | jpx "$(python3 -c "print('!'*5000+'a')")"
jpx: Parse error: Expression nesting exceeds maximum depth of 128 ...   # exit 1
```

## Approach

Three guards, all at a shared depth of **128** -- far above any realistic expression (nesting is in the low tens) yet safe even on a **~2 MiB stack** (the tokio worker-thread and Rust test-harness default), where debug frames are large. An initial value of 256 was rejected: it overflowed a 2 MiB stack in debug *before* the guard could fire.

| Guard | Catches |
|-------|---------|
| parser `nud` | recursive-descent nesting: `!!!...`, `(((...)))`, nested filters, function arguments |
| parser `expr` / let-binding loop | left-associative chains: `a.a.a...`, `a\|a\|a...`. These build a deep AST *iteratively* (no deep parser recursion), so they slip past the `nud` guard yet would overflow any recursive AST walker -- the interpreter, **`explain`** (an MCP tool), and even `Drop`. Rejecting them at parse time protects every downstream consumer. |
| interpreter `interpret` | defense-in-depth via `Context::eval_depth`: evaluating any deep AST -- including one built directly through the public API (`Expression::new`) -- returns a `RecursionLimitExceeded` error rather than aborting. |

Adds a `RuntimeError::RecursionLimitExceeded { limit }` variant.

## Tests

- Deep prefix nesting (`!` x300), deep parenthesisation (`(` x500), and deep subexpression chains (`a.a...` x300) all return a parse error.
- Within-limit expressions still parse and evaluate normally.
- A directly-constructed 400-deep AST evaluates to a `RecursionLimitExceeded` error -- run on an explicit 2 MiB stack so a regression aborts the test instead of passing silently.
- All **861 JMESPath compliance tests** still pass; full workspace `clippy -D warnings` and `fmt` are clean.

## Scope

This covers the recursion-depth p0 of #186. The other items in that issue -- the `__jpx_expref__` sentinel/user-data collision (p1) and the p2 cleanups -- are not addressed here and remain open.
