### PR TITLE
fix: prevent user data from colliding with expref sentinels (#186)

### DIFF
--- a/crates/jpx-core/src/lib.rs
+++ b/crates/jpx-core/src/lib.rs
@@ -201,11 +201,29 @@ impl<'a> Context<'a> {
     }
 }
 
+/// Per-process random key used for expref sentinels.
+///
+/// Exprefs (`&foo`) are carried internally as an in-band `Value` object keyed by
+/// this string. A fixed key (e.g. `"__jpx_expref__"`) collides with user data
+/// that happens to contain that key -- such data would be mis-typed as an expref
+/// and silently stripped from output. Seeding the key with a per-process random
+/// token (which never reaches output, since sentinels are stripped) means user
+/// data cannot accidentally -- or, in practice, maliciously, since the token is
+/// never observable -- be mistaken for an expref.
+pub(crate) static EXPREF_KEY: LazyLock<String> = LazyLock::new(|| {
+    use std::hash::{BuildHasher, Hasher};
+    // RandomState is seeded from OS entropy per process, so this differs across
+    // runs and is not predictable to a client.
+    let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+    hasher.write_u8(0);
+    format!("__jpx_expref_{:016x}__", hasher.finish())
+});
+
 /// Creates an expref sentinel value from a table index.
 pub(crate) fn make_expref_sentinel(id: usize) -> Value {
     let mut map = serde_json::Map::new();
     map.insert(
-        "__jpx_expref__".to_string(),
+        EXPREF_KEY.clone(),
         Value::Number(serde_json::Number::from(id)),
     );
     Value::Object(map)
@@ -215,7 +233,7 @@ pub(crate) fn make_expref_sentinel(id: usize) -> Value {
 pub fn get_expref_id(value: &Value) -> Option<usize> {
     value
         .as_object()
-        .and_then(|m| m.get("__jpx_expref__"))
+        .and_then(|m| m.get(EXPREF_KEY.as_str()))
         .and_then(|v| v.as_u64())
         .map(|v| v as usize)
 }
@@ -223,7 +241,7 @@ pub fn get_expref_id(value: &Value) -> Option<usize> {
 /// Strips expref sentinels from a value (recursive for arrays/objects).
 fn strip_expref_sentinels(value: Value) -> Value {
     match value {
-        Value::Object(map) if map.contains_key("__jpx_expref__") => Value::Null,
+        Value::Object(map) if map.contains_key(EXPREF_KEY.as_str()) => Value::Null,
         Value::Array(arr) => Value::Array(arr.into_iter().map(strip_expref_sentinels).collect()),
         Value::Object(map) => Value::Object(
             map.into_iter()
@@ -257,6 +275,29 @@ mod tests {
         let expr = compile("foo.bar").unwrap();
         let data = json!({"foo": {"bar": true}});
         assert_eq!(json!(true), expr.search(&data).unwrap());
+    }
+
+    #[test]
+    fn user_data_with_expref_key_is_not_mistaken_for_an_expref() {
+        // The sentinel key is randomised per process, so user data containing
+        // the old fixed literal key is treated as ordinary data: it round-trips
+        // through output (previously stripped to null) and types as an object
+        // (previously "expref").
+        let data = json!({"__jpx_expref__": 0});
+        assert_eq!(compile("@").unwrap().search(&data).unwrap(), data);
+        assert_eq!(
+            compile("type(@)").unwrap().search(&data).unwrap(),
+            json!("object")
+        );
+    }
+
+    #[test]
+    fn exprefs_still_evaluate() {
+        let data = json!([{"n": 3}, {"n": 1}, {"n": 2}]);
+        assert_eq!(
+            compile("sort_by(@, &n)").unwrap().search(&data).unwrap(),
+            json!([{"n": 1}, {"n": 2}, {"n": 3}])
+        );
     }
 
     #[test]

--- a/crates/jpx-core/src/value_ext.rs
+++ b/crates/jpx-core/src/value_ext.rs
@@ -168,7 +168,7 @@ impl ValueExt for Value {
     }
 
     fn is_expref(&self) -> bool {
-        matches!(self, Value::Object(map) if map.contains_key("__jpx_expref__"))
+        matches!(self, Value::Object(map) if map.contains_key(crate::EXPREF_KEY.as_str()))
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the expref-sentinel collision (the p1 from #186). Exprefs (`&foo`) are carried internally as an in-band `Value` object keyed by a fixed string, `"__jpx_expref__"`. User data that happened to contain that key was **indistinguishable from a real expref**:

```
$ echo '{"__jpx_expref__": 0}' | jpx 'type(@)'   # before: "expref"   after: "object"
$ echo '{"__jpx_expref__": 5}' | jpx '@'          # before: null       after: {"__jpx_expref__":5}
```

## Approach (the option we picked: nonce-hardened sentinel)

The sentinel key is now seeded with a **per-process random token** derived from `std::collections::hash_map::RandomState` (OS entropy, no new dependency). Because sentinels are stripped before output, the token is never observable to a client, so user data cannot accidentally -- or, in practice, maliciously -- be mistaken for an expref.

The change is fully internal and contained: the four key references (`make_expref_sentinel`, `get_expref_id`, `strip_expref_sentinels`, `ValueExt::is_expref`) now use the randomised key instead of the literal. **No public API change** (`get_expref_id` keeps its signature) and real exprefs are unaffected.

## Verification

- All **861 JMESPath compliance tests** pass; `sort_by` / `map` / filter expressions and the full jpx-core + jpx-engine + CLI suites are green. `clippy -D warnings` and `fmt` clean.
- New regression tests: user data with the old literal key round-trips through output and types as an object; exprefs still evaluate (`sort_by(@, &n)`).

## Scope / what remains in #186

This completes the substantive remaining work in #186 -- its recursion-depth **p0** shipped in #197, and this is the expref-collision **p1**. The leftover **p2 polish** is *not* in this PR:
- `error.rs` `column()` returns a byte offset, so the `^` caret misaligns for multibyte expressions.
- `value_ext.rs` `arr.len() as i32` could wrap for >2^31-element arrays (theoretical).
- the interpreter deep-clones the expref AST on every `Ast::Expref` eval (`Rc<Ast>` would avoid it) -- a perf nicety.

I left #186 open for those rather than auto-closing -- happy to do them as a small follow-up, or you can spin them into a fresh issue, after which #186 can be closed.
