### PR TITLE
refactor: non_exhaustive on extensible public enums + thiserror for ErrorReason (#194)

### DIFF
--- a/crates/jpx-core/src/error.rs
+++ b/crates/jpx-core/src/error.rs
@@ -72,25 +72,26 @@ impl fmt::Display for JmespathError {
 impl std::error::Error for JmespathError {}
 
 /// The reason for a JMESPath error.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Marked `#[non_exhaustive]`: new reason variants may be added in future
+/// releases, so downstream matches should include a wildcard arm.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
 pub enum ErrorReason {
     /// A parse-time error.
+    #[error("Parse error: {0}")]
     Parse(String),
     /// A runtime error.
+    #[error("Runtime error: {0}")]
     Runtime(RuntimeError),
 }
 
-impl fmt::Display for ErrorReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ErrorReason::Parse(msg) => write!(f, "Parse error: {msg}"),
-            ErrorReason::Runtime(err) => write!(f, "Runtime error: {err}"),
-        }
-    }
-}
-
 /// Runtime errors that can occur during expression evaluation.
+///
+/// Marked `#[non_exhaustive]`: new runtime-error variants may be added in
+/// future releases, so downstream matches should include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
 pub enum RuntimeError {
     /// A slice expression with step of 0.
     #[error("Invalid slice: step cannot be 0")]

--- a/crates/jpx-core/src/registry.rs
+++ b/crates/jpx-core/src/registry.rs
@@ -12,7 +12,12 @@ use crate::Runtime;
 use crate::functions::Function;
 
 /// Function category matching compile-time features.
+///
+/// Marked `#[non_exhaustive]`: new categories are added as the extension set
+/// grows, so downstream matches should include a wildcard arm (and prefer
+/// iterating [`Category::all`] over matching every variant).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Category {
     /// Standard JMESPath built-in functions (always available)
     Standard,
@@ -142,7 +147,11 @@ impl Category {
 }
 
 /// Feature tags for function classification.
+///
+/// Marked `#[non_exhaustive]`: new feature tags may be added over time, so
+/// downstream matches should include a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Feature {
     /// Standard JMESPath spec functions
     Spec,

--- a/crates/jpx-engine/src/error.rs
+++ b/crates/jpx-engine/src/error.rs
@@ -46,7 +46,11 @@ use thiserror::Error;
 ///
 /// This allows consumers to programmatically handle different error types
 /// without parsing error message strings.
+///
+/// Marked `#[non_exhaustive]`: new failure modes may be added in future
+/// releases, so downstream matches should include a wildcard arm.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EvaluationErrorKind {
     /// Expression called a function that is not defined.
     ///
@@ -139,7 +143,11 @@ fn extract_number_after(s: &str, prefix: &str) -> Option<u32> {
 ///
 /// Each variant represents a specific failure mode, making it easy to
 /// handle different error types appropriately.
+///
+/// Marked `#[non_exhaustive]`: new failure modes may be added in future
+/// releases, so downstream matches should include a wildcard arm.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EngineError {
     /// JMESPath expression has invalid syntax.
     ///


### PR DESCRIPTION
## Summary

Closes out the API-hardening items in #194.

### `#[non_exhaustive]` on the extensible public enums

Before 1.0, mark the public enums that genuinely grow over time so that adding
a variant later is not a breaking change:

- **jpx-core:** `ErrorReason`, `RuntimeError`, `Category`, `Feature`
- **jpx-engine:** `EngineError`, `EvaluationErrorKind`

**Deliberately left exhaustive:** `JmespathType` and `ArgumentType`. These are
closed, spec-stable type vocabularies (the JMESPath type system / the argument
constraint set) where downstream *exhaustive* matching is a legitimate feature,
not a hazard. Marking them `#[non_exhaustive]` would force a dead `_ =>` arm on
every downstream `match` for variants that won't appear -- the opposite of
helpful. Applying this selectively is the point.

This change is **free internally**: a workspace scan found zero cross-crate
exhaustive matches on any of these enums, so no wildcard arms were needed
anywhere (within-crate exhaustive matching still compiles under
`#[non_exhaustive]`).

### `ErrorReason` now derives `thiserror::Error`

`RuntimeError` and `jpx-engine`'s error types already use `thiserror`;
`ErrorReason` was the odd one out with a hand-rolled `Display`. It now derives
`thiserror::Error` with the same output, removing the manual impl.

## Verification

- `cargo test` green for jpx-core, jpx-engine, jpx, jpx-mcp (incl. the
  `ErrorReason` display tests, now routed through thiserror).
- `clippy --all-features -D warnings` and `fmt --check` clean.
- `cargo doc` adds no new warnings.

## Remaining #194 items (intentionally not in this PR)

The rest of #194 is already done or is track-only, so this closes the issue:

- **Done previously:** doc-count drift (#206), `Config::color` wired (#206),
  `atty` advisory removed (#205).
- **Track-only, no action:** the `Cow<Value>` interpreter change is a larger
  effort that should wait for a profiler showing a real hot path; the three
  remaining `cargo audit` entries (`paste`, `proc-macro-error2`, `rand`) are
  unmaintained/unsound **warnings** (not vulnerabilities) pulled in
  transitively with no current fix path -- a periodic `cargo update` is the
  whole strategy.

Closes #194.