### PR TITLE
fix: deduplicate flatten/mask name collisions (#189)

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -3033,18 +3033,6 @@ examples = [
 features = ["core"]
 
 [[functions]]
-name = "flatten"
-category = "object"
-description = "Alias for flatten_keys - flatten nested object with dot notation keys"
-signature = "object -> object"
-examples = [
-    { code = '''flatten({a: {b: 1}}) -> {\"a.b\": 1}''', description = "Simple nested" },
-    { code = '''flatten({a: {b: {c: 1}}}) -> {\"a.b.c\": 1}''', description = "Deep nested" },
-    { code = '''flatten({a: 1, b: 2}) -> {\"a\": 1, \"b\": 2}''', description = "Flat object" },
-]
-features = ["core"]
-
-[[functions]]
 name = "flatten_array"
 category = "object"
 description = "Flatten nested objects and arrays with dot notation keys (arrays use numeric indices)"
@@ -4534,14 +4522,14 @@ examples = [
 features = ["core"]
 
 [[functions]]
-name = "mask"
+name = "obscure"
 category = "string"
-description = "Mask string, keeping last N characters visible"
+description = "Mask all but the last N characters, with an optional mask character (defaults to masking the whole string with '*')"
 signature = "string, number?, string? -> string"
 examples = [
-    { code = '''mask('4111111111111111', `4`) -> \"************1111\"''', description = "Credit card" },
-    { code = '''mask('secret', `0`) -> \"******\"''', description = "Mask all" },
-    { code = '''mask('password', `4`, '#') -> \"####word\"''', description = "Custom mask char" },
+    { code = '''obscure('4111111111111111', `4`) -> \"************1111\"''', description = "Credit card" },
+    { code = '''obscure('secret', `0`) -> \"******\"''', description = "Mask all" },
+    { code = '''obscure('password', `4`, '#') -> \"####word\"''', description = "Custom mask char" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/object.rs
+++ b/crates/jpx-core/src/extensions/object.rs
@@ -49,7 +49,9 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         enabled,
         Box::new(FlattenKeysFn::new()),
     );
-    register_if_enabled(runtime, "flatten", enabled, Box::new(FlattenKeysFn::new()));
+    // NB: object key-flattening is registered only as `flatten_keys`. The array
+    // `flatten` (array.rs) owns the `flatten` name; registering FlattenKeysFn
+    // under `flatten` too created a nondeterministic collision.
     register_if_enabled(
         runtime,
         "unflatten_keys",

--- a/crates/jpx-core/src/extensions/string.rs
+++ b/crates/jpx-core/src/extensions/string.rs
@@ -1856,7 +1856,10 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         Box::new(EscapeRegexFn::new()),
     );
     register_if_enabled(runtime, "start_case", enabled, Box::new(StartCaseFn::new()));
-    register_if_enabled(runtime, "mask", enabled, Box::new(MaskFn::new()));
+    // Registered as `obscure`: the canonical `mask` is the object-module impl;
+    // this custom-mask-character variant lives under a distinct name to avoid a
+    // nondeterministic collision.
+    register_if_enabled(runtime, "obscure", enabled, Box::new(MaskFn::new()));
     register_if_enabled(runtime, "redact", enabled, Box::new(RedactFn::new()));
     register_if_enabled(
         runtime,
@@ -2219,6 +2222,17 @@ mod tests {
         let expr = runtime.compile("mask(@, `4`)").unwrap();
         let result = expr.search(&json!("héllo")).unwrap();
         assert_eq!(result.as_str().unwrap(), "*éllo");
+    }
+
+    #[test]
+    fn test_obscure_custom_char_and_default() {
+        // `obscure` is the renamed string-module mask: defaults to masking the
+        // whole string and supports a custom mask character.
+        let runtime = setup_runtime();
+        let expr = runtime.compile("obscure('password', `4`, '#')").unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!("####word"));
+        let expr = runtime.compile("obscure('secret')").unwrap();
+        assert_eq!(expr.search(&json!(null)).unwrap(), json!("******"));
     }
 
     #[test]

--- a/crates/jpx/tests/integration.rs
+++ b/crates/jpx/tests/integration.rs
@@ -649,9 +649,18 @@ mod flatten_unflatten {
     }
 
     #[test]
-    fn test_flatten_alias() {
-        let result = run_query(r#"{"a": {"b": 1}}"#, "flatten(@)");
-        assert!(result.contains("\"a.b\": 1"));
+    fn test_flatten_is_array_flatten_not_object_alias() {
+        // `flatten` is the array one-level flatten; object key-flattening is
+        // `flatten_keys`. Previously `flatten` also aliased object flattening,
+        // which collided nondeterministically with the array impl.
+        let arr = run_query(r#"[[1, 2], [3]]"#, "flatten(@)");
+        assert!(arr.contains('1') && arr.contains('2') && arr.contains('3'));
+        // It must NOT flatten object keys any more.
+        let obj = run_query(r#"{"a": {"b": 1}}"#, "flatten(@)");
+        assert!(
+            !obj.contains("a.b"),
+            "flatten should not key-flatten objects"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the nondeterministic `flatten` / `mask` name collisions (the p0 in #189). Each name was registered by **two different implementations** and had **duplicate `functions.toml` entries**, so which impl won varied with HashSet category-iteration order across process runs.

## Resolution (deterministic: one impl per name)

| Name | Now resolves to | Notes |
|------|-----------------|-------|
| `flatten` | array one-level flatten (`array.rs`) | e.g. `flatten([[1,2],[3]]) -> [1,2,3]` |
| `flatten_keys` | object key-flattening (`object.rs`) | already registered under this name; the redundant `flatten` registration + the duplicate object `"flatten"` toml entry (literally *"Alias for flatten_keys"*) are removed |
| `mask` | object impl (mask last N chars, default 4, `*`) | the documented/tested behaviour (`mask("4111...") -> "************1111"`) is unchanged |
| `obscure` | string impl (mask last N, **configurable mask char**) | the string-module variant is renamed here so its custom-char feature isn't lost: `obscure('password', `4`, '#') -> "####word"` |

Verified deterministic across repeated runs.

## Tests

- Updates the CLI integration test that asserted the old `flatten`-as-object-alias behaviour (now asserts `flatten` does array-flatten and does *not* key-flatten objects).
- Adds an `obscure` test (custom char + mask-all default).
- Full jpx-core + jpx-engine + CLI + MCP suites pass (incl. all compliance tests); `clippy -D warnings` + `fmt` clean.

## Scope

Fixes the **name-collision p0** of #189. Together with #208 (datetime panics + allocation caps + regex hoisting), the substantive #189 work is done; only minor **p2** items remain (`from_epoch_ms` negative-ms, the remaining harmless duplicate same-impl registrations, and untyped `arg!(array)` in some stats fns). Leaving #189 open for those.

Part of #189.
