### PR TITLE
fix: bound MCP resource usage on untrusted input (partial #191)

### DIFF
--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -298,6 +298,26 @@ fn error_result(message: impl Into<String>) -> CallToolResult {
     CallToolResult::error(message)
 }
 
+/// Maximum byte length accepted for an inline JSON argument. Mirrors the 50 MiB
+/// cap already enforced for `evaluate_file`, so the inline-JSON tools cannot be
+/// used to drive unbounded memory use from a single request.
+const MAX_INLINE_JSON_BYTES: usize = 50 * 1024 * 1024;
+/// Maximum number of expressions accepted by `batch_evaluate` in one call.
+const MAX_BATCH_EXPRESSIONS: usize = 1000;
+/// Upper bound applied to client-provided result counts (`limit` / `top_k`).
+const MAX_RESULT_LIMIT: usize = 1000;
+
+/// Rejects an inline JSON argument that exceeds [`MAX_INLINE_JSON_BYTES`].
+fn ensure_json_size(label: &str, s: &str) -> Result<(), Error> {
+    if s.len() > MAX_INLINE_JSON_BYTES {
+        return Err(Error::tool(format!(
+            "{label} exceeds the maximum size of {MAX_INLINE_JSON_BYTES} bytes ({} given)",
+            s.len()
+        )));
+    }
+    Ok(())
+}
+
 /// Strip natural-language filler from a task description to extract search terms.
 fn clean_task_description(task: &str) -> String {
     let prefixes: &[&str] = &[
@@ -371,6 +391,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: EvaluateParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 match engine.evaluate_str(&params.expression, &params.input) {
                     Ok(result) => json_result(&result),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -472,6 +493,13 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: BatchEvaluateParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
+                if params.expressions.len() > MAX_BATCH_EXPRESSIONS {
+                    return Err(Error::tool(format!(
+                        "too many expressions: {} (maximum {MAX_BATCH_EXPRESSIONS})",
+                        params.expressions.len()
+                    )));
+                }
                 let input: Value = serde_json::from_str(&params.input)
                     .map_err(|e| Error::tool(format!("Invalid JSON: {}", e)))?;
                 let result = engine.batch_evaluate(&params.expressions, &input);
@@ -489,6 +517,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: FormatParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 match engine.format_json(&params.input, params.indent) {
                     Ok(formatted) => Ok(text_result(formatted)),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -506,6 +535,8 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: DiffParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("source", &params.source)?;
+                ensure_json_size("target", &params.target)?;
                 match engine.diff(&params.source, &params.target) {
                     Ok(patch) => json_result(&patch),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -522,6 +553,8 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: PatchParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
+                ensure_json_size("patch", &params.patch)?;
                 match engine.patch(&params.input, &params.patch) {
                     Ok(result) => json_result(&result),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -538,6 +571,8 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: MergeParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
+                ensure_json_size("patch", &params.patch)?;
                 match engine.merge(&params.input, &params.patch) {
                     Ok(result) => json_result(&result),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -555,6 +590,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: KeysParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 match engine.keys(&params.input, params.recursive) {
                     Ok(keys) => json_result(&keys),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -624,7 +660,8 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: SearchParams| {
             let engine = e.clone();
             async move {
-                let results = engine.search_functions(&params.query, params.limit);
+                let results =
+                    engine.search_functions(&params.query, params.limit.min(MAX_RESULT_LIMIT));
                 json_result(&results)
             }
         })
@@ -672,7 +709,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
                     ));
                 }
 
-                let results = engine.search_functions(&query, params.limit);
+                let results = engine.search_functions(&query, params.limit.min(MAX_RESULT_LIMIT));
                 let suggestions: Vec<Suggestion> = results
                     .into_iter()
                     .map(|r| Suggestion {
@@ -698,6 +735,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: StatsParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 match engine.stats(&params.input) {
                     Ok(stats) => json_result(&stats),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -715,6 +753,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: PathsParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 match engine.paths(&params.input, params.include_types, params.include_values) {
                     Ok(paths) => json_result(&paths),
                     Err(e) => Err(Error::tool(e.to_string())),
@@ -804,7 +843,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: QueryToolsParams| {
             let engine = e.clone();
             async move {
-                match engine.query_tools(&params.query, params.top_k) {
+                match engine.query_tools(&params.query, params.top_k.min(MAX_RESULT_LIMIT)) {
                     Ok(results) => json_result(&results),
                     Err(e) => Err(Error::tool(e.to_string())),
                 }
@@ -821,7 +860,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: SimilarToolsParams| {
             let engine = e.clone();
             async move {
-                match engine.similar_tools(&params.tool_id, params.top_k) {
+                match engine.similar_tools(&params.tool_id, params.top_k.min(MAX_RESULT_LIMIT)) {
                     Ok(results) => json_result(&results),
                     Err(e) => Err(Error::tool(e.to_string())),
                 }
@@ -893,7 +932,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
     let e = engine.clone();
     let define_query = ToolBuilder::new("define_query")
         .title("Define Query")
-        .description("Store a named JMESPath query for reuse during this session. Useful for building and refining complex queries iteratively. The query is validated before storing.")
+        .description("Store a named JMESPath query for reuse. Useful for building and refining complex queries iteratively. The query is validated before storing. Note: the query store is shared across all clients of this server, not isolated per session.")
         .handler(move |params: DefineQueryParams| {
             let engine = e.clone();
             async move {
@@ -956,7 +995,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
     let e = engine.clone();
     let list_queries = ToolBuilder::new("list_queries")
         .title("List Queries")
-        .description("List all named queries stored in this session. Shows query names, expressions, and descriptions.")
+        .description("List all named queries stored on this server (shared across all clients, not isolated per session). Shows query names, expressions, and descriptions.")
         .read_only()
         .handler(move |_params: EmptyParams| {
             let engine = e.clone();
@@ -978,6 +1017,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .handler(move |params: RunQueryParams| {
             let engine = e.clone();
             async move {
+                ensure_json_size("input", &params.input)?;
                 let input: Value = serde_json::from_str(&params.input)
                     .map_err(|e| Error::tool(format!("Invalid JSON: {}", e)))?;
 

--- a/crates/jpx-mcp/tests/tools.rs
+++ b/crates/jpx-mcp/tests/tools.rs
@@ -1186,3 +1186,32 @@ async fn test_suggest_respects_limit() {
         parsed.len()
     );
 }
+
+// =============================================================================
+// Resource limits (#191)
+// =============================================================================
+
+#[tokio::test]
+async fn test_batch_evaluate_rejects_too_many_expressions() {
+    let mut client = create_client().await;
+    let exprs: Vec<String> = (0..1001).map(|_| "@".to_string()).collect();
+    let result = client
+        .call_tool_expect_error(
+            "batch_evaluate",
+            json!({ "input": "{}", "expressions": exprs }),
+        )
+        .await;
+    assert!(result.get("code").is_some() || result.get("isError").is_some());
+}
+
+#[tokio::test]
+async fn test_batch_evaluate_within_limit_ok() {
+    let mut client = create_client().await;
+    let result = client
+        .call_tool(
+            "batch_evaluate",
+            json!({ "input": r#"{"a":1}"#, "expressions": ["a", "@"] }),
+        )
+        .await;
+    assert!(!result.is_error);
+}


### PR DESCRIPTION
## Summary

Addresses the **resource-limits** portion of #191. The MCP tools accepted unbounded client input -- a single hostile request could drive arbitrary memory/CPU use. `evaluate_file` already caps reads at 50 MiB; this brings the inline-JSON and result-size paths in line.

## Caps added

- **Inline-JSON size** -- `evaluate`, `batch_evaluate`, `format`, `diff`, `patch`, `merge`, `keys`, `stats`, `paths`, `run_query` now reject a JSON argument larger than **50 MiB** before parsing (via a shared `ensure_json_size` helper covering every `input`/`source`/`target`/`patch` field).
- **batch_evaluate length** -- rejects more than **1000** expressions per call.
- **Result counts** -- `search`/`suggest` `limit` and `query_tools`/`similar_tools` `top_k` are clamped to **1000**.

## Wording fix

`define_query` / `list_queries` described the query store as per-session. It is actually **shared across all clients** of the server; the descriptions now say so (relevant for HTTP multi-tenant deployments).

## Tests

Adds tests for the batch-expression cap (reject >1000, accept within limit). Full jpx-mcp suite (60 tests) passes; `clippy --all-features --tests -D warnings` and `fmt` clean. (The 50 MiB size cap is a trivial length check wired into every JSON-input handler; it isn't exercised through the full client path to avoid a 50 MiB-per-test allocation.)

## Deferred from #191 (not in this PR)

- **Handler panic isolation** (`catch_unwind` / tower-mcp). The main panic vector -- the parser/interpreter stack overflow -- was already removed by the recursion-depth limit in #197, and the handlers are otherwise panic-free, so this is now low-value defensive work rather than a live risk.
- **Full per-session query-store isolation.** The engine is a shared `Arc`, so true per-session state is an HTTP-multi-tenant design change; for now the misleading "this session" wording is corrected instead.

Because those two remain, this does not fully close #191 -- it leaves the issue open for them.
