### PR TITLE
fix!: config strict-merge honors later layers both directions; deterministic similar_functions

### DIFF
--- a/crates/jpx-engine/src/config.rs
+++ b/crates/jpx-engine/src/config.rs
@@ -54,8 +54,12 @@ pub struct EngineConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct EngineSection {
-    /// If true, only standard JMESPath functions are available for evaluation.
-    pub strict: bool,
+    /// If `Some(true)`, only standard JMESPath functions are available for
+    /// evaluation. `None` means "not specified", which lets a higher-precedence
+    /// config layer override the value in either direction during [`EngineConfig::merge`]
+    /// (a plain `bool` could only ever be turned *on* by a later layer). Resolves
+    /// to `false` when unset; see [`EngineConfig::is_strict`].
+    pub strict: Option<bool>,
 }
 
 /// Function filtering configuration.
@@ -96,6 +100,12 @@ pub struct InlineQuery {
 }
 
 impl EngineConfig {
+    /// Returns whether strict mode is enabled, treating an unspecified value as
+    /// `false`.
+    pub fn is_strict(&self) -> bool {
+        self.engine.strict.unwrap_or(false)
+    }
+
     /// Parses an `EngineConfig` from a TOML file.
     pub fn from_file(path: &Path) -> crate::Result<Self> {
         let content = std::fs::read_to_string(path).map_err(|e| {
@@ -150,9 +160,11 @@ impl EngineConfig {
     /// - `queries.libraries`: concatenate
     /// - `queries.inline`: later keys override same-name
     pub fn merge(mut self, other: Self) -> Self {
-        // Engine section: later wins
-        if other.engine.strict {
-            self.engine.strict = true;
+        // Engine section: later wins in BOTH directions -- a later layer that
+        // explicitly sets `strict` (to true OR false) overrides; one that omits
+        // it leaves the earlier value intact.
+        if other.engine.strict.is_some() {
+            self.engine.strict = other.engine.strict;
         }
 
         // Functions section
@@ -211,7 +223,7 @@ impl EngineBuilder {
 
     /// Sets strict mode.
     pub fn strict(mut self, strict: bool) -> Self {
-        self.config.engine.strict = strict;
+        self.config.engine.strict = Some(strict);
         self
     }
 
@@ -436,7 +448,8 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = EngineConfig::default();
-        assert!(!config.engine.strict);
+        assert!(!config.is_strict());
+        assert_eq!(config.engine.strict, None);
         assert!(config.functions.disabled_categories.is_empty());
         assert!(config.functions.disabled_functions.is_empty());
         assert!(config.functions.enabled_categories.is_none());
@@ -461,7 +474,7 @@ libraries = ["~/.config/jpx/common.jpx"]
 active-users = { expression = "users[?active].name", description = "Get active user names" }
 "#;
         let config: EngineConfig = toml::from_str(toml).unwrap();
-        assert!(config.engine.strict);
+        assert_eq!(config.engine.strict, Some(true));
         assert_eq!(
             config.functions.disabled_categories,
             vec!["geo", "phonetic"]
@@ -475,11 +488,34 @@ active-users = { expression = "users[?active].name", description = "Get active u
     fn test_merge_scalars() {
         let base = EngineConfig::default();
         let overlay = EngineConfig {
-            engine: EngineSection { strict: true },
+            engine: EngineSection { strict: Some(true) },
             ..Default::default()
         };
         let merged = base.merge(overlay);
-        assert!(merged.engine.strict);
+        assert!(merged.is_strict());
+    }
+
+    #[test]
+    fn test_merge_strict_later_wins_both_directions() {
+        let strict_on = || EngineConfig {
+            engine: EngineSection { strict: Some(true) },
+            ..Default::default()
+        };
+        let strict_off = || EngineConfig {
+            engine: EngineSection {
+                strict: Some(false),
+            },
+            ..Default::default()
+        };
+
+        // A later layer that sets strict = false must override an earlier
+        // strict = true (the previous bug could only ever turn strict *on*).
+        assert!(!strict_on().merge(strict_off()).is_strict());
+        // ...and a later strict = true overrides an earlier false.
+        assert!(strict_off().merge(strict_on()).is_strict());
+        // A later layer that omits strict leaves the earlier value intact.
+        assert!(strict_on().merge(EngineConfig::default()).is_strict());
+        assert!(!strict_off().merge(EngineConfig::default()).is_strict());
     }
 
     #[test]
@@ -730,7 +766,7 @@ strict = true
         let b = EngineConfig::default();
         let merged = a.merge(b);
 
-        assert!(!merged.engine.strict);
+        assert!(!merged.is_strict());
         assert!(merged.functions.disabled_categories.is_empty());
         assert!(merged.functions.disabled_functions.is_empty());
         assert!(merged.functions.enabled_categories.is_none());

--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -338,25 +338,37 @@ impl JpxEngine {
         let info = self.registry.get_function(name)?;
         let all_functions: Vec<_> = self.registry.functions().collect();
 
-        // Same category
-        let same_category: Vec<FunctionDetail> = all_functions
+        // Same category. Sorted by name before truncating so the result is
+        // deterministic (the registry iterates in HashMap order, so an
+        // unsorted `take(5)` returned an arbitrary, run-varying subset).
+        let mut same_category_fns: Vec<&FunctionInfo> = all_functions
             .iter()
+            .copied()
             .filter(|f| f.category == info.category && f.name != info.name)
+            .collect();
+        same_category_fns.sort_by_key(|f| f.name);
+        let same_category: Vec<FunctionDetail> = same_category_fns
+            .into_iter()
             .take(5)
-            .map(|f| FunctionDetail::from(*f))
+            .map(FunctionDetail::from)
             .collect();
 
-        // Similar signature (same arity)
+        // Similar signature (same arity), likewise name-sorted for determinism.
         let this_arity = count_params(info.signature);
-        let similar_signature: Vec<FunctionDetail> = all_functions
+        let mut similar_signature_fns: Vec<&FunctionInfo> = all_functions
             .iter()
+            .copied()
             .filter(|f| {
                 f.name != info.name
                     && f.category != info.category
                     && count_params(f.signature) == this_arity
             })
+            .collect();
+        similar_signature_fns.sort_by_key(|f| f.name);
+        let similar_signature: Vec<FunctionDetail> = similar_signature_fns
+            .into_iter()
             .take(5)
-            .map(|f| FunctionDetail::from(*f))
+            .map(FunctionDetail::from)
             .collect();
 
         // Related concepts (description keyword overlap)
@@ -372,7 +384,9 @@ impl JpxEngine {
             .filter(|(_, score)| *score > 0)
             .collect();
 
-        concept_scores.sort_by_key(|b| std::cmp::Reverse(b.1));
+        // Highest overlap first, breaking ties by name so the result is stable
+        // across runs (the underlying iteration order is not).
+        concept_scores.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(b.0.name)));
 
         let related_concepts: Vec<FunctionDetail> = concept_scores
             .into_iter()
@@ -1005,6 +1019,43 @@ mod tests {
             !result.same_category.iter().any(|f| f.name == "upper"),
             "same_category should not contain the function itself"
         );
+    }
+
+    #[test]
+    fn test_similar_functions_deterministic_and_ordered() {
+        let engine = JpxEngine::new();
+        let a = engine.similar_functions("upper").unwrap();
+        let b = engine.similar_functions("upper").unwrap();
+
+        let names = |r: &super::SimilarFunctionsResult| {
+            (
+                r.same_category
+                    .iter()
+                    .map(|f| f.name.clone())
+                    .collect::<Vec<_>>(),
+                r.similar_signature
+                    .iter()
+                    .map(|f| f.name.clone())
+                    .collect::<Vec<_>>(),
+                r.related_concepts
+                    .iter()
+                    .map(|f| f.name.clone())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        // Repeated calls must return identical results (no HashMap-order flakiness).
+        assert_eq!(names(&a), names(&b));
+
+        // same_category and similar_signature are name-sorted.
+        let cat: Vec<_> = a.same_category.iter().map(|f| &f.name).collect();
+        let mut cat_sorted = cat.clone();
+        cat_sorted.sort();
+        assert_eq!(cat, cat_sorted, "same_category should be name-sorted");
+
+        let sig: Vec<_> = a.similar_signature.iter().map(|f| &f.name).collect();
+        let mut sig_sorted = sig.clone();
+        sig_sorted.sort();
+        assert_eq!(sig, sig_sorted, "similar_signature should be name-sorted");
     }
 
     #[test]

--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -446,7 +446,7 @@ impl JpxEngine {
     /// let engine = JpxEngine::from_config(config).unwrap();
     /// ```
     pub fn from_config(config: EngineConfig) -> Result<Self> {
-        let strict = config.engine.strict;
+        let strict = config.is_strict();
         let (runtime, registry) = config::build_runtime_from_config(&config.functions, strict);
 
         let discovery = Arc::new(RwLock::new(DiscoveryRegistryInner::new()));

--- a/crates/jpx-mcp/src/main.rs
+++ b/crates/jpx-mcp/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
     // Load engine config (jpx.toml discovery) and merge CLI flags
     let mut engine_config = jpx_engine::config::EngineConfig::discover().unwrap_or_default();
     if args.strict {
-        engine_config.engine.strict = true;
+        engine_config.engine.strict = Some(true);
     }
 
     // Build the router

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -349,7 +349,7 @@ fn relevance_note(match_type: &str) -> String {
 #[allow(dead_code)]
 pub fn build_router(strict: bool) -> Result<McpRouter, BoxError> {
     let mut config = EngineConfig::default();
-    config.engine.strict = strict;
+    config.engine.strict = Some(strict);
     build_router_from_config(config)
 }
 

--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -664,6 +664,6 @@ pub(crate) fn create_configured_runtime(
     engine_config: &jpx_engine::config::EngineConfig,
     strict: bool,
 ) -> (jpx_engine::Runtime, jpx_engine::FunctionRegistry) {
-    let effective_strict = strict || engine_config.engine.strict;
+    let effective_strict = strict || engine_config.is_strict();
     jpx_engine::config::build_runtime_from_config(&engine_config.functions, effective_strict)
 }


### PR DESCRIPTION
## Summary

Fixes #192 (jpx-engine). Three things:

### 1. Config `strict` merge was one-way (the bug)

`EngineConfig::merge` could only ever turn `strict` **on**:

```rust
if other.engine.strict { self.engine.strict = true; }
```

So a higher-precedence layer with `strict = false` could **not** override an earlier `strict = true` -- a global `~/.config/jpx/jpx.toml` with `strict = true` made a project-local `jpx.toml` with `strict = false` a no-op, the opposite of the documented "later wins" precedence.

Fix: `EngineSection.strict` is now `Option<bool>` (`None` = unspecified). `merge()` overrides only when the later layer explicitly set the value, so **later layers win in both directions**; an omitted value preserves the earlier one. The resolved value is read via the new `EngineConfig::is_strict()` (treats `None` as `false`). **The `jpx.toml` format is unchanged** -- `strict = true/false` and omitting it all behave as before.

### 2. Missing precedence tests

Added `test_merge_strict_later_wins_both_directions` covering all four cases: later-false overrides earlier-true (the bug), later-true overrides earlier-false, and an omitted later value preserving true/false.

### 3. `similar_functions` was nondeterministic

`same_category` and `similar_signature` did `take(5)` over the registry's HashMap iteration order, returning an arbitrary, run-varying subset; `related_concepts` was score-ranked but broke ties on HashMap order. Now `same_category`/`similar_signature` are name-sorted before truncation, and `related_concepts` breaks score ties by name. Added `test_similar_functions_deterministic_and_ordered` (repeated calls identical + name-sorted).

## Verification

All affected-crate suites (jpx-core, jpx-engine, jpx, jpx-mcp) pass; `clippy --all-features -D warnings` and `fmt` clean.

## ⚠️ Breaking change (jpx-engine public API)

`EngineConfig`'s `engine.strict` field changed from `bool` to `Option<bool>`. Code that reads it directly should use `EngineConfig::is_strict()` instead. The `EngineBuilder::strict(bool)` API and the `jpx.toml` config format are unchanged. Marked `fix!` so release-plz applies the appropriate version bump.

Closes #192.
