### PR TITLE
fix: terminate cleanly on a broken pipe (SIGPIPE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "dirs",
  "jpx-engine",
  "json-patch",
+ "libc",
  "parquet",
  "predicates",
  "rustyline",

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -48,6 +48,10 @@ tabled = "0.20"
 # Parquet support (optional)
 parquet = { version = "54", optional = true, default-features = false, features = ["arrow", "snap"] }
 
+# Restore default SIGPIPE handling so `jpx ... | head` exits cleanly (Unix only).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 let-expr = ["jpx-engine/let-expr"]

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -23,6 +23,21 @@ use std::io::{self, Write};
 use std::time::Instant;
 
 fn main() {
+    // Restore the default SIGPIPE disposition. Rust installs SIG_IGN at
+    // startup, which turns writes to a closed pipe (e.g. `jpx ... | head`)
+    // into EPIPE errors -- the non-streaming path then panics on `println!`
+    // and the streaming path exits with a spurious error. Resetting to SIG_DFL
+    // lets the OS terminate jpx normally (exit 141) on a closed pipe, the
+    // conventional behaviour for a streaming CLI, consistently across both
+    // output paths.
+    //
+    // Safety: a single `libc::signal` call with no preconditions, run before
+    // any other work or threads are spawned.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     match run() {
         Ok(code) => std::process::exit(code),
         Err(err) => {

--- a/crates/jpx/tests/cli_sigpipe.rs
+++ b/crates/jpx/tests/cli_sigpipe.rs
@@ -1,0 +1,52 @@
+//! Regression test for broken-pipe handling (issue #188).
+//!
+//! `jpx ... | head` must terminate cleanly via SIGPIPE rather than panicking
+//! on EPIPE. This is Unix-specific behaviour.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, Stdio};
+
+/// SIGPIPE signal number (13 on Linux and macOS).
+const SIGPIPE: i32 = 13;
+
+#[test]
+fn broken_pipe_terminates_via_sigpipe_not_panic() {
+    // A JSON array far larger than a pipe buffer (~64 KiB), so the process is
+    // guaranteed to still be writing when we close the read end.
+    let big = format!(
+        "[{}]",
+        (0..200_000)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let mut input = tempfile::NamedTempFile::new().unwrap();
+    input.write_all(big.as_bytes()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_jpx"))
+        .arg("@")
+        .arg(input.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Read a little, then close the read end of the pipe.
+    {
+        let mut out = child.stdout.take().unwrap();
+        let mut buf = [0u8; 16];
+        let _ = out.read(&mut buf);
+    } // `out` dropped here -> the downstream reader has "gone away"
+
+    let status = child.wait().unwrap();
+
+    // Killed by SIGPIPE -> signal() is Some(13); a regression would instead
+    // panic on EPIPE (exit code 101) with no terminating signal.
+    assert_eq!(
+        status.signal(),
+        Some(SIGPIPE),
+        "expected termination by SIGPIPE, got {status:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the broken-pipe crash (the p0 of #188). `jpx ... | head` -- or any consumer that closes the pipe early -- aborted:

- the non-streaming path **panicked on EPIPE** inside `println!` (exit 101)
- the streaming path bubbled a spurious anyhow error (`jpx: Broken pipe`, exit 1)

Rust installs `SIG_IGN` for SIGPIPE at startup, which is exactly what turns a closed pipe into an EPIPE error instead of the conventional terminating signal.

## Fix

Restore the default SIGPIPE disposition (`SIG_DFL`) as the first thing in `main`, on Unix. The OS now terminates jpx normally (exit 141) when the reader goes away -- consistent across **both** output paths, with no error output. `libc` is added as a Unix-only dependency for the single `signal` call (it was already in the tree transitively); the `unsafe` block is the textbook justified use and is documented inline.

Verified against the built CLI:

| Command | Before | After |
|---------|--------|-------|
| `jpx '@' big.json \| head -c 10` | panic, **exit 101** | silent, **exit 141** |
| `yes '{"a":1}' \| jpx --stream 'a' \| head -1` | `jpx: Broken pipe`, **exit 1** | silent, **exit 141** |
| normal output | ok | ok (unchanged) |

## Tests

Adds a `#[cfg(unix)]` regression test that spawns the binary against a result larger than a pipe buffer, closes the read end early, and asserts the process is terminated by **SIGPIPE (signal 13)** rather than panicking (exit 101). Full CLI suite, `clippy -D warnings`, and `fmt` are clean.

## Scope

This is the broken-pipe **p0** only. The other items bundled in #188 -- the streaming multi-expression pipeline error (a stage error currently runs later stages on un-transformed input) and the p2 cleanups (`-o` ignored in `--stream`, `bench.rs` `partial_cmp`, the `--parquet` `expect`) -- are not addressed here and #188 stays open for them.

Windows has no SIGPIPE; a closed pipe there still surfaces as an I/O error. That path is unchanged (out of scope for this Unix-focused fix).
