### PR TITLE
chore: refresh stale function counts, wire config color, drop dead code

### DIFF
--- a/crates/jpx-core/src/extensions/mod.rs
+++ b/crates/jpx-core/src/extensions/mod.rs
@@ -1,6 +1,6 @@
 //! Extension functions for JMESPath.
 //!
-//! This module contains 400+ additional functions organized by category.
+//! This module contains 490+ additional functions organized by category.
 //! Each submodule provides a `register_filtered` function that registers
 //! only the enabled functions with the runtime.
 //!

--- a/crates/jpx-core/src/lexer.rs
+++ b/crates/jpx-core/src/lexer.rs
@@ -170,10 +170,9 @@ impl<'a> Lexer<'a> {
     {
         loop {
             match self.iter.peek() {
-                Some(&(end, c)) if predicate(c) => {
+                Some(&(_, c)) if predicate(c) => {
                     self.iter.next();
                     // Continue -- we'll use the *next* peek or EOF to get the end
-                    let _ = end;
                 }
                 Some(&(end, _)) => return end,
                 None => return self.expr.len(),

--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -727,7 +727,7 @@ mod tests {
             !all.is_empty(),
             "functions(None) should return a non-empty list"
         );
-        // There should be a substantial number of functions (400+)
+        // There should be a substantial number of functions (490+)
         assert!(
             all.len() > 100,
             "Expected at least 100 functions, got {}",

--- a/crates/jpx-engine/src/lib.rs
+++ b/crates/jpx-engine/src/lib.rs
@@ -1,6 +1,6 @@
 //! # jpx-engine
 //!
-//! Protocol-agnostic JMESPath query engine with 400+ functions.
+//! Protocol-agnostic JMESPath query engine with 490+ functions.
 //!
 //! This crate provides the core "brain" of jpx - everything you can do with JMESPath
 //! beyond basic compile and evaluate. It's designed to be transport-agnostic, allowing
@@ -75,7 +75,7 @@
 //!
 //! ## Function Introspection
 //!
-//! Discover and explore the 400+ available functions:
+//! Discover and explore the 490+ available functions:
 //!
 //! ```rust
 //! use jpx_engine::JpxEngine;
@@ -235,7 +235,7 @@
 //! ## Architecture
 //!
 //! ```text
-//!    jpx-core           (parser, runtime, 400+ functions, registry)
+//!    jpx-core           (parser, runtime, 490+ functions, registry)
 //!         |
 //!    jpx-engine         (this crate - evaluation, search, discovery, config)
 //!         |
@@ -296,7 +296,7 @@ pub use jpx_core::{Category, Expression, FunctionInfo, FunctionRegistry, Runtime
 ///
 /// `JpxEngine` is the main entry point for all jpx functionality. It combines:
 ///
-/// - **JMESPath runtime** with 400+ extension functions
+/// - **JMESPath runtime** with 490+ extension functions
 /// - **Function registry** for introspection and search
 /// - **Discovery registry** for cross-server tool indexing
 /// - **Query store** for named query management
@@ -351,7 +351,7 @@ impl JpxEngine {
     /// Creates a new engine with all extension functions enabled.
     ///
     /// This is the standard way to create an engine with full functionality,
-    /// including all 400+ extension functions.
+    /// including all 490+ extension functions.
     ///
     /// # Example
     ///

--- a/crates/jpx-mcp/src/main.rs
+++ b/crates/jpx-mcp/src/main.rs
@@ -1,6 +1,6 @@
 //! JMESPath MCP Server
 //!
-//! An MCP server providing JMESPath functionality with 400+ extended functions.
+//! An MCP server providing JMESPath functionality with 490+ extended functions.
 
 mod tools;
 
@@ -20,7 +20,7 @@ enum Transport {
 
 #[derive(Parser, Debug)]
 #[command(name = "jpx-mcp")]
-#[command(about = "JMESPath MCP server with 400+ extended functions", long_about = None)]
+#[command(about = "JMESPath MCP server with 490+ extended functions", long_about = None)]
 #[command(version)]
 struct Args {
     /// Transport to use

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -386,7 +386,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
     let e = engine.clone();
     let evaluate = ToolBuilder::new("evaluate")
         .title("Evaluate Expression")
-        .description("Evaluate a JMESPath expression against JSON input. Returns the result of applying the expression to the input data. Supports 400+ extended functions beyond standard JMESPath.")
+        .description("Evaluate a JMESPath expression against JSON input. Returns the result of applying the expression to the input data. Supports 490+ extended functions beyond standard JMESPath.")
         .read_only()
         .handler(move |params: EvaluateParams| {
             let engine = e.clone();
@@ -1082,7 +1082,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
     let router = McpRouter::new()
         .server_info("jpx-mcp", env!("CARGO_PKG_VERSION"))
         .instructions(
-            "JMESPath query tool with 400+ extended functions. \
+            "JMESPath query tool with 490+ extended functions. \
             \n\nDISCOVERY: Use 'search' to find functions by keyword, 'similar' to find related functions, \
             'functions' to list all (optionally by category), 'describe' for function details, 'categories' to list categories. \
             \n\nDATA ANALYSIS: Use 'stats' to analyze JSON structure before querying, 'paths' to list all paths in dot notation, \

--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -25,7 +25,6 @@ struct Config {
     raw: Option<bool>,
     compact: Option<bool>,
     /// Color mode (auto, always, never)
-    #[allow(dead_code)]
     color: Option<String>,
 }
 
@@ -103,6 +102,16 @@ impl ConfigDefaults for Config {
         }
         if !args.compact && self.compact == Some(true) {
             args.compact = true;
+        }
+        // Color: only applies when the user did not pass --color (still Auto).
+        if matches!(args.color, ColorMode::Auto)
+            && let Some(c) = &self.color
+        {
+            args.color = match c.to_lowercase().as_str() {
+                "always" => ColorMode::Always,
+                "never" => ColorMode::Never,
+                _ => ColorMode::Auto,
+            };
         }
     }
 }
@@ -196,7 +205,7 @@ pub(crate) enum ColorMode {
     "    jpx -y 'config' < data.json         # YAML output\n",
     "\n",
     "  Discovery:\n",
-    "    jpx --list-functions                # List all 400+ functions\n",
+    "    jpx --list-functions                # List all 490+ functions\n",
     "    jpx --search date                   # Find date-related functions\n",
     "    jpx --describe format_date          # Function documentation\n",
     "\n",

--- a/crates/jpx/tests/cli_env_config.rs
+++ b/crates/jpx/tests/cli_env_config.rs
@@ -197,6 +197,38 @@ mod config_file {
     }
 
     #[test]
+    fn config_color_always_is_applied() {
+        // `color = "always"` from config now takes effect (previously ignored),
+        // so output is colored even though stdout is piped (not a terminal).
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "color = \"always\"").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .arg("name")
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            // ANSI escape present -> color was forced on.
+            .stdout(predicate::str::contains("\u{1b}["));
+    }
+
+    #[test]
+    fn config_color_overridden_by_cli_flag() {
+        // An explicit --color never on the CLI wins over config color = always.
+        let mut config = NamedTempFile::new().unwrap();
+        writeln!(config, "color = \"always\"").unwrap();
+
+        jpx()
+            .env("JPX_CONFIG", config.path().as_os_str())
+            .args(["name", "--color", "never"])
+            .write_stdin(r#"{"name":"alice"}"#)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("\u{1b}[").not());
+    }
+
+    #[test]
     fn config_invalid_toml() {
         let mut config = NamedTempFile::new().unwrap();
         writeln!(config, "invalid toml {{{{").unwrap();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -122,7 +122,7 @@ fn json_to_python(py: Python<'_>, value: &Value) -> PyResult<Py<PyAny>> {
 // Module-level functions (backed by global Runtime)
 // =============================================================================
 
-/// Search JSON data using a JMESPath expression with 400+ functions.
+/// Search JSON data using a JMESPath expression with 490+ functions.
 ///
 /// Args:
 ///     expression: A JMESPath expression string
@@ -805,7 +805,7 @@ impl JpxEngine {
 // Module definition
 // =============================================================================
 
-/// jpx Python module - JMESPath query engine with 400+ functions.
+/// jpx Python module - JMESPath query engine with 490+ functions.
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Module-level convenience functions


### PR DESCRIPTION
Cosmetic cleanups from the audit (#194):

- **Function-count docs** said `400+` in 14 places across jpx-core, jpx-engine, jpx-mcp, the CLI, and the Python bindings; the registry now has ~499 functions, so these are bumped to `490+`.
- **CLI `color` config key** was accepted but never applied (it was `#[allow(dead_code)]`). Now wired into `apply_defaults`: `color = "always"/"never"/"auto"` takes effect, with an explicit `--color` flag still winning. Tests added for both (forced color when piped; CLI override).
- **Dead `end` binding** in the lexer's skip helper removed.

Verified: clippy `-D warnings` + fmt clean; affected-crate suites pass.

## Not in this PR (deferred #194 items)
- `#[non_exhaustive]` on public enums -- a breaking API change that deserves its own PR + version bump.
- Interpreter `Value`-clone reduction (`Cow`) -- a larger perf refactor, flagged for tracking.
- Transitive `paste` / `proc-macro-error2` / `rand` cargo-audit warnings -- need upstream bumps.
- The `atty` advisory is handled in #205.

Part of #194 (leaves it open for the items above).