### PR TITLE
fix: eliminate UTF-8 byte-slice panics in CLI and extensions

### DIFF
--- a/crates/jpx-core/src/extensions/color.rs
+++ b/crates/jpx-core/src/extensions/color.rs
@@ -238,6 +238,12 @@ impl Function for ColorComplementFn {
 fn parse_hex_color(hex: &str) -> Option<(u8, u8, u8)> {
     let hex = hex.trim().trim_start_matches('#');
 
+    // Hex digits are ASCII; rejecting non-ASCII input up front keeps the
+    // byte-index slicing below safe (for ASCII, byte length == char length).
+    if !hex.is_ascii() {
+        return None;
+    }
+
     match hex.len() {
         3 => {
             let r = u8::from_str_radix(&hex[0..1], 16).ok()?;
@@ -380,6 +386,16 @@ mod tests {
         assert_eq!(parse_hex_color("#000000"), Some((0, 0, 0)));
         assert_eq!(parse_hex_color("#ffffff"), Some((255, 255, 255)));
         assert_eq!(parse_hex_color("invalid"), None);
+    }
+
+    #[test]
+    fn test_parse_hex_color_multibyte_does_not_panic() {
+        // Non-ASCII strings whose byte length happens to be 3 or 6 previously
+        // sliced through a multibyte code point and panicked; they must now
+        // return None.
+        assert_eq!(parse_hex_color("é2"), None); // 3 bytes, 2 chars
+        assert_eq!(parse_hex_color("ééé"), None); // 6 bytes, 3 chars
+        assert_eq!(parse_hex_color("#é2"), None);
     }
 
     #[test]

--- a/crates/jpx-core/src/extensions/object.rs
+++ b/crates/jpx-core/src/extensions/object.rs
@@ -1921,12 +1921,16 @@ impl Function for MaskFn {
             4
         };
 
-        let len = s.len();
+        // Count and slice by characters so "show the last N characters" is
+        // correct for multibyte input and never slices mid-code-point.
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
         let masked = if len <= show_last {
             "*".repeat(len)
         } else {
             let mask_count = len - show_last;
-            format!("{}{}", "*".repeat(mask_count), &s[mask_count..])
+            let visible: String = chars[mask_count..].iter().collect();
+            format!("{}{}", "*".repeat(mask_count), visible)
         };
 
         Ok(Value::String(masked))

--- a/crates/jpx-core/src/extensions/string.rs
+++ b/crates/jpx-core/src/extensions/string.rs
@@ -366,7 +366,10 @@ impl Function for IndexOfFn {
             .as_str()
             .ok_or_else(|| custom_error(ctx, "Expected search string"))?;
 
-        let len = s.len();
+        // Operate on character indices so multibyte input is handled correctly
+        // and never slices through a UTF-8 code point boundary.
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
 
         // Get optional start parameter (default: 0)
         let start = if args.len() > 2 {
@@ -390,14 +393,17 @@ impl Function for IndexOfFn {
             len
         };
 
-        // Search within the slice [start, end)
+        // Search within the [start, end) character window.
         if start >= end || start >= len {
             return Ok(Value::Null);
         }
 
-        let slice = &s[start..end.min(len)];
-        match slice.find(search) {
-            Some(idx) => Ok(Value::Number(Number::from((start + idx) as i64))),
+        let window: String = chars[start..end].iter().collect();
+        match window.find(search) {
+            Some(byte_idx) => {
+                let char_idx = window[..byte_idx].chars().count();
+                Ok(Value::Number(Number::from((start + char_idx) as i64)))
+            }
             None => Ok(Value::Null),
         }
     }
@@ -423,7 +429,10 @@ impl Function for LastIndexOfFn {
             .as_str()
             .ok_or_else(|| custom_error(ctx, "Expected search string"))?;
 
-        let len = s.len();
+        // Operate on character indices so multibyte input is handled correctly
+        // and never slices through a UTF-8 code point boundary.
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
 
         // Get optional start parameter (default: 0)
         let start = if args.len() > 2 {
@@ -447,14 +456,17 @@ impl Function for LastIndexOfFn {
             len
         };
 
-        // Search within the slice [start, end)
+        // Search within the [start, end) character window.
         if start >= end || start >= len {
             return Ok(Value::Null);
         }
 
-        let slice = &s[start..end.min(len)];
-        match slice.rfind(search) {
-            Some(idx) => Ok(Value::Number(Number::from((start + idx) as i64))),
+        let window: String = chars[start..end].iter().collect();
+        match window.rfind(search) {
+            Some(byte_idx) => {
+                let char_idx = window[..byte_idx].chars().count();
+                Ok(Value::Number(Number::from((start + char_idx) as i64)))
+            }
             None => Ok(Value::Null),
         }
     }
@@ -2197,6 +2209,38 @@ mod tests {
         // When show_last >= length, object mask returns all stars
         let result = expr.search(&json!("short")).unwrap();
         assert_eq!(result.as_str().unwrap(), "*****");
+    }
+
+    #[test]
+    fn test_mask_multibyte() {
+        let runtime = setup_runtime();
+        // "héllo" is 5 chars / 6 bytes. show_last=4 -> mask 1 char. A byte-based
+        // slice at byte 2 would land inside "é" and panic; char-based is safe.
+        let expr = runtime.compile("mask(@, `4`)").unwrap();
+        let result = expr.search(&json!("héllo")).unwrap();
+        assert_eq!(result.as_str().unwrap(), "*éllo");
+    }
+
+    #[test]
+    fn test_find_first_multibyte() {
+        // IndexOfFn is registered as `find_first`.
+        let runtime = setup_runtime();
+        // Character indices: h=0, é=1, l=2, l=3, o=4.
+        let expr = runtime.compile("find_first('héllo', 'l')").unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!(2));
+        // start/end window that previously sliced mid-"é" and panicked.
+        let expr = runtime
+            .compile("find_first('héllo', 'l', `1`, `5`)")
+            .unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!(2));
+    }
+
+    #[test]
+    fn test_find_last_multibyte() {
+        // LastIndexOfFn is registered as `find_last`.
+        let runtime = setup_runtime();
+        let expr = runtime.compile("find_last('héllo', 'l')").unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!(3));
     }
 
     // =========================================================================

--- a/crates/jpx/src/discovery.rs
+++ b/crates/jpx/src/discovery.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use colored::Colorize;
 use jpx_engine::{Category, FunctionInfo, FunctionRegistry};
 
+use crate::util::truncate_str;
+
 pub(crate) fn print_functions(registry: &FunctionRegistry) {
     println!(
         "{}\n",
@@ -569,13 +571,4 @@ fn extract_keywords(description: &str) -> Vec<String> {
         .filter(|w| w.len() > 3 && !stopwords.contains(w))
         .map(|s| s.to_string())
         .collect()
-}
-
-/// Truncate a string to max length with ellipsis
-fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max_len - 3])
-    }
 }

--- a/crates/jpx/src/input.rs
+++ b/crates/jpx/src/input.rs
@@ -7,11 +7,7 @@ use std::path::Path;
 /// Create a helpful error message for JSON parse failures.
 pub(crate) fn json_parse_error(input: &str, err: impl std::fmt::Display) -> anyhow::Error {
     let trimmed = input.trim();
-    let preview = if trimmed.len() > 60 {
-        format!("{}...", &trimmed[..60])
-    } else {
-        trimmed.to_string()
-    };
+    let preview = crate::util::truncate_str(trimmed, 60);
 
     // Detect common issues and provide specific suggestions
     let suggestion = if trimmed.is_empty() {

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -8,6 +8,7 @@ mod output;
 mod repl;
 mod stats;
 mod streaming;
+mod util;
 
 use args::{Args, ColorMode, ConfigDefaults};
 use jpx::query_library::{self, LoadResult};

--- a/crates/jpx/src/output.rs
+++ b/crates/jpx/src/output.rs
@@ -482,12 +482,8 @@ fn value_to_table_cell(value: &serde_json::Value, use_color: bool) -> String {
             }
         }
         serde_json::Value::String(s) => {
-            // Truncate long strings
-            if s.len() <= 40 {
-                s.clone()
-            } else {
-                format!("{}...", &s[..37])
-            }
+            // Truncate long strings (character-safe).
+            crate::util::truncate_str(s, 40)
         }
         serde_json::Value::Array(arr) => {
             if use_color {

--- a/crates/jpx/src/stats.rs
+++ b/crates/jpx/src/stats.rs
@@ -155,11 +155,15 @@ pub(crate) fn show_stats(file_path: &Option<String>, color_mode: &ColorMode) -> 
             }
         }
         serde_json::Value::String(s) => {
-            println!("{} {} chars", label("Length:"), number(s.len()));
-            if s.len() <= 100 {
+            println!("{} {} chars", label("Length:"), number(s.chars().count()));
+            if s.chars().count() <= 100 {
                 println!("{} \"{}\"", label("Value:"), s);
             } else {
-                println!("{} \"{}...\"", label("Preview:"), &s[..100]);
+                println!(
+                    "{} \"{}\"",
+                    label("Preview:"),
+                    crate::util::truncate_str(s, 100)
+                );
             }
         }
         serde_json::Value::Number(n) => {
@@ -310,11 +314,7 @@ fn analyze_object_keys(arr: &[serde_json::Value]) -> Vec<(String, FieldStats)> {
 fn get_value_preview(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::String(s) => {
-            if s.len() <= 30 {
-                format!("\"{}\"", s)
-            } else {
-                format!("\"{}...\"", &s[..27])
-            }
+            format!("\"{}\"", crate::util::truncate_str(s, 30))
         }
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::Bool(b) => b.to_string(),
@@ -455,11 +455,7 @@ fn collect_paths(
             }
         }
         serde_json::Value::String(s) => {
-            let preview = if s.len() <= 40 {
-                format!("\"{}\"", s)
-            } else {
-                format!("\"{}...\"", &s[..37])
-            };
+            let preview = format!("\"{}\"", crate::util::truncate_str(s, 40));
             paths.push((display_path, "string".to_string(), Some(preview)));
         }
         serde_json::Value::Number(n) => {

--- a/crates/jpx/src/util.rs
+++ b/crates/jpx/src/util.rs
@@ -1,0 +1,42 @@
+//! Small shared helpers for the CLI.
+
+/// Truncate `s` to at most `max_chars` characters for display, appending an
+/// ellipsis if it was longer.
+///
+/// Operates on characters, never byte offsets, so it is safe for any UTF-8
+/// input -- truncating with `&s[..n]` panics when byte `n` falls inside a
+/// multibyte code point.
+pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let prefix: String = s.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{prefix}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_string_unchanged() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn long_ascii_truncated_with_ellipsis() {
+        assert_eq!(truncate_str("abcdefghij", 8), "abcde...");
+    }
+
+    #[test]
+    fn multibyte_does_not_panic_and_counts_chars() {
+        // Each "é" is two bytes; a byte-index slice at 7 would panic mid-char.
+        let s = "ééééééééé"; // 9 chars, 18 bytes
+        let out = truncate_str(s, 7);
+        assert_eq!(out, "éééé..."); // 4 chars + ellipsis
+        // A 4-char string is under an 8-char limit -> unchanged.
+        assert_eq!(truncate_str("é\u{1f600}本a", 8), "é\u{1f600}本a");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the UTF-8 byte-slice panics (#187). Byte-index slicing (`&s[..N]`) on user-controlled strings panics with `byte index N is not a char boundary` when byte `N` lands inside a multibyte code point (accented Latin, CJK, emoji), aborting the process. Fixed at every reachable site across the CLI and jpx-core extensions.

Confirmed against the built CLI -- each of these used to abort:

```
$ echo "{\"k\":\"$(python3 -c "print('é'*60)")\"}" | jpx --paths --values   # was: panic at stats.rs:461
k  "ééééééééééééééééééééééééééééééééééééé..."                              # now: clean

$ echo "[{\"k\":\"$(python3 -c "print('é'*60)")\"}]" | jpx -t '@'           # was: panic at output.rs:489 -> now renders
$ echo "\"$(python3 -c "print('é'*60)")\"" | jpx --stats '@'               # was: panic at stats.rs:162 -> "Length: 60 chars"
$ printf '{%s:1}' "$(python3 -c "print('é'*60)")" | jpx '@'                # was: panic at input.rs:11 -> clean parse error
```

## Changes

**jpx-core extensions**
- `find_first` / `find_last` (the registered names for `IndexOfFn` / `LastIndexOfFn`): operate on **character** indices for the start/end window, the search, and the returned index. This removes the panic *and* makes the result correct for multibyte input -- previously a window boundary that fell mid-code-point aborted (`find_first('héllo','l',`1`,`5`)`).
- `parse_hex_color` (used by every color function -- `hex_to_rgb`, `lighten`, `mix`, ...): reject non-ASCII input up front, which keeps the subsequent fixed-offset ASCII slicing safe.
- `mask`: count and slice "show the last N characters" by character, not byte (a byte offset could both panic and mask the wrong number of characters).

**jpx CLI**
- New char-safe `util::truncate_str` helper used by the `--table` cell renderer, the `--stats` / `--paths` previews, and the JSON parse-error preview. Replaces six `&s[..N]` truncations and removes a duplicated local helper in `discovery.rs`.
- `--stats` length now reports character count rather than byte count (the label already said "chars").

## Tests

Multibyte regression tests for `find_first`/`find_last`, `mask`, `parse_hex_color`, and the truncate helper (covering the exact mid-code-point cases that panicked). All **861 JMESPath compliance tests** still pass; full-workspace `clippy -D warnings` and `fmt` are clean.

## Notes

While here I confirmed `IndexOfFn`/`LastIndexOfFn` are registered as `find_first`/`find_last` (not `index_of`/`last_index_of`) -- the unreachable-alias gap is tracked separately in #190. The duplicate `mask` registration (object vs string module) is the name-collision tracked in #189; this PR fixes the panic in the object-module `mask`, which the existing tests show is the one that wins.

Closes #187.
