### PR TITLE
fix: resolve jpx-core name collisions and from_epoch_ms pre-epoch handling (#189)

### DIFF
--- a/crates/jpx-core/functions.toml
+++ b/crates/jpx-core/functions.toml
@@ -4572,14 +4572,14 @@ jep = "JEP-014"
 features = ["core", "jep"]
 
 [[functions]]
-name = "redact"
+name = "redact_pattern"
 category = "string"
 description = "Redact regex pattern matches with replacement"
 signature = "string, string, string? -> string"
 examples = [
-    { code = '''redact('email: test@example.com', '\\S+@\\S+', '[EMAIL]') -> \"email: [EMAIL]\"''', description = "Redact email" },
-    { code = '''redact('call 555-1234', '\\d{3}-\\d{4}', '[PHONE]') -> \"call [PHONE]\"''', description = "Redact phone" },
-    { code = '''redact('no match', 'xyz', '[X]') -> \"no match\"''', description = "No matches" },
+    { code = '''redact_pattern('email: test@example.com', '\\S+@\\S+', '[EMAIL]') -> \"email: [EMAIL]\"''', description = "Redact email" },
+    { code = '''redact_pattern('call 555-1234', '\\d{3}-\\d{4}', '[PHONE]') -> \"call [PHONE]\"''', description = "Redact phone" },
+    { code = '''redact_pattern('no match', 'xyz', '[X]') -> \"no match\"''', description = "No matches" },
 ]
 features = ["core"]
 

--- a/crates/jpx-core/src/extensions/array.rs
+++ b/crates/jpx-core/src/extensions/array.rs
@@ -104,7 +104,6 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         enabled,
         Box::new(FrequenciesFn::new()),
     );
-    register_if_enabled(runtime, "mode", enabled, Box::new(ModeFn::new()));
     register_if_enabled(runtime, "cartesian", enabled, Box::new(CartesianFn::new()));
     register_if_enabled(runtime, "initial", enabled, Box::new(InitialFn::new()));
     // Alias for initial (Clojure-style name)
@@ -929,43 +928,8 @@ impl Function for FrequenciesFn {
     }
 }
 
-// =============================================================================
-// mode(array) -> any (most frequent value)
-// =============================================================================
-
-defn!(ModeFn, vec![arg!(array)], None);
-
-impl Function for ModeFn {
-    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
-        self.signature.validate(args, ctx)?;
-
-        let arr = args[0]
-            .as_array()
-            .ok_or_else(|| custom_error(ctx, "Expected array argument"))?;
-
-        if arr.is_empty() {
-            return Ok(Value::Null);
-        }
-
-        let mut counts: std::collections::HashMap<String, (i64, Value)> =
-            std::collections::HashMap::new();
-
-        for item in arr {
-            let key = serde_json::to_string(item).unwrap_or_default();
-            counts
-                .entry(key)
-                .and_modify(|(count, _)| *count += 1)
-                .or_insert((1, item.clone()));
-        }
-
-        let (_, (_, mode_value)) = counts
-            .into_iter()
-            .max_by_key(|(_, (count, _))| *count)
-            .unwrap();
-
-        Ok(mode_value)
-    }
-}
+// `mode` is owned by the math category (extensions/math.rs); functions.toml
+// lists it under `math`.
 
 // =============================================================================
 // cartesian(arr1, arr2) -> array (cartesian product of 2 arrays)

--- a/crates/jpx-core/src/extensions/datetime.rs
+++ b/crates/jpx-core/src/extensions/datetime.rs
@@ -13,7 +13,8 @@ use crate::{Context, Runtime, arg, defn};
 
 /// Register datetime functions filtered by the enabled set.
 pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
-    register_if_enabled(runtime, "now", enabled, Box::new(NowFn::new()));
+    // `now` is owned by the utility category (see extensions/utility.rs), which
+    // provides the same Unix-seconds value plus an optional fallback argument.
     register_if_enabled(runtime, "now_millis", enabled, Box::new(NowMillisFn::new()));
     register_if_enabled(runtime, "parse_date", enabled, Box::new(ParseDateFn::new()));
     register_if_enabled(
@@ -114,17 +115,6 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
         enabled,
         Box::new(ParseNaturalDateFn::new()),
     );
-}
-
-// now() -> number
-defn!(NowFn, vec![], None);
-
-impl Function for NowFn {
-    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
-        self.signature.validate(args, ctx)?;
-        let ts = Utc::now().timestamp();
-        Ok(number_value(ts as f64))
-    }
 }
 
 // now_millis() -> number
@@ -621,8 +611,12 @@ impl Function for FromEpochMsFn {
         self.signature.validate(args, ctx)?;
 
         let epoch_ms = args[0].as_f64().unwrap() as i64;
-        let seconds = epoch_ms / 1000;
-        let nanos = ((epoch_ms % 1000) * 1_000_000) as u32;
+        // Use Euclidean division/remainder so timestamps before the Unix epoch
+        // keep a sub-second remainder in [0, 999]. Plain `%` yields a negative
+        // remainder that wraps to a huge value when cast to `u32` nanoseconds,
+        // which `from_timestamp` then rejects (returning Null for valid input).
+        let seconds = epoch_ms.div_euclid(1000);
+        let nanos = (epoch_ms.rem_euclid(1000) * 1_000_000) as u32;
 
         match DateTime::from_timestamp(seconds, nanos) {
             Some(dt) => Ok(Value::String(
@@ -1595,6 +1589,17 @@ mod tests {
         let expr = runtime.compile("from_epoch_ms(`1702425600500`)").unwrap();
         let result = expr.search(&json!(null)).unwrap();
         assert_eq!(result.as_str().unwrap(), "2023-12-13T00:00:00.500Z");
+    }
+
+    #[test]
+    fn test_from_epoch_ms_negative() {
+        let runtime = setup_runtime();
+        // -500ms is 500ms before the Unix epoch: 1969-12-31T23:59:59.500Z.
+        // A naive `% 1000` would wrap the negative remainder when cast to u32
+        // and yield Null instead of the correct sub-second time.
+        let expr = runtime.compile("from_epoch_ms(`-500`)").unwrap();
+        let result = expr.search(&json!(null)).unwrap();
+        assert_eq!(result.as_str().unwrap(), "1969-12-31T23:59:59.500Z");
     }
 
     #[test]

--- a/crates/jpx-core/src/extensions/string.rs
+++ b/crates/jpx-core/src/extensions/string.rs
@@ -1491,13 +1491,19 @@ impl Function for MaskFn {
 }
 
 // =============================================================================
-// redact(string, pattern, replacement?) -> string
-// Replace all matches of a regex pattern with a replacement string
+// redact_pattern(string, pattern, replacement?) -> string
+// Replace all matches of a regex pattern with a replacement string.
+// Named `redact_pattern` to avoid colliding with the object-category `redact`,
+// which redacts named fields in a structure.
 // =============================================================================
 
-defn!(RedactFn, vec![arg!(string), arg!(string)], Some(arg!(any)));
+defn!(
+    RedactPatternFn,
+    vec![arg!(string), arg!(string)],
+    Some(arg!(any))
+);
 
-impl Function for RedactFn {
+impl Function for RedactPatternFn {
     fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
         self.signature.validate(args, ctx)?;
         let s = args[0]
@@ -1877,7 +1883,12 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     // this custom-mask-character variant lives under a distinct name to avoid a
     // nondeterministic collision.
     register_if_enabled(runtime, "obscure", enabled, Box::new(MaskFn::new()));
-    register_if_enabled(runtime, "redact", enabled, Box::new(RedactFn::new()));
+    register_if_enabled(
+        runtime,
+        "redact_pattern",
+        enabled,
+        Box::new(RedactPatternFn::new()),
+    );
     register_if_enabled(
         runtime,
         "normalize_whitespace",

--- a/crates/jpx-core/src/extensions/type_conv.rs
+++ b/crates/jpx-core/src/extensions/type_conv.rs
@@ -200,45 +200,9 @@ impl Function for IsEmptyFn {
     }
 }
 
-// =============================================================================
-// is_blank(string) -> boolean (empty or whitespace only)
-// =============================================================================
-
-defn!(IsBlankFn, vec![arg!(any)], None);
-
-impl Function for IsBlankFn {
-    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
-        self.signature.validate(args, ctx)?;
-
-        match &args[0] {
-            Value::String(s) => Ok(Value::Bool(s.trim().is_empty())),
-            Value::Null => Ok(Value::Bool(true)),
-            // Return null for non-string types
-            _ => Ok(Value::Null),
-        }
-    }
-}
-
-// =============================================================================
-// is_json(any) -> boolean|null (valid JSON string)
-// =============================================================================
-
-defn!(IsJsonFn, vec![arg!(any)], None);
-
-impl Function for IsJsonFn {
-    fn evaluate(&self, args: &[Value], ctx: &mut Context<'_>) -> SearchResult {
-        self.signature.validate(args, ctx)?;
-
-        // Return null for non-string types
-        let s = match args[0].as_str() {
-            Some(s) => s,
-            None => return Ok(Value::Null),
-        };
-
-        let is_valid = serde_json::from_str::<Value>(s).is_ok();
-        Ok(Value::Bool(is_valid))
-    }
-}
+// `is_blank` is owned by the string category (extensions/string.rs) and
+// `is_json` by the validation category (extensions/validation.rs); both match
+// the documented `string -> boolean` contract in functions.toml.
 
 // =============================================================================
 // parse_numbers(any) -> any (recursively convert numeric strings to numbers)
@@ -424,8 +388,6 @@ pub fn register_filtered(runtime: &mut Runtime, enabled: &HashSet<&str>) {
     register_if_enabled(runtime, "is_object", enabled, Box::new(IsObjectFn::new()));
     register_if_enabled(runtime, "is_null", enabled, Box::new(IsNullFn::new()));
     register_if_enabled(runtime, "is_empty", enabled, Box::new(IsEmptyFn::new()));
-    register_if_enabled(runtime, "is_blank", enabled, Box::new(IsBlankFn::new()));
-    register_if_enabled(runtime, "is_json", enabled, Box::new(IsJsonFn::new()));
     register_if_enabled(
         runtime,
         "parse_numbers",

--- a/docs/src/functions/math.md
+++ b/docs/src/functions/math.md
@@ -2,6 +2,19 @@
 
 Mathematical and statistical functions: arithmetic, rounding, statistics, and number formatting.
 
+## Non-numeric elements
+
+The statistical functions in this category -- `median`, `variance`, `stddev`,
+`percentile`, `quantile`, `quartiles`, `skew`, `kurtosis`, `mad`, `zscore`,
+`normalize`, `standardize`, `trend`, `trend_slope`, `rate_of_change`,
+`cumulative_sum`, `moving_avg`, `ewma`, `correlation`, `covariance`,
+`outliers_iqr`, `outliers_zscore`, and `histogram` -- operate on the numeric
+elements of their array argument and **silently ignore any non-numeric
+elements**. This is intentional and differs from the standard JMESPath `avg`
+and `sum` functions, which require every element to be a number and raise a
+type error otherwise. When no numeric elements remain, these functions return
+`null` (or an empty result for the element-wise functions).
+
 ## Summary
 
 | Function | Signature | Description |

--- a/docs/src/functions/string.md
+++ b/docs/src/functions/string.md
@@ -26,7 +26,7 @@ Functions for string manipulation: case conversion, splitting, joining, padding,
 | [`normalize_whitespace`](#normalize-whitespace) | `string -> string` | Collapse multiple whitespace to single space |
 | [`pad_left`](#pad-left) | `string, number, string -> string` | Pad string on the left to reach target length |
 | [`pad_right`](#pad-right) | `string, number, string -> string` | Pad string on the right to reach target length |
-| [`redact`](#redact) | `string, string, string? -> string` | Redact regex pattern matches with replacement |
+| [`redact_pattern`](#redact_pattern) | `string, string, string? -> string` | Redact regex pattern matches with replacement |
 | [`repeat`](#repeat) | `string, number -> string` | Repeat a string n times |
 | [`shouty_kebab_case`](#shouty-kebab-case) | `string -> string` | Convert to SHOUTY-KEBAB-CASE |
 | [`shouty_snake_case`](#shouty-snake-case) | `string -> string` | Convert to SHOUTY_SNAKE_CASE |
@@ -521,7 +521,7 @@ pad_right('hello', `3`, '0') -> \"hello\"
 echo '{}' | jpx 'pad_right(`"5"`, `3`, `"0"`)'
 ```
 
-### redact
+### redact_pattern
 
 Redact regex pattern matches with replacement
 
@@ -531,17 +531,17 @@ Redact regex pattern matches with replacement
 
 ```text
 # Redact email
-redact('email: test@example.com', '\\S+@\\S+', '[EMAIL]') -> \"email: [EMAIL]\"
+redact_pattern('email: test@example.com', '\\S+@\\S+', '[EMAIL]') -> \"email: [EMAIL]\"
 # Redact phone
-redact('call 555-1234', '\\d{3}-\\d{4}', '[PHONE]') -> \"call [PHONE]\"
+redact_pattern('call 555-1234', '\\d{3}-\\d{4}', '[PHONE]') -> \"call [PHONE]\"
 # No matches
-redact('no match', 'xyz', '[X]') -> \"no match\"
+redact_pattern('no match', 'xyz', '[X]') -> \"no match\"
 ```
 
 **CLI Usage:**
 
 ```bash
-echo '{}' | jpx 'redact(`"email: test@example.com"`, `"\\S+@\\S+"`, `"[EMAIL]"`)'
+echo '{}' | jpx 'redact_pattern(`"email: test@example.com"`, `"\\S+@\\S+"`, `"[EMAIL]"`)'
 ```
 
 ### repeat


### PR DESCRIPTION
## Summary

Closes the remaining items from the jpx-core extensions audit (#189).

While addressing what the audit called "7 duplicate same-impl registrations,"
**5 of them turned out to be real nondeterministic collisions** -- two
*different* implementations registered under one name. Which one wins depends
on `HashSet<Category>` iteration order, so results varied between runs. This is
the same class of bug as the already-fixed `flatten`/`mask` collisions, just
under-rated as p2.

| name | impl A | impl B | resolution |
|------|--------|--------|------------|
| `mode` | math `(array)` | array `(array)` | identical -> dedupe (no behavior change) |
| `now` | utility `([number])` superset | datetime `()` | dedupe, keep superset |
| `is_blank` | type_conv `(any)` lenient | string `(string)` strict | dedupe to documented `string -> boolean` |
| `is_json` | type_conv `(any)` lenient | validation `(string)` strict | dedupe to documented `string -> boolean` |
| `redact` | object `(any, array)` field-redact | string `(string, regex, [repl])` text-redact | genuinely different -> rename string variant to `redact_pattern` |

For the dedupes, the kept registration is the one whose file matches the
canonical category in `functions.toml`, so the surviving behavior is the one
already documented. `redact_pattern` pairs naturally with the existing
`redact_keys`; the object field-redaction keeps the `redact` name.

Also fixes **`from_epoch_ms` for pre-epoch timestamps**: `epoch_ms % 1000` gave
a negative remainder that wrapped when cast to `u32` nanoseconds, so
`from_timestamp` rejected valid input and returned `Null`. Now uses
`div_euclid`/`rem_euclid`, with a regression test
(`from_epoch_ms(-500) -> 1969-12-31T23:59:59.500Z`).

Finally, the third p2 bullet -- statistical math functions accept untyped
`arg!(array)` and silently drop non-numeric elements, unlike spec `avg`/`sum`.
That lenient behavior is intentional and is now **documented** as a convention
at the math category level (rather than flipping ~23 function signatures to
`array_number`).

## Verification

- `cargo test` green across the workspace (jpx-core, jpx-engine, jpx, jpx-mcp).
- `cargo clippy --all-features --workspace -- -D warnings` clean; `cargo fmt --check` clean.
- CLI spot checks: `redact(...)` (fields) and `redact_pattern(...)` (regex) both
  behave correctly and resolve to distinct functions; `mode`/`now`/`is_blank`/
  `is_json` all still resolve; `from_epoch_ms(-500)` returns the correct
  sub-second pre-epoch time.

Closes #189.