### PR TITLE
fix: preserve large-integer fidelity in Python bindings

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -40,6 +40,17 @@ fn python_to_json(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
         Ok(Value::Bool(b))
     } else if let Ok(i) = obj.extract::<i64>() {
         Ok(Value::Number(i.into()))
+    } else if let Ok(u) = obj.extract::<u64>() {
+        // Ints in (i64::MAX, u64::MAX] -- preserved exactly rather than being
+        // coerced to a lossy f64.
+        Ok(Value::Number(u.into()))
+    } else if obj.is_instance_of::<pyo3::types::PyInt>() {
+        // A Python int that fits neither i64 nor u64 cannot be represented in
+        // JSON without losing precision; error rather than silently coercing it
+        // to a float.
+        Err(PyValueError::new_err(
+            "integer is too large to represent in JSON (exceeds 64-bit range)",
+        ))
     } else if let Ok(f) = obj.extract::<f64>() {
         Ok(serde_json::Number::from_f64(f)
             .map(Value::Number)
@@ -79,6 +90,10 @@ fn json_to_python(py: Python<'_>, value: &Value) -> PyResult<Py<PyAny>> {
         Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 Ok(i.into_pyobject(py)?.to_owned().into_any().unbind())
+            } else if let Some(u) = n.as_u64() {
+                // Values in (i64::MAX, u64::MAX] -- return an exact Python int
+                // instead of falling through to a lossy float.
+                Ok(u.into_pyobject(py)?.to_owned().into_any().unbind())
             } else if let Some(f) = n.as_f64() {
                 Ok(f.into_pyobject(py)?.to_owned().into_any().unbind())
             } else {

--- a/python/tests/test_jpx.py
+++ b/python/tests/test_jpx.py
@@ -470,3 +470,44 @@ class TestJpxEngineQueryStore:
             assert False, "Should have raised ValueError"
         except ValueError:
             pass
+
+
+# =============================================================================
+# Numeric fidelity (#193)
+# =============================================================================
+
+
+class TestNumericFidelity:
+    """Large integers must round-trip exactly, not degrade to floats."""
+
+    def test_int_above_i64_roundtrips(self):
+        # 2**63 exceeds i64::MAX; must stay an exact int, not become a float.
+        n = 2**63
+        result = jpx.search("@", n)
+        assert result == n
+        assert isinstance(result, int)
+
+    def test_u64_max_roundtrips(self):
+        n = 2**64 - 1
+        result = jpx.search("@", n)
+        assert result == n
+        assert isinstance(result, int)
+
+    def test_int_beyond_u64_raises(self):
+        # Too large for 64-bit JSON integers: error rather than silently lossy.
+        try:
+            jpx.search("@", 2**64)
+            assert False, "Should have raised ValueError"
+        except ValueError:
+            pass
+
+    def test_regular_int_and_float_unaffected(self):
+        assert jpx.search("@", 42) == 42
+        assert isinstance(jpx.search("@", 42), int)
+        assert jpx.search("@", 3.14) == 3.14
+        assert isinstance(jpx.search("@", 3.14), float)
+
+    def test_large_int_in_nested_structure(self):
+        data = {"id": 2**63, "vals": [2**64 - 1, 1]}
+        assert jpx.search("id", data) == 2**63
+        assert jpx.search("vals[0]", data) == 2**64 - 1


### PR DESCRIPTION
## Summary

Fixes #193: JSON ↔ Python integer conversion was lossy for values outside the `i64` range.

- **`python_to_json`** tried `i64` and then fell straight through to `f64`, so a Python `int` in `(i64::MAX, u64::MAX]` -- e.g. `2**63`, `2**64-1`, or any 19-20 digit ID -- silently became a lossy `float`.
- **`json_to_python`** checked `as_i64` then `as_f64` but never `as_u64`, so a `u64` JSON value in that range came back to Python as a lossy float.

## Fix

Both directions now handle `u64`:
- `python_to_json` tries `u64` after `i64`. A Python int too large for even `u64` now raises `ValueError` ("integer is too large to represent in JSON") rather than being silently coerced to a float.
- `json_to_python` adds an `as_u64` branch before the `f64` fallback.

Verified against the built binding:

```python
jpx.search("@", 2**63)      # 9223372036854775808  (was 9.223...e+18 float)
jpx.search("@", 2**64 - 1)  # 18446744073709551615 (exact)
jpx.search("@", 2**64)      # raises ValueError
```

## Tests

Adds `TestNumericFidelity`: `2**63` / `u64::MAX` round-trips, the too-large-int `ValueError`, regular int/float unaffected, and a nested-structure case. **All 77 Python tests pass** (72 existing + 5 new); `clippy --all-features -D warnings` and `cargo fmt` clean.

Out of scope: `float('inf')`/`nan` still map to JSON `null` (a separate, pre-existing behaviour the audit noted) and is left unchanged here.

Closes #193.
