### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "jpx"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-engine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "dirs",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "jpx-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 default-members = ["crates/jpx"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -18,8 +18,8 @@ serde = "1.0"
 serde_json = "1.0"
 
 # Internal crates
-jpx-core = { path = "crates/jpx-core", version = "0.3.0" }
-jpx-engine = { path = "crates/jpx-engine", version = "0.4.0" }
+jpx-core = { path = "crates/jpx-core", version = "0.3.1" }
+jpx-engine = { path = "crates/jpx-engine", version = "0.4.1" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/crates/jpx-core/CHANGELOG.md
+++ b/crates/jpx-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.3.0...jpx-core-v0.3.1) - 2026-08-13
+
+### Fixed
+
+- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
+
 ## [0.3.0](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.2.2...jpx-core-v0.3.0) - 2026-06-11
 
 ### Added

--- a/crates/jpx-core/Cargo.toml
+++ b/crates/jpx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-core"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-engine/CHANGELOG.md
+++ b/crates/jpx-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.4.0...jpx-engine-v0.4.1) - 2026-08-13
+
+### Fixed
+
+- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
+
 ## [0.4.0](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.3.5...jpx-engine-v0.4.0) - 2026-06-11
 
 ### Added

--- a/crates/jpx-engine/Cargo.toml
+++ b/crates/jpx-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jpx-engine"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/jpx-mcp/CHANGELOG.md
+++ b/crates/jpx-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.5.0...jpx-mcp-v0.5.1) - 2026-08-13
+
+### Fixed
+
+- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
+
 ## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.4.4...jpx-mcp-v0.5.0) - 2026-06-11
 
 ### Added

--- a/crates/jpx/CHANGELOG.md
+++ b/crates/jpx/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/joshrotenberg/jpx/compare/jpx-v0.5.0...jpx-v0.5.1) - 2026-08-13
+
+### Fixed
+
+- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
+
 ## [0.5.0](https://github.com/joshrotenberg/jpx/compare/jpx-v0.4.4...jpx-v0.5.0) - 2026-06-11
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `jpx-core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `jpx-engine`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `jpx`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `jpx-mcp`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jpx-core`

<blockquote>

## [0.3.1](https://github.com/joshrotenberg/jpx/compare/jpx-core-v0.3.0...jpx-core-v0.3.1) - 2026-08-13

### Fixed

- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
</blockquote>

## `jpx-engine`

<blockquote>

## [0.4.1](https://github.com/joshrotenberg/jpx/compare/jpx-engine-v0.4.0...jpx-engine-v0.4.1) - 2026-08-13

### Fixed

- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
</blockquote>

## `jpx`

<blockquote>

## [0.5.1](https://github.com/joshrotenberg/jpx/compare/jpx-v0.5.0...jpx-v0.5.1) - 2026-08-13

### Fixed

- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
</blockquote>

## `jpx-mcp`

<blockquote>

## [0.5.1](https://github.com/joshrotenberg/jpx/compare/jpx-mcp-v0.5.0...jpx-mcp-v0.5.1) - 2026-08-13

### Fixed

- prepare the 0.5.1 point release ([#225](https://github.com/joshrotenberg/jpx/pull/225))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).