### PR TITLE
feat: add batch introspection API + batch_describe MCP tool (#29)

### DIFF
--- a/crates/jpx-engine/src/introspection.rs
+++ b/crates/jpx-engine/src/introspection.rs
@@ -220,6 +220,33 @@ impl JpxEngine {
         self.registry.get_function(name).map(FunctionDetail::from)
     }
 
+    /// Describes multiple functions in a single call.
+    ///
+    /// Returns one `(name, detail)` entry per requested name, preserving input
+    /// order, with `None` for names that do not resolve to a function (rather
+    /// than failing the whole batch). Names may be aliases, just like
+    /// [`describe_function`](Self::describe_function).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use jpx_engine::JpxEngine;
+    ///
+    /// let engine = JpxEngine::new();
+    /// let results = engine.describe_functions(&["upper", "not_a_function"]);
+    /// assert_eq!(results.len(), 2);
+    /// assert_eq!(results[0].0, "upper");
+    /// assert!(results[0].1.is_some());
+    /// assert_eq!(results[1].0, "not_a_function");
+    /// assert!(results[1].1.is_none());
+    /// ```
+    pub fn describe_functions(&self, names: &[&str]) -> Vec<(String, Option<FunctionDetail>)> {
+        names
+            .iter()
+            .map(|&name| (name.to_string(), self.describe_function(name)))
+            .collect()
+    }
+
     /// Searches for functions matching a query string.
     ///
     /// Uses fuzzy matching, synonyms, and searches across names, descriptions,
@@ -665,6 +692,28 @@ mod tests {
 
         let missing = engine.describe_function("nonexistent");
         assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_describe_functions_batch() {
+        let engine = JpxEngine::new();
+
+        let results = engine.describe_functions(&["upper", "nonexistent", "lower"]);
+        assert_eq!(results.len(), 3);
+
+        // Order is preserved and each name is echoed back.
+        assert_eq!(results[0].0, "upper");
+        assert_eq!(results[0].1.as_ref().unwrap().name, "upper");
+
+        // Missing names yield None rather than failing the whole batch.
+        assert_eq!(results[1].0, "nonexistent");
+        assert!(results[1].1.is_none());
+
+        assert_eq!(results[2].0, "lower");
+        assert_eq!(results[2].1.as_ref().unwrap().name, "lower");
+
+        // Empty input yields an empty result.
+        assert!(engine.describe_functions(&[]).is_empty());
     }
 
     #[test]

--- a/crates/jpx-mcp/src/tools.rs
+++ b/crates/jpx-mcp/src/tools.rs
@@ -36,6 +36,12 @@ pub struct DescribeParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct BatchDescribeParams {
+    /// Function names to describe (canonical names; each result also lists aliases)
+    pub names: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ValidateParams {
     /// JMESPath expression to validate
     pub expression: String,
@@ -431,6 +437,26 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
                         params.name
                     ))),
                 }
+            }
+        })
+        .build();
+
+    // -- batch_describe
+    let e = engine.clone();
+    let batch_describe = ToolBuilder::new("batch_describe")
+        .title("Describe Multiple Functions")
+        .description("Get detailed information about several JMESPath functions in one call. Accepts a list of function names and returns one entry per name in the same order, each `{name, detail}`; unknown names yield a null detail rather than failing the whole batch. Prefer this over calling 'describe' repeatedly when comparing functions.")
+        .read_only()
+        .handler(move |params: BatchDescribeParams| {
+            let engine = e.clone();
+            async move {
+                let names: Vec<&str> = params.names.iter().map(String::as_str).collect();
+                let results: Vec<serde_json::Value> = engine
+                    .describe_functions(&names)
+                    .into_iter()
+                    .map(|(name, detail)| serde_json::json!({ "name": name, "detail": detail }))
+                    .collect();
+                json_result(&results)
             }
         })
         .build();
@@ -1098,6 +1124,7 @@ pub fn build_router_from_config(config: EngineConfig) -> Result<McpRouter, BoxEr
         .tool(evaluate)
         .tool(functions)
         .tool(describe)
+        .tool(batch_describe)
         .tool(categories)
         .tool(validate)
         .tool(explain)

--- a/crates/jpx-mcp/tests/tools.rs
+++ b/crates/jpx-mcp/tests/tools.rs
@@ -48,8 +48,8 @@ async fn test_list_tools() {
 
     let tools = client.list_tools().await;
 
-    // Should have 30 tools (29 + suggest_function)
-    assert_eq!(tools.len(), 30, "Expected 30 tools, got {}", tools.len());
+    // Should have 31 tools (30 + batch_describe)
+    assert_eq!(tools.len(), 31, "Expected 31 tools, got {}", tools.len());
 
     let tool_names: Vec<&str> = tools
         .iter()
@@ -65,6 +65,7 @@ async fn test_list_tools() {
     // Introspection tools
     assert!(tool_names.contains(&"functions"));
     assert!(tool_names.contains(&"describe"));
+    assert!(tool_names.contains(&"batch_describe"));
     assert!(tool_names.contains(&"categories"));
     assert!(tool_names.contains(&"search"));
     assert!(tool_names.contains(&"similar"));
@@ -245,6 +246,28 @@ async fn test_categories() {
     assert!(text.contains("string") || text.contains("String"));
     assert!(text.contains("math") || text.contains("Math"));
     assert!(text.contains("array") || text.contains("Array"));
+}
+
+#[tokio::test]
+async fn test_batch_describe() {
+    let mut client = create_client().await;
+
+    let result = client
+        .call_tool(
+            "batch_describe",
+            json!({ "names": ["upper", "nonexistent", "lower"] }),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.first_text().unwrap();
+    // Known functions are described...
+    assert!(text.contains("upper"));
+    assert!(text.contains("lower"));
+    // ...and an unknown name is echoed back with a null detail rather than
+    // failing the whole batch.
+    assert!(text.contains("nonexistent"));
+    assert!(text.contains("null"));
 }
 
 #[tokio::test]

--- a/docs/src/mcp/overview.md
+++ b/docs/src/mcp/overview.md
@@ -42,6 +42,7 @@ The MCP server exposes **29 tools** organized by purpose:
 | `similar` | Find functions related to a specified function |
 | `functions` | List available functions (optionally filter by category) |
 | `describe` | Get detailed info for a specific function |
+| `batch_describe` | Get details for several functions in one call |
 | `categories` | List all function categories |
 
 ### JSON Utilities

--- a/docs/src/mcp/tools.md
+++ b/docs/src/mcp/tools.md
@@ -76,6 +76,16 @@ Get detailed documentation for a specific function including signature, paramete
 }
 ```
 
+### batch_describe
+
+Get details for several functions in one call. Returns one `{name, detail}` entry per requested name, in order; unknown names yield a `null` detail rather than failing the whole batch.
+
+```json
+{
+  "names": ["pad_left", "split", "join"]
+}
+```
+
 ### categories
 
 List all function categories with function counts.


### PR DESCRIPTION
## Summary

Implements batch function introspection (issue #29).

**jpx-engine** gains:

```rust
pub fn describe_functions(&self, names: &[&str]) -> Vec<(String, Option<FunctionDetail>)>
```

It returns one `(name, detail)` entry per requested name, **preserving input
order**, with `None` for names that don't resolve -- so one unknown name doesn't
fail the whole batch. (Consistent with `describe_function`, names are canonical;
each `FunctionDetail` still surfaces its aliases.)

**jpx-mcp** exposes this as a new `batch_describe` tool, bringing the server to
**31 tools**. An assistant comparing several functions no longer needs N
separate `describe` round-trips:

```json
{ "names": ["pad_left", "split", "join"] }
```

returns an array of `{ "name": ..., "detail": <FunctionDetail|null> }`.

## Verification

- Engine unit test (order preserved, `None` for unknown, empty input) + a
  doctest on `describe_functions`.
- MCP `test_batch_describe` integration test; `test_list_tools` updated to
  expect 31 tools and assert `batch_describe` is present.
- `cargo test` green for jpx-engine and jpx-mcp; `clippy --all-features
  --workspace -D warnings` and `fmt --check` clean.
- MCP tool reference (`overview.md`, `tools.md`) updated.

Closes #29.