### PR TITLE
fix: correct streaming pipeline error handling and CLI cleanups

### DIFF
--- a/crates/jpx/src/bench.rs
+++ b/crates/jpx/src/bench.rs
@@ -139,8 +139,9 @@ pub(crate) fn run_benchmark(
     println!("done");
     println!();
 
-    // Calculate statistics
-    timings.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // Calculate statistics (total_cmp is total over all f64, so no unwrap of a
+    // possible NaN comparison).
+    timings.sort_by(|a, b| a.total_cmp(b));
 
     let total: f64 = timings.iter().sum();
     let mean = total / timings.len() as f64;

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -400,7 +400,10 @@ fn run() -> Result<i32> {
     }
     #[cfg(feature = "parquet")]
     if args.parquet_output {
-        let output_path = args.output.as_ref().expect("--parquet requires --output");
+        let output_path = args
+            .output
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("--parquet requires --output"))?;
         jpx::parquet_support::write_json_to_parquet(&json_value, std::path::Path::new(output_path))
             .context("Failed to write parquet file")?;
         return Ok(exit_code);

--- a/crates/jpx/src/streaming.rs
+++ b/crates/jpx/src/streaming.rs
@@ -4,6 +4,7 @@ use crate::output::{collect_flattened_keys, flatten_object, value_to_cell};
 use anyhow::{Context, Result};
 use jpx_engine::Runtime;
 use serde_json::Value;
+use std::fs::File;
 use std::io::{self, BufRead, BufWriter, Write};
 
 /// Streaming delimited output state -- tracks headers derived from the first result.
@@ -95,9 +96,15 @@ pub(crate) fn run_streaming(
         None => Box::new(std::io::BufReader::new(io::stdin())),
     };
 
-    // Set up buffered output
-    let stdout = io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
+    // Set up buffered output, honouring --output if given (previously the
+    // streaming path always wrote to stdout and silently ignored --output).
+    let sink: Box<dyn Write> = match &args.output {
+        Some(path) => Box::new(
+            File::create(path).with_context(|| format!("Failed to create output file: {path}"))?,
+        ),
+        None => Box::new(io::stdout().lock()),
+    };
+    let mut writer = BufWriter::new(sink);
 
     // Compile expressions once
     let compiled: Vec<_> = expressions
@@ -123,7 +130,7 @@ pub(crate) fn run_streaming(
         None
     };
 
-    for line in input.lines() {
+    'lines: for line in input.lines() {
         let line = line.context("Failed to read line")?;
         let trimmed = line.trim();
         line_count += 1;
@@ -154,7 +161,11 @@ pub(crate) fn run_streaming(
                     if !quiet {
                         eprintln!("jpx: Expression error: {}", e);
                     }
-                    continue;
+                    // Abandon the whole line: skip remaining pipeline stages and
+                    // do not emit output for it (previously this `continue`
+                    // skipped only the failed stage, then ran later stages on
+                    // the un-transformed value and still emitted a result).
+                    continue 'lines;
                 }
             };
         }

--- a/crates/jpx/tests/cli_streaming.rs
+++ b/crates/jpx/tests/cli_streaming.rs
@@ -134,6 +134,44 @@ fn stream_multiple_expressions() {
         .stdout("alice\nbob\n");
 }
 
+#[test]
+fn stream_pipeline_stage_error_skips_line() {
+    // The first stage errors (unknown function). The whole line must be skipped
+    // -- no output -- rather than running the later stage on the un-transformed
+    // value and emitting it anyway.
+    jpx()
+        .args([
+            "--stream",
+            "-e",
+            "nonexistent_fn(@)",
+            "-e",
+            "@",
+            "--color",
+            "never",
+        ])
+        .write_stdin("{\"a\":1}\n")
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("Expression error"));
+}
+
+#[test]
+fn stream_output_to_file() {
+    // --output must be honoured in streaming mode (previously silently ignored,
+    // with everything going to stdout).
+    let file = tempfile::NamedTempFile::new().unwrap();
+    jpx()
+        .args(["--stream", "a", "--color", "never", "-o"])
+        .arg(file.path())
+        .write_stdin("{\"a\":1}\n{\"a\":2}\n")
+        .assert()
+        .success()
+        .stdout("");
+    let contents = std::fs::read_to_string(file.path()).unwrap();
+    assert_eq!(contents, "1\n2\n");
+}
+
 // ---------------------------------------------------------------------------
 // 4. Complex expressions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the remaining #188 items. The broken-pipe **p0** landed separately in #199; this PR handles the streaming pipeline **p1** and the **p2** cleanups.

## Streaming multi-expression pipeline (p1)

When a pipeline stage errored on a line (e.g. `-e 'bad_fn(@)' -e '@'`), the `continue` skipped only the failed stage, then ran the *later* stages against the un-transformed value and **still emitted output**:

```
$ printf '{"a":1}\n' | jpx --stream -e 'nonexistent_fn(@)' -e '@'
jpx: Expression error: ...        # before: also printed {"a":1}
                                  # after:  no output -- the line is dropped
```

Fixed with a labelled `continue 'lines` so a stage error abandons the whole line, matching the documented behaviour. Good lines after a bad one still process normally.

## Cleanups (p2)

- **Streaming honours `--output`** -- it was silently ignored, with everything going to stdout regardless of `-o`. Now writes to the file.
- **`bench`**: `sort_by(|a, b| a.partial_cmp(b).unwrap())` -> `a.total_cmp(b)`, removing a latent NaN-comparison panic.
- **`--parquet`**: the output-path `expect(...)` on the main path is now a returned error instead of a potential panic (it is already guarded by clap's `requires = "output"`, so this is defense in depth).

## Tests

Adds streaming integration tests for the pipeline-stage-error skip (asserts empty stdout + error on stderr) and for `--output` to a file. Full CLI suite, `clippy --all-features -D warnings`, and `fmt` are clean.

## Note on the remaining p3

#188 also listed a p3: `--tab` / `--sort-keys` are silently ignored when combined with `--csv` / `--tsv`. I deliberately left this as-is -- they are harmless no-ops, and turning them into hard clap conflicts would be more disruptive (rejecting otherwise-valid invocations) than the cosmetic no-op it replaces. Closing #188 on that basis; happy to add the conflicts or a doc note if you'd prefer.

Closes #188.
