### PR TITLE
fix: replace unmaintained atty with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,17 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,15 +1181,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -1483,7 +1463,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -1527,7 +1507,6 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "atty",
  "clap",
  "clap_complete",
  "colored",
@@ -3580,22 +3559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,12 +3566,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 anyhow = "1.0"
 colored_json = "5"
-atty = "0.2"
 
 # Search and similarity
 strsim = "0.11"

--- a/crates/jpx/Cargo.toml
+++ b/crates/jpx/Cargo.toml
@@ -34,7 +34,6 @@ serde_json.workspace = true
 anyhow.workspace = true
 colored_json.workspace = true
 colored = "3"
-atty.workspace = true
 rustyline = "17"
 dirs = "6.0.0"
 json-patch.workspace = true

--- a/crates/jpx/src/bench.rs
+++ b/crates/jpx/src/bench.rs
@@ -19,7 +19,7 @@ pub(crate) fn run_benchmark(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     // Helper for colored output

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -417,7 +417,7 @@ fn run() -> Result<i32> {
     let should_colorize = match args.color {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => args.output.is_none() && atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => args.output.is_none() && crate::util::stdout_is_terminal(),
     };
 
     // Determine indent string

--- a/crates/jpx/src/ops.rs
+++ b/crates/jpx/src/ops.rs
@@ -55,7 +55,7 @@ pub(crate) fn list_queries(query_path: &str, color_mode: &ColorMode) -> Result<(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     println!("Queries in {}:\n", file_path);
@@ -132,7 +132,7 @@ pub(crate) fn check_queries(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     let mut has_errors = false;

--- a/crates/jpx/src/output.rs
+++ b/crates/jpx/src/output.rs
@@ -52,7 +52,7 @@ pub(crate) fn output_json(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     if compact {
@@ -315,7 +315,7 @@ pub(crate) fn output_as_table(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => output_path.is_none() && atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => output_path.is_none() && crate::util::stdout_is_terminal(),
     };
 
     match value {

--- a/crates/jpx/src/stats.rs
+++ b/crates/jpx/src/stats.rs
@@ -11,7 +11,7 @@ pub(crate) fn show_stats(file_path: &Option<String>, color_mode: &ColorMode) -> 
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     // Helper for colored output
@@ -340,7 +340,7 @@ pub(crate) fn show_paths(
     let use_color = match color_mode {
         ColorMode::Always => true,
         ColorMode::Never => false,
-        ColorMode::Auto => atty::is(atty::Stream::Stdout),
+        ColorMode::Auto => crate::util::stdout_is_terminal(),
     };
 
     let mut paths_info: Vec<(String, String, Option<String>)> = Vec::new();

--- a/crates/jpx/src/util.rs
+++ b/crates/jpx/src/util.rs
@@ -15,6 +15,14 @@ pub(crate) fn truncate_str(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Whether stdout is connected to a terminal.
+///
+/// Uses the std library's `IsTerminal` (stable since Rust 1.70) rather than the
+/// unmaintained, unsound `atty` crate.
+pub(crate) fn stdout_is_terminal() -> bool {
+    std::io::IsTerminal::is_terminal(&std::io::stdout())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Replaces the **`atty`** crate -- a direct CLI dependency that is unmaintained ([RUSTSEC-2024-0375](https://rustsec.org/advisories/RUSTSEC-2024-0375)) and unsound ([RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145), potential unaligned read) -- with the standard library's `std::io::IsTerminal` (stable since Rust 1.70; crate MSRV is 1.90).

The 8 `atty::is(atty::Stream::Stdout)` call sites now use a small `util::stdout_is_terminal()` helper. `atty` is dropped from the dependency tree entirely.

**`cargo audit` warnings: 6 -> 4** (both atty advisories cleared; the remaining 4 are transitive `paste`/`proc-macro-error2`/`rand` warnings that need upstream bumps).

Verified: clippy `-D warnings` + fmt clean, full jpx CLI suite passes, color auto-detection still works.

Part of #194 (the remaining doc-count/dead-code/`#[non_exhaustive]` cleanups are a separate PR).