### PR TITLE
fix: character-based error column + bounded slice length cast (#186)

### DIFF
--- a/crates/jpx-core/src/error.rs
+++ b/crates/jpx-core/src/error.rs
@@ -41,12 +41,16 @@ impl JmespathError {
             + 1
     }
 
-    /// Returns the column number of the error (0-indexed).
+    /// Returns the column number of the error (0-indexed, in characters).
+    ///
+    /// `offset` is a byte position, so the column is counted in characters
+    /// since the last newline -- a byte count would misalign the `^` caret in
+    /// [`Display`](Self) for expressions containing multibyte characters.
     pub fn column(&self) -> usize {
         let before = &self.expression[..self.offset.min(self.expression.len())];
         match before.rfind('\n') {
-            Some(pos) => self.offset - pos - 1,
-            None => self.offset,
+            Some(pos) => before[pos + 1..].chars().count(),
+            None => before.chars().count(),
         }
     }
 }
@@ -165,8 +169,16 @@ mod tests {
         let err = JmespathError::new("foo", 100, ErrorReason::Parse("test".into()));
         // line() clamps to expression length, so still line 1
         assert_eq!(err.line(), 1);
-        // column() returns the raw offset when no newline is found
-        assert_eq!(err.column(), 100);
+        // column() clamps to the expression and counts characters (3 for "foo")
+        assert_eq!(err.column(), 3);
+    }
+
+    #[test]
+    fn column_counts_characters_not_bytes() {
+        // "ä.x": 'ä' is 2 bytes, so the byte offset of 'x' is 3 but its column
+        // (in characters, for caret alignment) is 2.
+        let err = JmespathError::new("ä.x", 3, ErrorReason::Parse("test".into()));
+        assert_eq!(err.column(), 2);
     }
 
     #[test]

--- a/crates/jpx-core/src/value_ext.rs
+++ b/crates/jpx-core/src/value_ext.rs
@@ -124,7 +124,11 @@ impl ValueExt for Value {
 
     fn slice(&self, start: Option<i32>, stop: Option<i32>, step: i32) -> Option<Vec<Value>> {
         let arr = self.as_array()?;
-        let len = arr.len() as i32;
+        // Slice endpoints are i32 (matching the AST); clamp rather than letting
+        // `arr.len() as i32` wrap negative for arrays larger than i32::MAX (which
+        // would then panic on `arr[i as usize]`). Such arrays are unrealistic but
+        // the cast must not be unchecked.
+        let len = i32::try_from(arr.len()).unwrap_or(i32::MAX);
         if len == 0 {
             return Some(vec![]);
         }


### PR DESCRIPTION
Two p2 cleanups from #186 (its recursion-depth p0 shipped in #197, expref-sentinel collision p1 in #207).

- **`JmespathError::column()`** counted bytes, so the `^` caret in the error display misaligned for expressions with multibyte characters. It now counts **characters** since the last newline. (`"ä.x"` error at `x` -> column 2, not byte 3.)
- **`ValueExt::slice()`** cast `arr.len()` to `i32` unchecked, which would wrap negative -- and then panic on `arr[i as usize]` -- for arrays larger than `i32::MAX`. The cast now clamps via `try_from`. Theoretical (needs ~2 billion elements) but the cast should not be unchecked.

Adds a multibyte-column test; updates the `offset_beyond_expression_length` test (column now clamps + counts chars). Full jpx-core suite incl. all compliance tests passes; clippy `-D warnings` + fmt clean.

### Not done (deliberately)
The third #186 p2 -- storing exprefs as `Rc<Ast>` to avoid a clone -- is left out. The clone happens **once per expref evaluation, not per element** (`get_expref_ast` returns a reference), so the gain is negligible while the change (`Box<Ast>` -> `Rc<Ast>` through the AST) is invasive.

Closes #186.