### PR TITLE
fix: stop datetime panics and bound allocation in extensions (#189)

### DIFF
--- a/crates/jpx-core/src/extensions/datetime.rs
+++ b/crates/jpx-core/src/extensions/datetime.rs
@@ -766,7 +766,10 @@ impl Function for StartOfDayFn {
             Some(t) => t,
             None => return Ok(Value::Null),
         };
-        let dt = DateTime::from_timestamp(ts, 0).unwrap();
+        let dt = match DateTime::from_timestamp(ts, 0) {
+            Some(dt) => dt,
+            None => return Ok(Value::Null),
+        };
         let start = dt.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc();
 
         Ok(Value::String(
@@ -789,7 +792,10 @@ impl Function for EndOfDayFn {
             Some(t) => t,
             None => return Ok(Value::Null),
         };
-        let dt = DateTime::from_timestamp(ts, 0).unwrap();
+        let dt = match DateTime::from_timestamp(ts, 0) {
+            Some(dt) => dt,
+            None => return Ok(Value::Null),
+        };
         let end = dt.date_naive().and_hms_opt(23, 59, 59).unwrap().and_utc();
 
         Ok(Value::String(end.format("%Y-%m-%dT%H:%M:%SZ").to_string()))
@@ -810,7 +816,10 @@ impl Function for StartOfWeekFn {
             Some(t) => t,
             None => return Ok(Value::Null),
         };
-        let dt = DateTime::from_timestamp(ts, 0).unwrap();
+        let dt = match DateTime::from_timestamp(ts, 0) {
+            Some(dt) => dt,
+            None => return Ok(Value::Null),
+        };
 
         // Calculate days since Monday (Monday = 0)
         let days_since_monday = dt.weekday().num_days_from_monday();
@@ -837,7 +846,10 @@ impl Function for StartOfMonthFn {
             Some(t) => t,
             None => return Ok(Value::Null),
         };
-        let dt = DateTime::from_timestamp(ts, 0).unwrap();
+        let dt = match DateTime::from_timestamp(ts, 0) {
+            Some(dt) => dt,
+            None => return Ok(Value::Null),
+        };
 
         let start = dt
             .date_naive()
@@ -867,7 +879,10 @@ impl Function for StartOfYearFn {
             Some(t) => t,
             None => return Ok(Value::Null),
         };
-        let dt = DateTime::from_timestamp(ts, 0).unwrap();
+        let dt = match DateTime::from_timestamp(ts, 0) {
+            Some(dt) => dt,
+            None => return Ok(Value::Null),
+        };
 
         let start = chrono::NaiveDate::from_ymd_opt(dt.year(), 1, 1)
             .unwrap()
@@ -980,6 +995,23 @@ mod tests {
         let ts = result.as_f64().unwrap();
         // Should be a reasonable timestamp (after 2020)
         assert!(ts > 1577836800.0);
+    }
+
+    #[test]
+    fn test_start_of_out_of_range_timestamp_is_null_not_panic() {
+        // A timestamp chrono cannot represent must yield null, not abort the
+        // process (these used to `from_timestamp(..).unwrap()`).
+        let runtime = setup_runtime();
+        for f in [
+            "start_of_day",
+            "end_of_day",
+            "start_of_week",
+            "start_of_month",
+            "start_of_year",
+        ] {
+            let expr = runtime.compile(&format!("{f}(`1e19`)")).unwrap();
+            assert_eq!(expr.search(&json!(null)).unwrap(), json!(null), "{f}");
+        }
     }
 
     #[test]

--- a/crates/jpx-core/src/extensions/math.rs
+++ b/crates/jpx-core/src/extensions/math.rs
@@ -9,6 +9,13 @@ use crate::interpreter::SearchResult;
 use crate::registry::register_if_enabled;
 use crate::{Context, Runtime, arg, defn};
 
+/// Maximum decimal precision for `to_fixed`. An f64 carries ~17 significant
+/// digits, so anything beyond this is meaningless and only risks a huge
+/// allocation from a user-controlled precision (e.g. `to_fixed(`1`, `1e15`)`).
+const MAX_FLOAT_PRECISION: usize = 100;
+/// Maximum number of bins accepted by `histogram`, to bound allocation.
+const MAX_HISTOGRAM_BINS: usize = 1_000_000;
+
 /// Register only the math functions that are in the enabled set.
 pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "round", enabled, Box::new(RoundFn::new()));
@@ -664,7 +671,9 @@ impl Function for ToFixedFn {
         self.signature.validate(args, ctx)?;
 
         let num = args[0].as_f64().unwrap();
-        let precision = args[1].as_f64().unwrap() as usize;
+        // Clamp to a meaningful maximum -- f64 has ~17 significant digits, and a
+        // huge precision would otherwise allocate an enormous string.
+        let precision = (args[1].as_f64().unwrap() as usize).min(MAX_FLOAT_PRECISION);
 
         let result = format!("{:.prec$}", num, prec = precision);
         Ok(Value::String(result))
@@ -780,6 +789,13 @@ impl Function for HistogramFn {
         let arr = args[0].as_array().unwrap();
 
         let num_bins = args[1].as_f64().unwrap() as usize;
+
+        if num_bins > MAX_HISTOGRAM_BINS {
+            return Err(crate::functions::custom_error(
+                ctx,
+                "Number of bins exceeds the maximum allowed",
+            ));
+        }
 
         if num_bins == 0 {
             return Err(crate::functions::custom_error(
@@ -1578,6 +1594,25 @@ mod tests {
         let expr = runtime.compile("round(`3.14159`, `2`)").unwrap();
         let result = expr.search(&json!(null)).unwrap();
         assert!((result.as_f64().unwrap() - 3.14_f64).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_to_fixed_clamps_huge_precision() {
+        // A huge precision must be clamped rather than allocating a giant string.
+        let runtime = setup_runtime();
+        let expr = runtime.compile("to_fixed(`1`, `1000000000`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        // "1." + at most MAX_FLOAT_PRECISION (100) fractional digits.
+        assert!(result.as_str().unwrap().len() <= 103);
+    }
+
+    #[test]
+    fn test_histogram_rejects_excessive_bins() {
+        let runtime = setup_runtime();
+        let expr = runtime
+            .compile("histogram(`[1,2,3]`, `100000000`)")
+            .unwrap();
+        assert!(expr.search(&json!(null)).is_err());
     }
 
     #[test]

--- a/crates/jpx-core/src/extensions/string.rs
+++ b/crates/jpx-core/src/extensions/string.rs
@@ -14,6 +14,11 @@ use crate::interpreter::SearchResult;
 use crate::registry::register_if_enabled;
 use crate::{Context, Runtime, arg, defn};
 
+/// Upper bound on the size of a string produced by user-controlled repetition
+/// (`repeat`, `center`, ...). Prevents a single call from requesting a
+/// petabyte-sized allocation (e.g. `repeat('x', `1e15`)`).
+const MAX_GENERATED_STRING_BYTES: usize = 64 * 1024 * 1024;
+
 // =============================================================================
 // lower(string) -> string
 // =============================================================================
@@ -333,6 +338,12 @@ impl Function for RepeatFn {
             .map(|n| n as usize)
             .ok_or_else(|| custom_error(ctx, "Expected positive number for count"))?;
 
+        if count.saturating_mul(s.len()) > MAX_GENERATED_STRING_BYTES {
+            return Err(custom_error(
+                ctx,
+                "repeat result exceeds the maximum allowed size",
+            ));
+        }
         Ok(Value::String(s.repeat(count)))
     }
 }
@@ -1624,6 +1635,12 @@ impl Function for CenterFn {
             .as_f64()
             .ok_or_else(|| custom_error(ctx, "Expected number for width"))?
             as usize;
+        if width > MAX_GENERATED_STRING_BYTES {
+            return Err(custom_error(
+                ctx,
+                "center width exceeds the maximum allowed size",
+            ));
+        }
 
         // Padding character (default: ' ')
         let pad_char = if args.len() > 2 && !args[2].is_null() {
@@ -1906,6 +1923,17 @@ mod tests {
         let expr = runtime.compile("lower(@)").unwrap();
         let result = expr.search(&json!("HELLO")).unwrap();
         assert_eq!(result.as_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_repeat_rejects_excessive_output() {
+        // A petabyte-sized repeat must error instead of attempting the alloc.
+        let runtime = setup_runtime();
+        let expr = runtime.compile("repeat('x', `1000000000000`)").unwrap();
+        assert!(expr.search(&json!(null)).is_err());
+        // A normal repeat still works.
+        let expr = runtime.compile("repeat('ab', `3`)").unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!("ababab"));
     }
 
     #[test]

--- a/crates/jpx-core/src/extensions/validation.rs
+++ b/crates/jpx-core/src/extensions/validation.rs
@@ -1,6 +1,7 @@
 //! Data validation functions.
 
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
 use regex::Regex;
 use serde_json::Value;
@@ -9,6 +10,19 @@ use crate::functions::Function;
 use crate::interpreter::SearchResult;
 use crate::registry::register_if_enabled;
 use crate::{Context, Runtime, arg, defn};
+
+// Constant validation patterns, compiled once instead of on every call (these
+// were previously recompiled per invocation, e.g. once per element in a map).
+static EMAIL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap());
+static URL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^https?://[^\s/$.?#].[^\s]*$").unwrap());
+static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+        .unwrap()
+});
+static PHONE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\+?[\d\s\-\(\)\.]{7,}$").unwrap());
 
 /// Register validation functions filtered by the enabled set.
 pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
@@ -49,8 +63,7 @@ impl Function for IsEmailFn {
 
         let s = args[0].as_str().unwrap();
 
-        let email_re = Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap();
-        Ok(Value::Bool(email_re.is_match(s)))
+        Ok(Value::Bool(EMAIL_RE.is_match(s)))
     }
 }
 
@@ -66,8 +79,7 @@ impl Function for IsUrlFn {
 
         let s = args[0].as_str().unwrap();
 
-        let url_re = Regex::new(r"^https?://[^\s/$.?#].[^\s]*$").unwrap();
-        Ok(Value::Bool(url_re.is_match(s)))
+        Ok(Value::Bool(URL_RE.is_match(s)))
     }
 }
 
@@ -83,11 +95,7 @@ impl Function for IsUuidFn {
 
         let s = args[0].as_str().unwrap();
 
-        let uuid_re = Regex::new(
-            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        )
-        .unwrap();
-        Ok(Value::Bool(uuid_re.is_match(s)))
+        Ok(Value::Bool(UUID_RE.is_match(s)))
     }
 }
 
@@ -210,8 +218,7 @@ impl Function for IsPhoneFn {
 
         // Basic phone pattern: optional + followed by digits, spaces, dashes, parens
         // Minimum 7 digits for a valid phone number
-        let phone_re = Regex::new(r"^\+?[\d\s\-\(\)\.]{7,}$").unwrap();
-        if !phone_re.is_match(s) {
+        if !PHONE_RE.is_match(s) {
             return Ok(Value::Bool(false));
         }
 


### PR DESCRIPTION
## Summary

Fixes the reachable crashes and unbounded allocations from #189.

### datetime panics (p0)

`start_of_day` / `end_of_day` / `start_of_week` / `start_of_month` / `start_of_year` called `DateTime::from_timestamp(ts, 0).unwrap()`. An out-of-range timestamp made `from_timestamp` return `None` and the `.unwrap()` **aborted the process**:

```
$ echo null | jpx 'start_of_day(`1e19`)'   # before: SIGABRT   after: null (exit 0)
```

They now return `null`, matching the `timestamp_opt`/`match` pattern the rest of the file already uses. (The other `.unwrap()`s in these functions are on always-valid inputs like `and_hms_opt(0,0,0)`.)

### unbounded allocation (p1)

`repeat`, `center` (width), `to_fixed` (precision) and `histogram` (bins) took a `usize` straight from user input, so `repeat('x', `1e15`)` or `to_fixed(`1`, `1e15`)` attempted a petabyte allocation:

- `repeat` / `center` reject results larger than **64 MiB**
- `to_fixed` clamps precision to **100** (an f64 carries ~17 significant digits)
- `histogram` rejects more than **1,000,000** bins

### regex recompilation (p1)

The constant patterns in `is_email` / `is_url` / `is_uuid` / `is_phone` were recompiled on **every call** (once per element in a `map`/filter). Hoisted to `LazyLock<Regex>` so they compile once.

## Tests

Regression tests for the datetime null-on-out-of-range (all five functions) and the `repeat` / `to_fixed` / `histogram` caps. Full jpx-core + jpx-engine + CLI + MCP suites pass; CI-equivalent `clippy -D warnings` and `fmt` clean.

## Deferred (still open in #189)

- **Nondeterministic `flatten` / `mask` name collisions (p0).** Each has **two `functions.toml` entries and two registrations** under the same name (`flatten` = array `FlattenFn` + object `FlattenKeysFn`; `mask` = object + string impls). Fixing it right means deciding the canonical impl per name, removing the duplicate toml entry + losing registration, and possibly exposing the other under a distinct name -- a naming/API decision I didn't want to make unilaterally. Real-world impact is low (one impl wins consistently in practice). Happy to do it once we agree the canonical names.
- Minor p2 items (`from_epoch_ms` negative-ms, duplicate same-impl registrations, untyped `arg!(array)` in some stats fns).

Part of #189 (leaves it open for the collisions + p2s).
