### PR TITLE
feat: add --cheatsheet flag for a one-page quick reference (#6)

### DIFF
--- a/crates/jpx/src/args.rs
+++ b/crates/jpx/src/args.rs
@@ -205,6 +205,7 @@ pub(crate) enum ColorMode {
     "    jpx -y 'config' < data.json         # YAML output\n",
     "\n",
     "  Discovery:\n",
+    "    jpx --cheatsheet                    # One-page quick reference\n",
     "    jpx --list-functions                # List all 490+ functions\n",
     "    jpx --search date                   # Find date-related functions\n",
     "    jpx --describe format_date          # Function documentation\n",
@@ -221,7 +222,7 @@ pub(crate) enum ColorMode {
     "  ~/.config/jpx/config.toml  or  ~/.jpxrc\n",
     "\n",
     "Version: ", env!("CARGO_PKG_VERSION"),
-    "\nDocumentation: https://docs.rs/jmespath_extensions"
+    "\nDocumentation: https://joshrotenberg.github.io/jpx/"
 ))]
 pub(crate) struct Args {
     /// Print help (use --help for more detail)
@@ -532,6 +533,14 @@ pub(crate) struct Args {
         long_help = "List all available extension functions organized by category.\nUse --list-category for a specific category or --describe for details."
     )]
     pub(crate) list_functions: bool,
+
+    /// Print a one-page quick reference
+    #[arg(
+        long,
+        help = "Print a one-page cheatsheet of syntax and common functions",
+        long_help = "Print a concise quick reference covering JMESPath syntax, common\npatterns, and a sampling of functions by category. For the full list use\n--list-functions; for details on one function use --describe."
+    )]
+    pub(crate) cheatsheet: bool,
 
     /// List functions in category
     #[arg(

--- a/crates/jpx/src/discovery.rs
+++ b/crates/jpx/src/discovery.rs
@@ -71,7 +71,7 @@ pub(crate) fn print_functions(registry: &FunctionRegistry) {
     println!("Use {} to find functions", "--search <query>".cyan());
     println!(
         "\nFor full documentation: {}",
-        "https://docs.rs/jmespath_extensions".blue().underline()
+        "https://joshrotenberg.github.io/jpx/".blue().underline()
     );
 }
 
@@ -571,4 +571,115 @@ fn extract_keywords(description: &str) -> Vec<String> {
         .filter(|w| w.len() > 3 && !stopwords.contains(w))
         .map(|s| s.to_string())
         .collect()
+}
+
+/// Print a concise one-page quick reference of syntax and common functions.
+///
+/// The function count is read live from the registry so it cannot drift; the
+/// featured functions are a curated sampling -- use `--list-functions` for the
+/// complete set and `--describe <fn>` for details.
+pub(crate) fn print_cheatsheet(registry: &FunctionRegistry) {
+    let total = registry.functions().count();
+
+    // Pad to a column width *before* coloring; padding a colored string would
+    // count the ANSI escape bytes and misalign the columns.
+    fn row(key: &str, desc: &str, width: usize) {
+        println!("  {} {}", format!("{key:<width$}").cyan(), desc.dimmed());
+    }
+    fn header(title: &str) {
+        println!("\n{}", title.bold().green());
+    }
+
+    println!("{}", "jpx cheatsheet".bold().cyan());
+    println!(
+        "{}",
+        "JMESPath with extended functions -- quick reference".dimmed()
+    );
+
+    header("BASICS");
+    for (k, v) in [
+        (".field", "Select a field"),
+        ("[0]  [-1]", "Index (negative counts from the end)"),
+        ("[*]", "All array elements (projection)"),
+        ("[1:5]  [::2]", "Slice / slice with step"),
+        ("@", "The current element"),
+        ("|", "Pipe: feed the result into the next expression"),
+        (
+            "&expr",
+            "Expression reference (sort_by, group_by, map, ...)",
+        ),
+        (
+            "`1`  `\"s\"`",
+            "JSON literal (number, string, true/false/null)",
+        ),
+    ] {
+        row(k, v, 14);
+    }
+
+    header("SELECT & RESHAPE");
+    for (k, v) in [
+        ("items[*].name", "Extract a field from each element"),
+        ("items[?price > `10`]", "Filter by a condition"),
+        ("items[?status=='active'].name", "Filter, then project"),
+        (
+            "{name: name, qty: count}",
+            "Build an object (multiselect hash)",
+        ),
+        ("[name, count]", "Build an array (multiselect list)"),
+    ] {
+        row(k, v, 31);
+    }
+
+    header("COMMON PATTERNS");
+    for (k, v) in [
+        ("sort_by(items, &price)", "Sort ascending by a field"),
+        ("reverse(sort_by(items, &price))", "Sort descending"),
+        ("max_by(items, &score)", "Element with the largest field"),
+        (
+            "group_by(items, &category)",
+            "Group into an object keyed by field",
+        ),
+        ("merge(a, b)", "Shallow-merge objects (later wins)"),
+        ("pick(obj, ['id', 'name'])", "Keep only these keys"),
+        ("omit(obj, ['secret'])", "Drop these keys"),
+    ] {
+        row(k, v, 33);
+    }
+
+    header("LET EXPRESSIONS (JEP-18)");
+    row(
+        "let $top = max(p[*].v) in p[?v == $top]",
+        "Name an intermediate result",
+        41,
+    );
+
+    header("A FEW FUNCTIONS BY CATEGORY");
+    for (cat, fns) in [
+        (
+            "String",
+            "split join upper lower trim replace pad_left contains",
+        ),
+        ("Array", "first last unique flatten chunk zip count_by"),
+        ("Object", "keys values items merge pick omit map_values"),
+        ("Math", "sum avg median min max round abs clamp percentile"),
+        ("Date", "now format_date parse_date date_diff from_epoch"),
+    ] {
+        println!("  {} {}", format!("{cat:<8}").yellow(), fns);
+    }
+
+    header("DISCOVER");
+    for (k, v) in [
+        ("jpx --list-functions", "Every function, by category"),
+        ("jpx --describe <fn>", "Signature, description, examples"),
+        ("jpx --search <keyword>", "Find functions by keyword"),
+        ("jpx --repl", "Interactive REPL with completion"),
+    ] {
+        row(k, v, 23);
+    }
+
+    println!(
+        "\n{} functions available.  Docs: {}",
+        total.to_string().yellow(),
+        "https://joshrotenberg.github.io/jpx/".cyan()
+    );
 }

--- a/crates/jpx/src/main.rs
+++ b/crates/jpx/src/main.rs
@@ -84,6 +84,11 @@ fn run() -> Result<i32> {
         return Ok(0);
     }
 
+    if args.cheatsheet {
+        discovery::print_cheatsheet(&registry);
+        return Ok(0);
+    }
+
     if let Some(category_name) = &args.list_category {
         discovery::print_category(&registry, category_name)?;
         return Ok(0);

--- a/crates/jpx/tests/integration.rs
+++ b/crates/jpx/tests/integration.rs
@@ -309,6 +309,25 @@ mod cli_options {
     }
 
     #[test]
+    fn test_cheatsheet() {
+        let output = jpx_cmd()
+            .arg("--cheatsheet")
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn jpx")
+            .wait_with_output()
+            .expect("Failed to wait");
+
+        assert!(output.status.success());
+        let result = String::from_utf8_lossy(&output.stdout);
+        assert!(result.contains("cheatsheet"));
+        assert!(result.contains("BASICS"));
+        assert!(result.contains("COMMON PATTERNS"));
+        assert!(result.contains("sort_by(items, &price)"));
+        assert!(result.contains("functions available"));
+    }
+
+    #[test]
     fn test_version() {
         let output = jpx_cmd()
             .arg("--version")


### PR DESCRIPTION
## Summary

Implements `jpx --cheatsheet` (issue #6): a one-page quick reference printed to
stdout, covering JMESPath syntax basics, select/reshape, common patterns, JEP-18
let expressions, a sampling of functions by category, and the discovery commands.

```
$ jpx --cheatsheet
jpx cheatsheet
JMESPath with extended functions -- quick reference

BASICS
  .field         Select a field
  [*]            All array elements (projection)
  &expr          Expression reference (sort_by, group_by, map, ...)
  ...
COMMON PATTERNS
  sort_by(items, &price)            Sort ascending by a field
  group_by(items, &category)        Group into an object keyed by field
  ...
498 functions available.  Docs: https://joshrotenberg.github.io/jpx/
```

Notes:
- The function **count is read live from the registry** (`registry.functions().count()`)
  so it can't drift -- the exact concern raised in #194.
- Every example query in the sheet was run against the CLI to confirm it works.
- Column alignment is padded before coloring so it survives ANSI codes; color
  degrades automatically (NO_COLOR / non-TTY) via the `colored` crate.

Also fixes the stale `docs.rs/jmespath_extensions` URL (a dead link, the same
one this issue's original text referenced) in the `--list-functions` and
`--help` footers, pointing them at the current docs site.

## Verification

- New integration test `test_cheatsheet` asserts the sections and a sample
  pattern render and the command exits 0.
- `cargo test -p jpx --all-features` green; `clippy -D warnings` and `fmt --check` clean.

Closes #6.